### PR TITLE
Ship all 9 roadmap milestones (M0–M8)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,26 @@ TEXT_MODEL=claude-sonnet-4-6
 MIN_DELAY_BETWEEN_POSTS_SEC=120
 MAX_DELAY_BETWEEN_POSTS_SEC=300
 MAX_POSTS_PER_DAY=50
+
+# M7 — Meta (Instagram + Threads) OAuth
+META_APP_ID=
+META_APP_SECRET=
+META_REDIRECT_URI=http://localhost:8787/api/meta/oauth/callback
+# Optional: a manually obtained long-lived access token (CLI escape hatch).
+META_ACCESS_TOKEN=
+# Optional: explicit account IDs if auto-discovery from /me/accounts doesn't
+# find the right one. IG requires a Business account linked to a Page.
+INSTAGRAM_ACCOUNT_ID=
+THREADS_USER_ID=
+
+# M8 — Security
+# Leave empty for localhost-only usage. Set to any 4–32 char string to gate
+# /api/* behind a PIN (X-Dashboard-Pin header or /api/auth/login cookie).
+DASHBOARD_PIN=
+# Fernet key (44-char urlsafe base64). Leave empty to auto-generate one into
+# data/.fernet.key — back that file up somewhere safe.
+FERNET_KEY=
+
+# M8 — Backups
+BACKUP_DIR=data/backups
+BACKUP_KEEP_DAYS=14

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.12-slim AS backend
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /app
+
+# System deps: Pillow needs libjpeg / zlib headers at runtime.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        libjpeg-dev \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY backend/pyproject.toml backend/README.md* /app/backend/
+RUN pip install --upgrade pip && pip install -e "/app/backend"
+
+COPY backend /app/backend
+WORKDIR /app/backend
+
+ENV PYTHONPATH=/app/backend
+EXPOSE 8787
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8787"]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Groups + Profile, расширяемся на LinkedIn / X / Threads / Bluesky /
 
 | Слой | Что делает | Стек |
 |------|-----------|------|
-| `backend/` | FastAPI-сервер: планировщик, AI-генерация, БД, оркестрация | Python 3.12, FastAPI, SQLAlchemy, APScheduler, Anthropic SDK, Gemini SDK |
+| `backend/` | FastAPI-сервер: планировщик, AI-генерация, БД, оркестрация | Python 3.11+, FastAPI, SQLAlchemy, APScheduler, Anthropic SDK, Gemini SDK |
 | `extension/` | Chrome-расширение: DOM-автоматизация Facebook | TypeScript, Manifest V3, Vite |
 | `dashboard/` | UI: business profile, календарь, очередь ревью, логи | Next.js 15, Tailwind, shadcn/ui |
 
@@ -68,7 +68,7 @@ class Platform(ABC):
 ## Setup
 
 ### Требования
-- Python 3.12+
+- Python 3.11+
 - Node.js 20+
 - Chrome или Chromium-based браузер
 - API-ключи: `ANTHROPIC_API_KEY`, `GEMINI_API_KEY` (оба в `.env`)

--- a/backend/app/agents/__init__.py
+++ b/backend/app/agents/__init__.py
@@ -1,0 +1,1 @@
+"""Long-running AI agents: Planner (M1), Target (M3), Analyst (M6), Optimizer (M6)."""

--- a/backend/app/agents/analyst.py
+++ b/backend/app/agents/analyst.py
@@ -1,0 +1,327 @@
+"""SMM Analyst agent (M6).
+
+Given the last N days of posts + their collected metrics, ask Claude for a
+structured analysis:
+
+- `summary` — one paragraph the user reads on the dashboard
+- `top_performers` / `bottom_performers` — post_ids + why
+- `patterns` — observations about post_type / time_of_day / length / tone
+- `proposals` — concrete mutations for BusinessProfile / posting strategy
+
+We store the full JSON body and emit OptimizerProposal rows so the user can
+review them one-by-one.
+
+Proposal confidence thresholds (tunable in one place):
+- auto-apply ONLY for `posting_window_*`, `post_type_ratios`, `emoji_density`
+  when `confidence >= 0.75` — safe, revertable, small-blast-radius.
+- everything else stays PENDING until a human clicks Apply.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+
+from anthropic import Anthropic
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.db.models import (
+    AnalystReport,
+    BusinessProfile,
+    OptimizerProposal,
+    Post,
+    PostMetrics,
+    PostStatus,
+    PostVariant,
+    ProposalStatus,
+)
+
+log = logging.getLogger("agents.analyst")
+
+_COST_IN = 3.0 / 1_000_000
+_COST_OUT = 15.0 / 1_000_000
+
+
+# Fields that can be auto-applied safely when the agent is confident enough.
+AUTO_APPLIABLE_FIELDS = {
+    "posting_window_start_hour",
+    "posting_window_end_hour",
+    "post_type_ratios",
+    "emoji_density",
+    "posts_per_day",
+}
+
+AUTO_APPLY_CONFIDENCE = 0.75
+
+
+ANALYST_SYSTEM = """You are an expert SMM analyst reviewing a solo business \
+owner's recent social-media performance.
+
+The user provides:
+- BusinessProfile (current tone, length, emoji density, posting windows, \
+  post_type_ratios, etc.)
+- A list of recent posts with their engagement metrics (likes, comments, \
+  shares, engagement_score across windows 1h / 24h / 7d).
+
+Produce a STRUCTURED JSON report. Your job:
+1. Spot honest patterns (what drives engagement? what doesn't?).
+2. Propose concrete, minimal mutations to the profile that would plausibly \
+  lift numbers next period.
+3. Flag which proposals are safe to auto-apply (small, revertable) and which \
+  need the human to decide.
+
+## Output — single JSON object, nothing else:
+{
+  "summary": "One-paragraph human-facing takeaway (2–3 sentences).",
+  "top_performers": [{"post_id": 12, "why": "Short, concrete, morning slot."}],
+  "bottom_performers": [{"post_id": 7, "why": "Long salesy hook; posted at \
+22:00 weekday."}],
+  "patterns": [
+    "Informative posts at 9-11am get 2x engagement of ones posted 18-21.",
+    "Posts with a concrete number in the opening hook outperform generic ones."
+  ],
+  "proposals": [
+    {
+      "field": "posting_window_start_hour",
+      "current_value": 9,
+      "proposed_value": 10,
+      "reasoning": "3 of 4 top performers were posted after 10am; 9-10am \
+underperforms by 40%.",
+      "confidence": 0.8
+    },
+    {
+      "field": "post_type_ratios",
+      "current_value": {"informative": 0.5, "hard_sell": 0.2},
+      "proposed_value": {"informative": 0.6, "hard_sell": 0.1},
+      "reasoning": "Hard-sell variants score 3x lower than informative.",
+      "confidence": 0.7
+    }
+  ]
+}
+
+Guidelines:
+- Proposals MUST reference real fields on BusinessProfile: \
+  posting_window_start_hour, posting_window_end_hour, post_type_ratios, \
+  tone, length, emoji_density, posts_per_day.
+- Keep confidence honest — 0.9+ only if you see a clear pattern with n>=5.
+- Be concrete in reasoning; name specific posts or metrics.
+- 2–5 proposals is plenty. If there's no signal yet, return an empty \
+  proposals array and say so in the summary.
+"""
+
+
+@dataclass
+class ProposalPayload:
+    field: str
+    current_value: object
+    proposed_value: object
+    reasoning: str
+    confidence: float
+
+
+@dataclass
+class AnalystOutput:
+    summary: str
+    body: dict
+    proposals: list[ProposalPayload] = field(default_factory=list)
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cost_usd: float = 0.0
+    model: str = ""
+
+
+def _extract_json(text: str) -> dict:
+    text = text.strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```(?:json)?\s*", "", text)
+        text = re.sub(r"\s*```$", "", text)
+    first = text.find("{")
+    last = text.rfind("}")
+    if first == -1 or last == -1 or first > last:
+        raise ValueError(f"No JSON in analyst response: {text[:300]!r}")
+    return json.loads(text[first : last + 1])
+
+
+def _posts_block(db: Session, period_start: datetime, period_end: datetime) -> str:
+    """JSON-serialize posts posted in the window plus their metrics."""
+    rows: list[dict] = []
+    posts: list[Post] = (
+        db.query(Post)
+        .filter(Post.status == PostStatus.POSTED)
+        .filter(Post.posted_at >= period_start)
+        .filter(Post.posted_at <= period_end)
+        .all()
+    )
+    for post in posts:
+        metrics: list[PostMetrics] = (
+            db.query(PostMetrics)
+            .join(PostVariant, PostMetrics.variant_id == PostVariant.id)
+            .filter(PostVariant.post_id == post.id)
+            .all()
+        )
+        # Collapse to per-post max for each window (in case multi-variant).
+        by_window: dict[str, dict] = {}
+        for m in metrics:
+            key = m.window.value
+            cur = by_window.get(key)
+            if cur is None or m.engagement_score > cur["engagement_score"]:
+                by_window[key] = {
+                    "likes": m.likes,
+                    "comments": m.comments,
+                    "shares": m.shares,
+                    "reach": m.reach,
+                    "engagement_score": m.engagement_score,
+                }
+        rows.append(
+            {
+                "post_id": post.id,
+                "post_type": post.post_type.value,
+                "posted_at": post.posted_at.isoformat() if post.posted_at else None,
+                "length_chars": len(post.text),
+                "text_preview": post.text[:200],
+                "metrics": by_window,
+            }
+        )
+    return json.dumps(rows, ensure_ascii=False, indent=2)
+
+
+def _profile_block(profile: BusinessProfile) -> str:
+    return json.dumps(
+        {
+            "tone": profile.tone.value,
+            "length": profile.length.value,
+            "emoji_density": profile.emoji_density.value,
+            "posting_window_start_hour": profile.posting_window_start_hour,
+            "posting_window_end_hour": profile.posting_window_end_hour,
+            "posts_per_day": profile.posts_per_day,
+            "post_type_ratios": profile.post_type_ratios or {},
+            "language": profile.language,
+        },
+        ensure_ascii=False,
+        indent=2,
+    )
+
+
+def run_analysis(
+    db: Session,
+    profile: BusinessProfile,
+    period_start: datetime,
+    period_end: datetime,
+) -> AnalystOutput:
+    """Invoke Claude and parse the structured report."""
+    if not settings.anthropic_api_key:
+        raise RuntimeError("ANTHROPIC_API_KEY not set")
+
+    posts_json = _posts_block(db, period_start, period_end)
+    profile_json = _profile_block(profile)
+    user = (
+        "## BusinessProfile\n"
+        f"{profile_json}\n\n"
+        f"## Posts in window {period_start.date()} → {period_end.date()}\n"
+        f"{posts_json}\n"
+    )
+
+    client = Anthropic(api_key=settings.anthropic_api_key)
+    resp = client.messages.create(
+        model=settings.text_model,
+        max_tokens=3000,
+        system=ANALYST_SYSTEM,
+        messages=[{"role": "user", "content": user}],
+    )
+    raw = resp.content[0].text
+    data = _extract_json(raw)
+    proposals = [
+        ProposalPayload(
+            field=p.get("field", ""),
+            current_value=p.get("current_value"),
+            proposed_value=p.get("proposed_value"),
+            reasoning=p.get("reasoning", ""),
+            confidence=float(p.get("confidence", 0.5)),
+        )
+        for p in (data.get("proposals") or [])
+        if p.get("field")
+    ]
+    in_tokens = resp.usage.input_tokens
+    out_tokens = resp.usage.output_tokens
+    cost = in_tokens * _COST_IN + out_tokens * _COST_OUT
+    return AnalystOutput(
+        summary=data.get("summary", ""),
+        body=data,
+        proposals=proposals,
+        input_tokens=in_tokens,
+        output_tokens=out_tokens,
+        cost_usd=cost,
+        model=settings.text_model,
+    )
+
+
+def apply_proposal(db: Session, profile: BusinessProfile, proposal: OptimizerProposal) -> None:
+    """Mutate BusinessProfile in-place with `proposal.proposed_value`. Commits."""
+    field_name = proposal.field
+    if not hasattr(profile, field_name):
+        raise ValueError(f"Unknown BusinessProfile field: {field_name}")
+    setattr(profile, field_name, proposal.proposed_value)
+    proposal.status = ProposalStatus.APPLIED
+    proposal.applied_at = datetime.now(UTC)
+    db.commit()
+
+
+def persist_report_and_proposals(
+    db: Session,
+    profile: BusinessProfile,
+    output: AnalystOutput,
+    period_start: datetime,
+    period_end: datetime,
+) -> AnalystReport:
+    """Write the report + N proposal rows. Auto-applies small safe ones."""
+    report = AnalystReport(
+        period_start=period_start,
+        period_end=period_end,
+        summary=output.summary,
+        body=output.body,
+        cost_usd=output.cost_usd,
+        model=output.model,
+    )
+    db.add(report)
+    db.flush()  # get id
+
+    for p in output.proposals:
+        eligible = (
+            p.field in AUTO_APPLIABLE_FIELDS
+            and p.confidence >= AUTO_APPLY_CONFIDENCE
+        )
+        proposal = OptimizerProposal(
+            report_id=report.id,
+            field=p.field,
+            # JSON columns want dict/list — wrap scalars consistently so UI can
+            # introspect.
+            current_value={"value": p.current_value} if not isinstance(p.current_value, dict) else p.current_value,
+            proposed_value={"value": p.proposed_value} if not isinstance(p.proposed_value, dict) else p.proposed_value,
+            reasoning=p.reasoning,
+            confidence=p.confidence,
+            status=ProposalStatus.PENDING,
+            auto_applied=False,
+        )
+        db.add(proposal)
+        db.flush()
+        if eligible and hasattr(profile, p.field):
+            # Unwrap scalar for assignment.
+            value = p.proposed_value
+            try:
+                setattr(profile, p.field, value)
+                proposal.status = ProposalStatus.APPLIED
+                proposal.auto_applied = True
+                proposal.applied_at = datetime.now(UTC)
+            except Exception as exc:
+                log.warning("Auto-apply failed for %s: %s", p.field, exc)
+    db.commit()
+    return report
+
+
+def default_window(now: datetime | None = None) -> tuple[datetime, datetime]:
+    """Last 7 days, inclusive."""
+    now = now or datetime.now(UTC)
+    return (now - timedelta(days=7), now)

--- a/backend/app/agents/planner.py
+++ b/backend/app/agents/planner.py
@@ -1,0 +1,320 @@
+"""Content Planner Agent.
+
+Given a BusinessProfile, a date range, and an optional goal, Claude returns a list of
+PlanSlot proposals (date+time, post_type, topic_hint, rationale). The agent also
+supports conversational refinement: the user chats "move Thursday's post to Friday
+evening and make it an engagement post" and the agent returns a patched plan.
+
+Design notes:
+- We call Claude with a single JSON-response prompt. If it doesn't parse, we retry once
+  and then surface the error.
+- Scheduling heuristics (posting window, posts_per_day, weekday spread) are ENCODED IN
+  THE PROMPT, not applied after the fact. That keeps Claude's distribution choices
+  coherent with the business profile instead of being re-shuffled by us.
+- The agent never writes actual post text. It only proposes slots. Generating the post
+  is a separate step (calls `generate_post` in `ai.content`).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+
+from anthropic import Anthropic
+
+from app.config import settings
+from app.db.models import BusinessProfile, PostType
+
+log = logging.getLogger("agents.planner")
+
+# Claude Sonnet 4.6 pricing per million tokens
+_COST_IN = 3.0 / 1_000_000
+_COST_OUT = 15.0 / 1_000_000
+
+_VALID_POST_TYPES = {pt.value for pt in PostType}
+
+
+SYSTEM_PROMPT = """You are a content planner for a real business's social media.
+
+Your job: given the business profile, a date range, and an optional goal, design a \
+content calendar. You propose SLOTS (date + time + post type + topic hint + short \
+rationale). You NEVER write the actual post text; that's a separate step.
+
+## Strict rules
+1. Output MUST be a single JSON object with this shape:
+   {
+     "slots": [
+       {"scheduled_for": "2025-07-12T10:30:00Z", "post_type": "informative", \
+"topic_hint": "...", "rationale": "..."},
+       ...
+     ],
+     "summary": "1-2 sentence overall strategy for this plan."
+   }
+2. `post_type` MUST be one of: informative, soft_sell, hard_sell, engagement, story, \
+motivational, testimonial, hot_take, seasonal.
+3. All `scheduled_for` timestamps must be in ISO 8601 with a "Z" suffix (UTC).
+4. Respect the posting window: only schedule inside [posting_window_start_hour, \
+posting_window_end_hour] in the business's local timezone, converted to UTC.
+5. Respect posts_per_day: MAX this many slots on any single calendar day.
+6. Respect post_type_ratios if provided (e.g. {"informative": 0.4, "soft_sell": 0.3, \
+"engagement": 0.2, "story": 0.1}). The mix across all slots should roughly match.
+7. Spread slots across weekdays — never cluster all posts on one day.
+8. Each `topic_hint` must be SPECIFIC. Not "share a tip" — say what tip, e.g. "how to \
+spot overwatered basil in 10 seconds". The writer uses this as a brief.
+9. Return NO markdown code fences, NO commentary, JUST the JSON object.
+10. Do not include hashtags or emojis in topic_hint — that's the writer's job.
+
+## Quality bar
+- Each slot should feel like a different angle, not 14 riffs on the same idea.
+- Seasonal slots only when there's a genuine tie-in to the date range.
+- Testimonials: include only if the goal allows it (the business may not have cases \
+yet).
+- Hot takes: at most 1 per week.
+- Stories: include 1-2 to humanize the brand.
+"""
+
+
+@dataclass
+class SlotProposal:
+    scheduled_for: datetime
+    post_type: PostType
+    topic_hint: str | None
+    rationale: str | None
+
+
+@dataclass
+class PlanProposal:
+    slots: list[SlotProposal]
+    summary: str
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cost_usd: float = 0.0
+    raw_response: str = ""
+
+
+@dataclass
+class RefinementResult(PlanProposal):
+    reply: str = ""  # Natural-language assistant reply shown in the chat UI
+    assistant_history_entry: dict = field(default_factory=dict)
+
+
+def _extract_json(text: str) -> dict:
+    """Pull the JSON object out of a Claude reply that may include stray fences."""
+    text = text.strip()
+    if text.startswith("```"):
+        # Strip ``` blocks
+        text = re.sub(r"^```(?:json)?\s*", "", text)
+        text = re.sub(r"\s*```$", "", text)
+    # Find first { and last }
+    first = text.find("{")
+    last = text.rfind("}")
+    if first == -1 or last == -1 or first > last:
+        raise ValueError(f"No JSON object found in model response: {text[:200]!r}")
+    snippet = text[first : last + 1]
+    return json.loads(snippet)
+
+
+def _build_user_prompt(
+    bp: BusinessProfile,
+    start_date: datetime,
+    end_date: datetime,
+    goal: str | None,
+    existing_slots: list[dict] | None = None,
+) -> str:
+    ratios_str = (
+        json.dumps(bp.post_type_ratios) if bp.post_type_ratios else "(not set — use a natural mix)"
+    )
+    existing_block = ""
+    if existing_slots:
+        existing_block = (
+            "\n## Existing slots (for reference — rebuild or adjust, not duplicate)\n"
+            + json.dumps(existing_slots, default=str, indent=2)
+        )
+    return f"""## Business
+Name: {bp.name}
+What they do: {bp.description}
+{"Products: " + bp.products if bp.products else ""}
+{"Audience: " + bp.target_audience if bp.target_audience else ""}
+
+## Voice
+Tone: {bp.tone.value}. Length: {bp.length.value}. Emoji density: {bp.emoji_density.value}.
+Language: {bp.language}.
+
+## Schedule constraints
+Start: {start_date.isoformat()}
+End: {end_date.isoformat()}
+Posts per day (max): {bp.posts_per_day}
+Posting window (local hours): {bp.posting_window_start_hour}:00 – \
+{bp.posting_window_end_hour}:00
+Timezone: {bp.timezone}
+post_type_ratios: {ratios_str}
+
+## Goal
+{goal or "Steady engagement. Mix of value-giving and soft promotion."}
+{existing_block}
+
+Return the JSON plan now.
+"""
+
+
+def _parse_slots(data: dict) -> list[SlotProposal]:
+    raw_slots = data.get("slots", [])
+    if not isinstance(raw_slots, list):
+        raise ValueError("'slots' must be a list")
+    out: list[SlotProposal] = []
+    for i, raw in enumerate(raw_slots):
+        if not isinstance(raw, dict):
+            raise ValueError(f"Slot {i} is not an object")
+        pt_raw = raw.get("post_type")
+        if pt_raw not in _VALID_POST_TYPES:
+            raise ValueError(f"Slot {i} has invalid post_type: {pt_raw!r}")
+        sched_raw = raw.get("scheduled_for")
+        if not sched_raw:
+            raise ValueError(f"Slot {i} missing scheduled_for")
+        sched = datetime.fromisoformat(sched_raw.replace("Z", "+00:00"))
+        if sched.tzinfo is None:
+            sched = sched.replace(tzinfo=UTC)
+        out.append(
+            SlotProposal(
+                scheduled_for=sched.astimezone(UTC),
+                post_type=PostType(pt_raw),
+                topic_hint=raw.get("topic_hint"),
+                rationale=raw.get("rationale"),
+            )
+        )
+    return out
+
+
+def _call_claude(messages: list[dict], system: str = SYSTEM_PROMPT) -> tuple[str, int, int]:
+    if not settings.anthropic_api_key:
+        raise RuntimeError("ANTHROPIC_API_KEY not set")
+    client = Anthropic(api_key=settings.anthropic_api_key)
+    resp = client.messages.create(
+        model=settings.text_model,
+        max_tokens=4000,
+        system=system,
+        messages=messages,
+    )
+    return resp.content[0].text, resp.usage.input_tokens, resp.usage.output_tokens
+
+
+def propose_plan(
+    business_profile: BusinessProfile,
+    start_date: datetime,
+    end_date: datetime,
+    goal: str | None = None,
+) -> PlanProposal:
+    """Initial plan generation. Returns N SlotProposals."""
+    if end_date <= start_date:
+        raise ValueError("end_date must be after start_date")
+    if (end_date - start_date) > timedelta(days=60):
+        raise ValueError("Plan range must be ≤ 60 days")
+
+    user_prompt = _build_user_prompt(business_profile, start_date, end_date, goal)
+    raw, in_tok, out_tok = _call_claude([{"role": "user", "content": user_prompt}])
+    try:
+        data = _extract_json(raw)
+    except Exception:
+        log.warning("First planner JSON parse failed, retrying once")
+        raw, in_tok2, out_tok2 = _call_claude(
+            [
+                {"role": "user", "content": user_prompt},
+                {"role": "assistant", "content": raw},
+                {
+                    "role": "user",
+                    "content": (
+                        "Your response wasn't valid JSON. Respond again with ONLY the "
+                        "JSON object, no prose."
+                    ),
+                },
+            ]
+        )
+        in_tok += in_tok2
+        out_tok += out_tok2
+        data = _extract_json(raw)
+
+    slots = _parse_slots(data)
+    cost = in_tok * _COST_IN + out_tok * _COST_OUT
+    return PlanProposal(
+        slots=slots,
+        summary=data.get("summary", ""),
+        input_tokens=in_tok,
+        output_tokens=out_tok,
+        cost_usd=cost,
+        raw_response=raw,
+    )
+
+
+def refine_plan(
+    business_profile: BusinessProfile,
+    start_date: datetime,
+    end_date: datetime,
+    current_slots: list[dict],
+    chat_history: list[dict],
+    user_message: str,
+) -> RefinementResult:
+    """Conversational refinement.
+
+    `chat_history` is the prior transcript (list of {role, content} dicts).
+    `current_slots` is the current saved state of the plan's slots.
+    `user_message` is the new user turn.
+
+    The agent may either:
+    - Answer in natural language without changing the plan (returns an empty `slots`).
+    - Propose a new slot list that replaces the current one.
+
+    To disambiguate: the agent ALWAYS returns JSON with:
+      {"reply": "...", "updated": bool, "slots": [...] | null, "summary": "..."}
+    """
+    system = SYSTEM_PROMPT + """
+
+## Refinement mode
+You're in a chat with the user about their existing plan. They may ask questions, \
+request edits, or approve what's there.
+
+Always respond with JSON:
+{
+  "reply": "Short natural-language reply to the user, ≤3 sentences.",
+  "updated": true | false,
+  "slots": <same shape as before, or null if updated=false>,
+  "summary": "If updated, a 1-sentence new overall strategy. Else null."
+}
+
+Set `updated`=false when the user just asks a question or you want clarification.
+Set `updated`=true only when you're replacing the entire slot list with a new one.
+"""
+    user_prompt = _build_user_prompt(
+        business_profile, start_date, end_date, goal=None, existing_slots=current_slots
+    )
+
+    messages: list[dict] = [{"role": "user", "content": user_prompt}]
+    # Replay prior chat history
+    for turn in chat_history:
+        role = turn.get("role")
+        content = turn.get("content")
+        if role in ("user", "assistant") and content:
+            messages.append({"role": role, "content": content})
+    messages.append({"role": "user", "content": user_message})
+
+    raw, in_tok, out_tok = _call_claude(messages, system=system)
+    data = _extract_json(raw)
+
+    reply = data.get("reply", "")
+    updated = bool(data.get("updated", False))
+    slots: list[SlotProposal] = []
+    if updated:
+        slots = _parse_slots(data)
+
+    cost = in_tok * _COST_IN + out_tok * _COST_OUT
+    return RefinementResult(
+        slots=slots,
+        summary=data.get("summary") or "",
+        input_tokens=in_tok,
+        output_tokens=out_tok,
+        cost_usd=cost,
+        raw_response=raw,
+        reply=reply,
+        assistant_history_entry={"role": "assistant", "content": reply},
+    )

--- a/backend/app/agents/targets.py
+++ b/backend/app/agents/targets.py
@@ -1,0 +1,260 @@
+"""Target Agent (M3).
+
+Two capabilities:
+
+1. `score_targets(profile, targets)` — given the BusinessProfile and a batch of
+   unscored (or stale) Targets, returns a relevance_score 0–100 and a short
+   reasoning per target. Used to help the user decide which scraped groups are
+   worth posting to.
+
+2. `cluster_targets(profile, targets)` — reads the currently approved targets and
+   groups them into a handful of named lists (e.g. "Urban gardeners", "Pest /
+   disease help", "Permaculture & off-grid"). Returns a mapping
+   {target_id: list_name}. The caller persists via Target.list_name.
+
+Both operations call Claude once with a structured-JSON prompt. Cost is logged but
+the caller decides whether to store it.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+
+from anthropic import Anthropic
+
+from app.config import settings
+from app.db.models import BusinessProfile, Target
+
+log = logging.getLogger("agents.targets")
+
+# Claude Sonnet 4.6 pricing per million tokens (kept in sync with planner.py).
+_COST_IN = 3.0 / 1_000_000
+_COST_OUT = 15.0 / 1_000_000
+
+
+SCORE_SYSTEM = """You are a careful B2C/B2B marketing analyst judging whether a given \
+social-media community is a good fit for a business's content.
+
+Given a business profile and a LIST of candidate communities (Facebook groups, subreddits, \
+etc.), return an integer relevance_score from 0 to 100 and a one-sentence reasoning for \
+each. 100 = the business's exact target audience hangs out here; 0 = completely unrelated.
+
+## Output
+Return a single JSON object:
+{
+  "scores": [
+    {"id": 12, "score": 85, "reasoning": "Active urban-gardening community; matches your \
+target audience of apartment dwellers who grow herbs indoors."},
+    {"id": 13, "score": 20, "reasoning": "General cooking group; only ~5% of members would \
+care about indoor gardening supplies."}
+  ]
+}
+
+Guidelines:
+- Be numeric and honest. Don't inflate scores to be polite.
+- If description is missing, rely on name + member_count + category.
+- Big groups with loose fit can still score low — relevance > reach.
+- Keep reasoning to ONE sentence, concrete (mention what overlaps or doesn't).
+"""
+
+
+CLUSTER_SYSTEM = """You are helping a solo business owner organize their list of \
+communities into 3–6 named segments.
+
+Given a list of approved targets, cluster them into meaningful groups and name each group \
+with a short human-readable label (e.g. "Urban gardeners", "Permaculture & off-grid", \
+"Pest & disease help"). Every target gets exactly ONE label.
+
+## Output
+Return a single JSON object:
+{
+  "lists": [
+    {"name": "Urban gardeners", "target_ids": [3, 7, 12]},
+    {"name": "Permaculture & off-grid", "target_ids": [4, 9]}
+  ]
+}
+
+Guidelines:
+- 3–6 clusters is the sweet spot; fewer if targets are homogeneous, more if very diverse.
+- Labels are short (2–4 words), title-case, human-facing.
+- Every id from input MUST appear exactly once across all clusters.
+- If two groups feel the same, merge them.
+"""
+
+
+@dataclass
+class TargetScore:
+    target_id: int
+    score: int
+    reasoning: str
+
+
+@dataclass
+class ScoreResult:
+    scores: list[TargetScore]
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cost_usd: float = 0.0
+
+
+@dataclass
+class ClusterAssignment:
+    list_name: str
+    target_ids: list[int]
+
+
+@dataclass
+class ClusterResult:
+    lists: list[ClusterAssignment] = field(default_factory=list)
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cost_usd: float = 0.0
+
+
+def _extract_json(text: str) -> dict:
+    text = text.strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```(?:json)?\s*", "", text)
+        text = re.sub(r"\s*```$", "", text)
+    first = text.find("{")
+    last = text.rfind("}")
+    if first == -1 or last == -1 or first > last:
+        raise ValueError(f"No JSON object in model response: {text[:200]!r}")
+    return json.loads(text[first : last + 1])
+
+
+def _call_claude(system: str, user: str) -> tuple[str, int, int]:
+    if not settings.anthropic_api_key:
+        raise RuntimeError("ANTHROPIC_API_KEY not set")
+    client = Anthropic(api_key=settings.anthropic_api_key)
+    resp = client.messages.create(
+        model=settings.text_model,
+        max_tokens=2500,
+        system=system,
+        messages=[{"role": "user", "content": user}],
+    )
+    return resp.content[0].text, resp.usage.input_tokens, resp.usage.output_tokens
+
+
+def _profile_block(bp: BusinessProfile) -> str:
+    audience = bp.target_audience or "(not set)"
+    products = bp.products or "(not set)"
+    return (
+        f"Name: {bp.name}\n"
+        f"What they do: {bp.description}\n"
+        f"Products: {products}\n"
+        f"Target audience: {audience}\n"
+        f"Language: {bp.language}\n"
+    )
+
+
+def _targets_block(targets: list[Target]) -> str:
+    rows = []
+    for t in targets:
+        rows.append(
+            {
+                "id": t.id,
+                "name": t.name,
+                "platform": t.platform_id,
+                "category": t.category,
+                "description": t.description_snippet,
+                "member_count": t.member_count,
+            }
+        )
+    return json.dumps(rows, ensure_ascii=False, indent=2)
+
+
+def score_targets(profile: BusinessProfile, targets: list[Target]) -> ScoreResult:
+    """Ask Claude to score a batch of targets for relevance to the business.
+
+    Returns ScoreResult; caller applies scores/reasoning to the DB rows.
+    """
+    if not targets:
+        return ScoreResult(scores=[])
+    user = (
+        "## Business\n" + _profile_block(profile) + "\n## Candidate communities\n"
+        + _targets_block(targets) + "\n\nReturn the JSON scores now."
+    )
+    raw, in_tok, out_tok = _call_claude(SCORE_SYSTEM, user)
+    data = _extract_json(raw)
+    raw_scores = data.get("scores") or []
+    if not isinstance(raw_scores, list):
+        raise ValueError("'scores' must be a list")
+
+    out: list[TargetScore] = []
+    known_ids = {t.id for t in targets}
+    for row in raw_scores:
+        if not isinstance(row, dict):
+            continue
+        tid = row.get("id")
+        if tid not in known_ids:
+            log.warning("Target agent returned unknown id=%s, skipping", tid)
+            continue
+        try:
+            score = int(row.get("score", 0))
+        except (TypeError, ValueError):
+            continue
+        score = max(0, min(100, score))
+        out.append(
+            TargetScore(
+                target_id=tid,
+                score=score,
+                reasoning=str(row.get("reasoning", "")).strip(),
+            )
+        )
+    cost = in_tok * _COST_IN + out_tok * _COST_OUT
+    return ScoreResult(scores=out, input_tokens=in_tok, output_tokens=out_tok, cost_usd=cost)
+
+
+def cluster_targets(profile: BusinessProfile, targets: list[Target]) -> ClusterResult:
+    """Group approved targets into 3–6 named segments.
+
+    The business profile is included so Claude can pick labels that match the owner's
+    mental model (e.g. if you sell gardening tools, it'll pick plant-focused labels).
+    """
+    if len(targets) < 2:
+        # Degenerate — single-bucket cluster. Cheap, no API call.
+        return ClusterResult(
+            lists=[ClusterAssignment(list_name="All targets", target_ids=[t.id for t in targets])]
+        )
+    user = (
+        "## Business\n" + _profile_block(profile) + "\n## Targets to cluster\n"
+        + _targets_block(targets) + "\n\nReturn the JSON clusters now."
+    )
+    raw, in_tok, out_tok = _call_claude(CLUSTER_SYSTEM, user)
+    data = _extract_json(raw)
+    raw_lists = data.get("lists") or []
+    if not isinstance(raw_lists, list):
+        raise ValueError("'lists' must be a list")
+
+    assignments: list[ClusterAssignment] = []
+    seen: set[int] = set()
+    known = {t.id for t in targets}
+    for row in raw_lists:
+        if not isinstance(row, dict):
+            continue
+        name = str(row.get("name", "")).strip() or "Unlabeled"
+        ids_raw = row.get("target_ids") or []
+        clean_ids: list[int] = []
+        for raw_id in ids_raw:
+            try:
+                tid = int(raw_id)
+            except (TypeError, ValueError):
+                continue
+            if tid in known and tid not in seen:
+                clean_ids.append(tid)
+                seen.add(tid)
+        if clean_ids:
+            assignments.append(ClusterAssignment(list_name=name, target_ids=clean_ids))
+
+    # Anything unplaced goes to "Other" so we don't silently lose targets.
+    leftover = [t.id for t in targets if t.id not in seen]
+    if leftover:
+        assignments.append(ClusterAssignment(list_name="Other", target_ids=leftover))
+
+    cost = in_tok * _COST_IN + out_tok * _COST_OUT
+    return ClusterResult(
+        lists=assignments, input_tokens=in_tok, output_tokens=out_tok, cost_usd=cost
+    )

--- a/backend/app/ai/content.py
+++ b/backend/app/ai/content.py
@@ -86,7 +86,18 @@ def _scrub(text: str) -> tuple[str, bool]:
 
 
 def _fetch_few_shot_examples(db: Session, post_type: PostType, limit: int = 3) -> list[str]:
-    """Get top N thumbs-up posts of the same type for few-shot injection."""
+    """Few-shot examples for the Writer.
+
+    Prefers the engagement-ranked store curated by the Analyst (M6). If empty
+    (nothing posted yet, or metrics haven't been collected), fall back to
+    thumbs-up-rated posts of the same type — M0/M1 behaviour.
+    """
+    from app.services.few_shot import fetch_few_shot_examples as fetch_engagement_examples
+
+    engagement = fetch_engagement_examples(db, post_type, limit=limit)
+    if engagement:
+        return engagement
+
     rows = (
         db.query(Post)
         .join(Post.feedback)

--- a/backend/app/ai/image.py
+++ b/backend/app/ai/image.py
@@ -12,7 +12,6 @@ Alternatives easy to plug in:
 from __future__ import annotations
 
 import base64
-import os
 import uuid
 from dataclasses import dataclass
 from pathlib import Path

--- a/backend/app/ai/vision.py
+++ b/backend/app/ai/vision.py
@@ -1,0 +1,137 @@
+"""Claude Vision-based tagging for MediaAssets.
+
+Given an image file, we ask Claude for:
+- a concrete 1-sentence caption
+- 3-8 short semantic tags
+
+These fuel the auto-suggest-for-slot feature: match a slot's topic_hint + post_type
+against each asset's tags/caption.
+
+We intentionally don't compute vector embeddings — tags give us 80% of the quality
+for 0% of the dependency cost on a vector DB.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from anthropic import Anthropic
+
+from app.config import settings
+
+log = logging.getLogger("ai.vision")
+
+_COST_IN = 3.0 / 1_000_000
+_COST_OUT = 15.0 / 1_000_000
+
+_MIME_BY_EXT = {
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".webp": "image/webp",
+    ".gif": "image/gif",
+}
+
+SYSTEM_PROMPT = """You tag images for a business's social media library. You're \
+shown one image and you return JSON with a short factual caption and 3-8 tags.
+
+Rules:
+- The caption is one sentence, ≤20 words, present tense, concrete. \
+  No opinions, no marketing adjectives.
+- Tags are lowercase, 1-2 words each, no hashtags, no punctuation.
+- Tags should be searchable ("basil", "windowsill", "morning-light", \
+"woman-cooking"), not vague ("beautiful", "nice", "cool").
+
+Return ONLY JSON of the form:
+{"caption": "...", "tags": ["...", "..."]}"""
+
+
+@dataclass
+class TagResult:
+    caption: str
+    tags: list[str]
+    cost_usd: float
+
+
+def _extract_json(text: str) -> dict:
+    text = text.strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```(?:json)?\s*", "", text)
+        text = re.sub(r"\s*```$", "", text)
+    first = text.find("{")
+    last = text.rfind("}")
+    if first == -1 or last == -1:
+        raise ValueError(f"No JSON in response: {text[:200]!r}")
+    return json.loads(text[first : last + 1])
+
+
+def tag_image(file_path: Path, mime: str | None = None) -> TagResult:
+    """Call Claude with the image, parse tags. Raises if API key missing."""
+    if not settings.anthropic_api_key:
+        raise RuntimeError("ANTHROPIC_API_KEY not set — cannot tag images")
+    if mime is None:
+        mime = _MIME_BY_EXT.get(file_path.suffix.lower(), "image/jpeg")
+    data = file_path.read_bytes()
+    b64 = base64.b64encode(data).decode("ascii")
+
+    client = Anthropic(api_key=settings.anthropic_api_key)
+    resp = client.messages.create(
+        model=settings.text_model,
+        max_tokens=400,
+        system=SYSTEM_PROMPT,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "source": {"type": "base64", "media_type": mime, "data": b64},
+                    },
+                    {"type": "text", "text": "Tag this image."},
+                ],
+            }
+        ],
+    )
+    raw = resp.content[0].text
+    data_json = _extract_json(raw)
+    caption = str(data_json.get("caption", "")).strip()
+    tags_raw = data_json.get("tags", []) or []
+    tags = [str(t).strip().lower() for t in tags_raw if str(t).strip()]
+    cost = resp.usage.input_tokens * _COST_IN + resp.usage.output_tokens * _COST_OUT
+    return TagResult(caption=caption, tags=tags, cost_usd=cost)
+
+
+# ---------- Relevance scoring ----------
+
+_WORD_RE = re.compile(r"[a-zA-Zа-яА-ЯёЁ]+")
+
+
+def _tokenize(text: str | None) -> set[str]:
+    if not text:
+        return set()
+    return {w.lower() for w in _WORD_RE.findall(text) if len(w) >= 3}
+
+
+def media_relevance_score(
+    slot_post_type: str,
+    slot_topic_hint: str | None,
+    asset_tags: list[str],
+    asset_caption: str | None,
+) -> float:
+    """Jaccard-ish overlap between slot keywords and asset tags+caption.
+
+    Purely lexical — no embeddings. Good enough for v1. Returns 0.0 if nothing \
+    matches, up to 1.0.
+    """
+    slot_tokens = _tokenize(slot_topic_hint) | {slot_post_type.lower()}
+    asset_tokens = _tokenize(" ".join(asset_tags) + " " + (asset_caption or ""))
+    if not slot_tokens or not asset_tokens:
+        return 0.0
+    overlap = slot_tokens & asset_tokens
+    if not overlap:
+        return 0.0
+    return len(overlap) / (len(slot_tokens | asset_tokens) ** 0.5 + 1e-9)

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,13 +1,14 @@
 """Aggregate router. Import this from main.py."""
 from fastapi import APIRouter
 
-from app.api import business_profile, feedback, health, media, posts, targets
+from app.api import business_profile, feedback, health, media, plans, posts, targets
 
 api_router = APIRouter()
 api_router.include_router(health.router)
 api_router.include_router(business_profile.router)
 api_router.include_router(targets.router)
 api_router.include_router(posts.router)
+api_router.include_router(plans.router)
 api_router.include_router(feedback.router)
 api_router.include_router(media.router)
 

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,0 +1,14 @@
+"""Aggregate router. Import this from main.py."""
+from fastapi import APIRouter
+
+from app.api import business_profile, feedback, health, media, posts, targets
+
+api_router = APIRouter()
+api_router.include_router(health.router)
+api_router.include_router(business_profile.router)
+api_router.include_router(targets.router)
+api_router.include_router(posts.router)
+api_router.include_router(feedback.router)
+api_router.include_router(media.router)
+
+__all__ = ["api_router"]

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter
 
 from app.api import (
     analytics,
+    auth,
     business_profile,
     feedback,
     health,
@@ -16,6 +17,7 @@ from app.api import (
 )
 
 api_router = APIRouter()
+api_router.include_router(auth.router)
 api_router.include_router(health.router)
 api_router.include_router(business_profile.router)
 api_router.include_router(targets.router)

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -2,6 +2,7 @@
 from fastapi import APIRouter
 
 from app.api import (
+    analytics,
     business_profile,
     feedback,
     health,
@@ -21,5 +22,6 @@ api_router.include_router(plans.router)
 api_router.include_router(feedback.router)
 api_router.include_router(media.router)
 api_router.include_router(humanizer.router)
+api_router.include_router(analytics.router)
 
 __all__ = ["api_router"]

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -8,7 +8,9 @@ from app.api import (
     health,
     humanizer,
     media,
+    meta_oauth,
     plans,
+    platform_credentials,
     posts,
     targets,
 )
@@ -23,5 +25,7 @@ api_router.include_router(feedback.router)
 api_router.include_router(media.router)
 api_router.include_router(humanizer.router)
 api_router.include_router(analytics.router)
+api_router.include_router(meta_oauth.router)
+api_router.include_router(platform_credentials.router)
 
 __all__ = ["api_router"]

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,7 +1,16 @@
 """Aggregate router. Import this from main.py."""
 from fastapi import APIRouter
 
-from app.api import business_profile, feedback, health, media, plans, posts, targets
+from app.api import (
+    business_profile,
+    feedback,
+    health,
+    humanizer,
+    media,
+    plans,
+    posts,
+    targets,
+)
 
 api_router = APIRouter()
 api_router.include_router(health.router)
@@ -11,5 +20,6 @@ api_router.include_router(posts.router)
 api_router.include_router(plans.router)
 api_router.include_router(feedback.router)
 api_router.include_router(media.router)
+api_router.include_router(humanizer.router)
 
 __all__ = ["api_router"]

--- a/backend/app/api/analytics.py
+++ b/backend/app/api/analytics.py
@@ -1,0 +1,256 @@
+"""Analytics / Analyst / Optimizer routes (M6).
+
+Surfaces:
+- Raw metrics for a post / the whole queue.
+- Weekly Analyst reports (list + detail, plus a manual generate trigger).
+- Optimizer proposals (list + apply + reject).
+- Manual `/metrics/collect` trigger so you can refresh without waiting for the
+  hourly cron during development.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime, timedelta
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import func
+from sqlalchemy.orm import Session, selectinload
+
+from app.agents import analyst as analyst_agent
+from app.db import get_session
+from app.db.models import (
+    AnalystReport,
+    BusinessProfile,
+    OptimizerProposal,
+    Post,
+    PostMetrics,
+    PostStatus,
+    PostVariant,
+    ProposalStatus,
+)
+from app.schemas import (
+    AnalystGenerateRequest,
+    AnalystReportOut,
+    AnalyticsSummaryOut,
+    MetricsCollectResult,
+    OptimizerProposalOut,
+    PostMetricsOut,
+    TopPerformerOut,
+)
+from app.services import few_shot, metrics as metrics_service
+
+log = logging.getLogger("api.analytics")
+
+router = APIRouter(prefix="/api", tags=["analytics"])
+
+
+# ---------- Metrics ----------
+
+
+@router.get("/metrics/post/{post_id}", response_model=list[PostMetricsOut])
+def post_metrics(post_id: int, db: Session = Depends(get_session)) -> list[PostMetrics]:
+    return (
+        db.query(PostMetrics)
+        .join(PostVariant, PostMetrics.variant_id == PostVariant.id)
+        .filter(PostVariant.post_id == post_id)
+        .order_by(PostMetrics.collected_at.desc())
+        .all()
+    )
+
+
+@router.post("/metrics/collect", response_model=MetricsCollectResult)
+async def collect_metrics_now(db: Session = Depends(get_session)) -> MetricsCollectResult:
+    """Manual trigger — runs a full collection pass synchronously."""
+    try:
+        result = await metrics_service.collect_metrics(db)
+    except Exception as exc:
+        log.exception("Metrics collection failed")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    return MetricsCollectResult(**result)
+
+
+@router.get("/analytics/summary", response_model=AnalyticsSummaryOut)
+def analytics_summary(
+    days: int = 7,
+    db: Session = Depends(get_session),
+) -> AnalyticsSummaryOut:
+    """Quick KPI block for the dashboard home."""
+    period_start = datetime.now(UTC) - timedelta(days=days)
+    total_posts = (
+        db.query(func.count(Post.id))
+        .filter(Post.status == PostStatus.POSTED)
+        .filter(Post.posted_at >= period_start)
+        .scalar()
+        or 0
+    )
+    totals = (
+        db.query(
+            func.coalesce(func.sum(PostMetrics.likes), 0),
+            func.coalesce(func.sum(PostMetrics.comments), 0),
+            func.coalesce(func.sum(PostMetrics.shares), 0),
+            func.coalesce(func.avg(PostMetrics.engagement_score), 0.0),
+        )
+        .join(PostVariant, PostMetrics.variant_id == PostVariant.id)
+        .join(Post, Post.id == PostVariant.post_id)
+        .filter(Post.posted_at >= period_start)
+        .first()
+        or (0, 0, 0, 0.0)
+    )
+    return AnalyticsSummaryOut(
+        period_days=days,
+        posts=int(total_posts),
+        likes=int(totals[0]),
+        comments=int(totals[1]),
+        shares=int(totals[2]),
+        avg_engagement_score=float(totals[3] or 0.0),
+    )
+
+
+@router.get("/analytics/top-performers", response_model=list[TopPerformerOut])
+def top_performers(
+    days: int = 7,
+    limit: int = 5,
+    reverse: bool = False,
+    db: Session = Depends(get_session),
+) -> list[TopPerformerOut]:
+    """Best (or worst, if reverse=true) posts in the window by engagement_score."""
+    period_start = datetime.now(UTC) - timedelta(days=days)
+    best_score = func.max(PostMetrics.engagement_score).label("best")
+    rows = (
+        db.query(Post, best_score)
+        .join(PostVariant, PostVariant.post_id == Post.id)
+        .join(PostMetrics, PostMetrics.variant_id == PostVariant.id)
+        .filter(Post.posted_at >= period_start)
+        .group_by(Post.id)
+        .order_by(best_score.asc() if reverse else best_score.desc())
+        .limit(limit)
+        .all()
+    )
+    return [
+        TopPerformerOut(
+            post_id=p.id,
+            post_type=p.post_type,
+            posted_at=p.posted_at,
+            text_preview=p.text[:200],
+            engagement_score=float(score or 0.0),
+        )
+        for p, score in rows
+    ]
+
+
+# ---------- Analyst reports ----------
+
+
+@router.get("/analyst/reports", response_model=list[AnalystReportOut])
+def list_reports(
+    limit: int = 20,
+    db: Session = Depends(get_session),
+) -> list[AnalystReport]:
+    return (
+        db.query(AnalystReport)
+        .order_by(AnalystReport.created_at.desc())
+        .limit(limit)
+        .all()
+    )
+
+
+@router.get("/analyst/reports/{report_id}", response_model=AnalystReportOut)
+def get_report(report_id: int, db: Session = Depends(get_session)) -> AnalystReport:
+    r = db.get(AnalystReport, report_id)
+    if r is None:
+        raise HTTPException(status_code=404, detail="Report not found")
+    return r
+
+
+@router.post("/analyst/generate", response_model=AnalystReportOut)
+async def generate_report(
+    payload: AnalystGenerateRequest,
+    db: Session = Depends(get_session),
+) -> AnalystReport:
+    """Kick off a fresh analyst run. Blocks until Claude responds."""
+    profile = db.query(BusinessProfile).order_by(BusinessProfile.id.asc()).first()
+    if profile is None:
+        raise HTTPException(status_code=400, detail="Business profile required.")
+
+    end = payload.period_end or datetime.now(UTC)
+    start = payload.period_start or (end - timedelta(days=payload.days or 7))
+
+    # The Claude call can be slow; run it in a thread so we don't hog the loop.
+    output = await asyncio.to_thread(analyst_agent.run_analysis, db, profile, start, end)
+    report = analyst_agent.persist_report_and_proposals(db, profile, output, start, end)
+
+    # Side-effect: refresh few-shot store now that we have fresh metrics.
+    try:
+        few_shot.refresh_few_shot_store(db)
+    except Exception:
+        log.exception("Few-shot refresh failed (non-fatal)")
+
+    return report
+
+
+# ---------- Proposals ----------
+
+
+@router.get("/optimizer/proposals", response_model=list[OptimizerProposalOut])
+def list_proposals(
+    status: ProposalStatus | None = None,
+    limit: int = 100,
+    db: Session = Depends(get_session),
+) -> list[OptimizerProposal]:
+    q = db.query(OptimizerProposal)
+    if status is not None:
+        q = q.filter(OptimizerProposal.status == status)
+    return q.order_by(OptimizerProposal.created_at.desc()).limit(limit).all()
+
+
+@router.post("/optimizer/proposals/{proposal_id}/apply", response_model=OptimizerProposalOut)
+def apply_proposal(proposal_id: int, db: Session = Depends(get_session)) -> OptimizerProposal:
+    proposal = db.get(OptimizerProposal, proposal_id)
+    if proposal is None:
+        raise HTTPException(status_code=404, detail="Proposal not found")
+    if proposal.status != ProposalStatus.PENDING:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Proposal is already {proposal.status.value}.",
+        )
+    profile = db.query(BusinessProfile).order_by(BusinessProfile.id.asc()).first()
+    if profile is None:
+        raise HTTPException(status_code=400, detail="Business profile required.")
+    # Unwrap scalar container if that's how the agent stored it.
+    value = proposal.proposed_value
+    if isinstance(value, dict) and "value" in value and len(value) == 1:
+        value = value["value"]
+    if not hasattr(profile, proposal.field):
+        raise HTTPException(status_code=400, detail=f"Unknown field {proposal.field}")
+    setattr(profile, proposal.field, value)
+    proposal.status = ProposalStatus.APPLIED
+    proposal.applied_at = datetime.now(UTC)
+    db.commit()
+    db.refresh(proposal)
+    return proposal
+
+
+@router.post("/optimizer/proposals/{proposal_id}/reject", response_model=OptimizerProposalOut)
+def reject_proposal(proposal_id: int, db: Session = Depends(get_session)) -> OptimizerProposal:
+    proposal = db.get(OptimizerProposal, proposal_id)
+    if proposal is None:
+        raise HTTPException(status_code=404, detail="Proposal not found")
+    if proposal.status != ProposalStatus.PENDING:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Proposal is already {proposal.status.value}.",
+        )
+    proposal.status = ProposalStatus.REJECTED
+    db.commit()
+    db.refresh(proposal)
+    return proposal
+
+
+# ---------- Few-shot store ----------
+
+
+@router.post("/few-shot/refresh")
+def refresh_few_shot(db: Session = Depends(get_session)) -> dict:
+    count = few_shot.refresh_few_shot_store(db)
+    return {"inserted": count}

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,0 +1,66 @@
+"""Dashboard PIN auth endpoints.
+
+- POST /api/auth/login { pin } → sets signed cookie
+- POST /api/auth/logout        → clears cookie
+- GET  /api/auth/status        → { authenticated, auth_required }
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request, Response
+from pydantic import BaseModel
+
+from app.config import settings
+from app.security import (
+    _COOKIE_MAX_AGE,
+    _COOKIE_NAME,
+    _verify_session,
+    make_session_cookie,
+    verify_pin,
+)
+
+router = APIRouter(prefix="/api/auth", tags=["auth"])
+
+
+class LoginIn(BaseModel):
+    pin: str
+
+
+class AuthStatus(BaseModel):
+    auth_required: bool
+    authenticated: bool
+
+
+@router.get("/status", response_model=AuthStatus)
+def status(request: Request) -> AuthStatus:
+    pin = settings.dashboard_pin.strip()
+    if not pin:
+        return AuthStatus(auth_required=False, authenticated=True)
+    cookie = request.cookies.get(_COOKIE_NAME, "")
+    ok = bool(cookie) and _verify_session(cookie, pin)
+    return AuthStatus(auth_required=True, authenticated=ok)
+
+
+@router.post("/login", response_model=AuthStatus)
+def login(payload: LoginIn, response: Response) -> AuthStatus:
+    pin = settings.dashboard_pin.strip()
+    if not pin:
+        return AuthStatus(auth_required=False, authenticated=True)
+    if not verify_pin(payload.pin):
+        raise HTTPException(status_code=401, detail="Invalid PIN")
+    response.set_cookie(
+        key=_COOKIE_NAME,
+        value=make_session_cookie(pin),
+        max_age=_COOKIE_MAX_AGE,
+        httponly=True,
+        samesite="lax",
+    )
+    return AuthStatus(auth_required=True, authenticated=True)
+
+
+@router.post("/logout", response_model=AuthStatus)
+def logout(response: Response) -> AuthStatus:
+    response.delete_cookie(_COOKIE_NAME)
+    return AuthStatus(
+        auth_required=bool(settings.dashboard_pin.strip()),
+        authenticated=False,
+    )

--- a/backend/app/api/business_profile.py
+++ b/backend/app/api/business_profile.py
@@ -1,0 +1,39 @@
+"""Business profile CRUD. Singleton for v1 — we always upsert row with id=1."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.db import get_session
+from app.db.models import BusinessProfile
+from app.schemas import BusinessProfileIn, BusinessProfileOut
+
+router = APIRouter(prefix="/api/business-profile", tags=["business-profile"])
+
+
+@router.get("", response_model=BusinessProfileOut)
+def get_profile(db: Session = Depends(get_session)) -> BusinessProfile:
+    profile = db.query(BusinessProfile).order_by(BusinessProfile.id.asc()).first()
+    if profile is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Business profile not set yet. PUT to create it.",
+        )
+    return profile
+
+
+@router.put("", response_model=BusinessProfileOut)
+def upsert_profile(
+    payload: BusinessProfileIn,
+    db: Session = Depends(get_session),
+) -> BusinessProfile:
+    profile = db.query(BusinessProfile).order_by(BusinessProfile.id.asc()).first()
+    if profile is None:
+        profile = BusinessProfile(**payload.model_dump())
+        db.add(profile)
+    else:
+        for key, value in payload.model_dump().items():
+            setattr(profile, key, value)
+    db.commit()
+    db.refresh(profile)
+    return profile

--- a/backend/app/api/feedback.py
+++ b/backend/app/api/feedback.py
@@ -1,0 +1,36 @@
+"""Feedback endpoint. Thumbs up/down on a post feeds into few-shot examples."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.db import get_session
+from app.db.models import Feedback, Post
+from app.schemas import FeedbackIn, FeedbackOut
+
+router = APIRouter(prefix="/api/feedback", tags=["feedback"])
+
+
+@router.post("", response_model=FeedbackOut, status_code=status.HTTP_201_CREATED)
+def create_feedback(payload: FeedbackIn, db: Session = Depends(get_session)) -> Feedback:
+    if db.get(Post, payload.post_id) is None:
+        raise HTTPException(status_code=404, detail="Post not found")
+    row = Feedback(
+        post_id=payload.post_id,
+        rating=payload.rating,
+        comment=payload.comment,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.get("/by-post/{post_id}", response_model=list[FeedbackOut])
+def list_feedback(post_id: int, db: Session = Depends(get_session)) -> list[Feedback]:
+    return (
+        db.query(Feedback)
+        .filter(Feedback.post_id == post_id)
+        .order_by(Feedback.created_at.desc())
+        .all()
+    )

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -1,0 +1,47 @@
+"""Health + status endpoints."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.db import get_session
+from app.db.models import Post, PostStatus
+from app.schemas import StatusOut
+from app.ws.extension_bridge import bridge
+
+router = APIRouter(tags=["health"])
+
+
+@router.get("/healthz")
+def healthz() -> dict:
+    """Lightweight liveness check — no DB hit."""
+    return {
+        "ok": True,
+        "extension_connected": bridge.connected,
+        "version": "0.1.0",
+    }
+
+
+@router.get("/api/status", response_model=StatusOut)
+def status(db: Session = Depends(get_session)) -> StatusOut:
+    from app.scheduler import scheduler  # late import to avoid cycles
+
+    next_post = (
+        db.query(Post)
+        .filter(Post.status == PostStatus.SCHEDULED)
+        .filter(Post.scheduled_for.isnot(None))
+        .order_by(Post.scheduled_for.asc())
+        .first()
+    )
+    pending = (
+        db.query(Post).filter(Post.status.in_([PostStatus.SCHEDULED, PostStatus.DRAFT])).count()
+    )
+
+    return StatusOut(
+        ok=True,
+        version="0.1.0",
+        extension_connected=bridge.connected,
+        scheduler_running=scheduler.is_running(),
+        next_scheduled_post_at=next_post.scheduled_for if next_post else None,
+        pending_posts=pending,
+    )

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -45,3 +45,12 @@ def status(db: Session = Depends(get_session)) -> StatusOut:
         next_scheduled_post_at=next_post.scheduled_for if next_post else None,
         pending_posts=pending,
     )
+
+
+@router.post("/api/admin/backup")
+def run_backup_now() -> dict:
+    """Trigger an on-demand backup (the scheduler also runs one at 03:00 UTC)."""
+    from app.services import backups
+
+    path = backups.run_backup()
+    return {"ok": True, "path": str(path), "size_bytes": path.stat().st_size}

--- a/backend/app/api/humanizer.py
+++ b/backend/app/api/humanizer.py
@@ -1,0 +1,100 @@
+"""Humanizer + session health + blackout-date endpoints (M4)."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.db import get_session
+from app.db.models import BlackoutDate, SessionHealth
+from app.schemas import (
+    BlackoutDateIn,
+    BlackoutDateOut,
+    HumanizerProfileIn,
+    HumanizerProfileOut,
+    SessionHealthOut,
+    SmartPauseInfo,
+)
+from app.services import humanizer as hz
+
+router = APIRouter(prefix="/api/humanizer", tags=["humanizer"])
+
+
+@router.get("/profile", response_model=HumanizerProfileOut)
+def get_profile(db: Session = Depends(get_session)) -> HumanizerProfileOut:
+    return hz.get_or_create_profile(db)
+
+
+@router.patch("/profile", response_model=HumanizerProfileOut)
+def patch_profile(
+    payload: HumanizerProfileIn, db: Session = Depends(get_session)
+) -> HumanizerProfileOut:
+    profile = hz.get_or_create_profile(db)
+    for key, value in payload.model_dump(exclude_unset=True).items():
+        setattr(profile, key, value)
+    db.commit()
+    db.refresh(profile)
+    return profile
+
+
+@router.get("/session-health", response_model=list[SessionHealthOut])
+def list_session_health(db: Session = Depends(get_session)) -> list[SessionHealth]:
+    return db.query(SessionHealth).order_by(SessionHealth.platform_id.asc()).all()
+
+
+@router.post("/pause", response_model=SmartPauseInfo)
+def activate_pause(db: Session = Depends(get_session)) -> SmartPauseInfo:
+    """Manually trigger the smart pause for the configured duration."""
+    profile = hz.get_or_create_profile(db)
+    hz._activate_pause(profile, reason="manual pause from dashboard")
+    db.commit()
+    return SmartPauseInfo(
+        paused=True,
+        until=profile.smart_pause_until,
+        reason=profile.smart_pause_reason,
+    )
+
+
+@router.post("/resume", response_model=SmartPauseInfo)
+def clear_pause(db: Session = Depends(get_session)) -> SmartPauseInfo:
+    hz.clear_pause(db)
+    return SmartPauseInfo(paused=False, until=None, reason=None)
+
+
+@router.get("/pause", response_model=SmartPauseInfo)
+def pause_status(db: Session = Depends(get_session)) -> SmartPauseInfo:
+    profile = hz.get_or_create_profile(db)
+    until = hz.check_pause(db)
+    return SmartPauseInfo(
+        paused=until is not None,
+        until=until,
+        reason=profile.smart_pause_reason if until else None,
+    )
+
+
+@router.get("/blackout-dates", response_model=list[BlackoutDateOut])
+def list_blackouts(db: Session = Depends(get_session)) -> list[BlackoutDate]:
+    return db.query(BlackoutDate).order_by(BlackoutDate.date.asc()).all()
+
+
+@router.post(
+    "/blackout-dates",
+    response_model=BlackoutDateOut,
+    status_code=status.HTTP_201_CREATED,
+)
+def add_blackout(
+    payload: BlackoutDateIn, db: Session = Depends(get_session)
+) -> BlackoutDate:
+    row = BlackoutDate(date=payload.date, reason=payload.reason)
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.delete("/blackout-dates/{bid}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_blackout(bid: int, db: Session = Depends(get_session)) -> None:
+    row = db.get(BlackoutDate, bid)
+    if row is None:
+        raise HTTPException(status_code=404, detail="not found")
+    db.delete(row)
+    db.commit()

--- a/backend/app/api/media.py
+++ b/backend/app/api/media.py
@@ -1,14 +1,46 @@
-"""Media upload endpoint. User drops a photo, we save it under data/images/uploads/
-and return a URL the frontend can embed / hand to the extension."""
+"""Media library endpoints.
+
+POST   /api/media/upload                  — upload image, store on disk + DB
+GET    /api/media                         — list assets
+GET    /api/media/{id}                    — detail
+PATCH  /api/media/{id}                    — edit user tags
+DELETE /api/media/{id}
+POST   /api/media/{id}/tag                — (re)run Claude Vision tagging
+POST   /api/media/{id}/attach-to-slot/{slot_id}
+                                          — link asset to a PlanSlot
+GET    /api/media/suggest-for-slot/{slot_id}?limit=3
+                                          — top-N by tag overlap
+"""
 from __future__ import annotations
 
+import logging
 import uuid
+from datetime import UTC, datetime
 from pathlib import Path
 
-from fastapi import APIRouter, File, HTTPException, UploadFile
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    HTTPException,
+    UploadFile,
+    status,
+)
+from PIL import Image as PILImage
+from sqlalchemy.orm import Session
 
-from app.schemas import MediaUploadOut
+from app.ai.vision import media_relevance_score, tag_image
+from app.db import get_session
+from app.db.models import MediaAsset, MediaKind, PlanSlot
+from app.schemas import (
+    MediaAssetOut,
+    MediaAssetPatch,
+    MediaSuggestion,
+    MediaTagResult,
+    MediaUploadOut,
+)
 
+log = logging.getLogger("api.media")
 router = APIRouter(prefix="/api/media", tags=["media"])
 
 UPLOADS_DIR = Path("data/images/uploads")
@@ -20,11 +52,29 @@ ALLOWED_MIME = {
     "image/webp",
     "image/gif",
 }
+EXT_MAP = {
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/webp": ".webp",
+    "image/gif": ".gif",
+}
 MAX_BYTES = 10 * 1024 * 1024  # 10 MB for v1 — images only
 
 
+def _read_dimensions(path: Path) -> tuple[int | None, int | None]:
+    try:
+        with PILImage.open(path) as img:
+            return int(img.width), int(img.height)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("Pillow failed to open %s: %s", path, exc)
+        return None, None
+
+
 @router.post("/upload", response_model=MediaUploadOut)
-async def upload(file: UploadFile = File(...)) -> MediaUploadOut:
+async def upload(
+    file: UploadFile = File(...),
+    db: Session = Depends(get_session),
+) -> MediaUploadOut:
     mime = file.content_type or "application/octet-stream"
     if mime not in ALLOWED_MIME:
         raise HTTPException(status_code=400, detail=f"Unsupported mime type: {mime}")
@@ -35,20 +85,161 @@ async def upload(file: UploadFile = File(...)) -> MediaUploadOut:
     if not data:
         raise HTTPException(status_code=400, detail="Empty file")
 
-    ext_map = {
-        "image/jpeg": ".jpg",
-        "image/png": ".png",
-        "image/webp": ".webp",
-        "image/gif": ".gif",
-    }
-    ext = ext_map[mime]
+    ext = EXT_MAP[mime]
     filename = f"{uuid.uuid4().hex}{ext}"
     out_path = UPLOADS_DIR / filename
     out_path.write_bytes(data)
+    width, height = _read_dimensions(out_path)
+
+    asset = MediaAsset(
+        kind=MediaKind.IMAGE,
+        mime=mime,
+        local_path=f"images/uploads/{filename}",
+        filename=filename,
+        size_bytes=len(data),
+        width=width,
+        height=height,
+        ai_caption=None,
+        ai_tags=[],
+        tags_user=[],
+        variants_json={},
+    )
+    db.add(asset)
+    db.commit()
+    db.refresh(asset)
 
     return MediaUploadOut(
-        url=f"/static/images/uploads/{filename}",
-        filename=filename,
-        mime=mime,
-        size_bytes=len(data),
+        id=asset.id,
+        url=f"/static/{asset.local_path}",
+        filename=asset.filename,
+        mime=asset.mime,
+        size_bytes=asset.size_bytes,
+        width=asset.width,
+        height=asset.height,
     )
+
+
+@router.get("", response_model=list[MediaAssetOut])
+def list_media(
+    limit: int = 200,
+    db: Session = Depends(get_session),
+) -> list[MediaAsset]:
+    return (
+        db.query(MediaAsset)
+        .order_by(MediaAsset.created_at.desc())
+        .limit(limit)
+        .all()
+    )
+
+
+@router.get("/{asset_id}", response_model=MediaAssetOut)
+def get_media(asset_id: int, db: Session = Depends(get_session)) -> MediaAsset:
+    asset = db.get(MediaAsset, asset_id)
+    if asset is None:
+        raise HTTPException(status_code=404, detail="Asset not found")
+    return asset
+
+
+@router.patch("/{asset_id}", response_model=MediaAssetOut)
+def patch_media(
+    asset_id: int,
+    payload: MediaAssetPatch,
+    db: Session = Depends(get_session),
+) -> MediaAsset:
+    asset = db.get(MediaAsset, asset_id)
+    if asset is None:
+        raise HTTPException(status_code=404, detail="Asset not found")
+    for key, value in payload.model_dump(exclude_unset=True).items():
+        setattr(asset, key, value)
+    db.commit()
+    db.refresh(asset)
+    return asset
+
+
+@router.delete("/{asset_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_media(asset_id: int, db: Session = Depends(get_session)) -> None:
+    asset = db.get(MediaAsset, asset_id)
+    if asset is None:
+        raise HTTPException(status_code=404, detail="Asset not found")
+    # Best-effort: remove file. We don't fail the API call if the file is already gone.
+    full_path = Path("data") / asset.local_path
+    try:
+        if full_path.exists():
+            full_path.unlink()
+    except Exception as exc:  # noqa: BLE001
+        log.warning("Could not remove %s: %s", full_path, exc)
+    db.delete(asset)
+    db.commit()
+
+
+@router.post("/{asset_id}/tag", response_model=MediaTagResult)
+def run_tagging(asset_id: int, db: Session = Depends(get_session)) -> MediaTagResult:
+    asset = db.get(MediaAsset, asset_id)
+    if asset is None:
+        raise HTTPException(status_code=404, detail="Asset not found")
+    full_path = Path("data") / asset.local_path
+    if not full_path.exists():
+        raise HTTPException(status_code=410, detail="Underlying file missing")
+
+    result = tag_image(full_path, mime=asset.mime)
+    asset.ai_caption = result.caption
+    asset.ai_tags = result.tags
+    asset.tagged_at = datetime.now(UTC)
+    db.commit()
+    db.refresh(asset)
+    return MediaTagResult(caption=result.caption, tags=result.tags, cost_usd=result.cost_usd)
+
+
+@router.post(
+    "/{asset_id}/attach-to-slot/{slot_id}",
+    response_model=MediaAssetOut,
+)
+def attach_to_slot(
+    asset_id: int,
+    slot_id: int,
+    db: Session = Depends(get_session),
+) -> MediaAsset:
+    asset = db.get(MediaAsset, asset_id)
+    if asset is None:
+        raise HTTPException(status_code=404, detail="Asset not found")
+    slot = db.get(PlanSlot, slot_id)
+    if slot is None:
+        raise HTTPException(status_code=404, detail="Slot not found")
+    slot.media_asset_id = asset.id
+    db.commit()
+    return asset
+
+
+@router.get(
+    "/suggest-for-slot/{slot_id}",
+    response_model=list[MediaSuggestion],
+)
+def suggest_for_slot(
+    slot_id: int,
+    limit: int = 3,
+    db: Session = Depends(get_session),
+) -> list[MediaSuggestion]:
+    slot = db.get(PlanSlot, slot_id)
+    if slot is None:
+        raise HTTPException(status_code=404, detail="Slot not found")
+    assets = db.query(MediaAsset).all()
+    scored: list[tuple[float, MediaAsset]] = []
+    for a in assets:
+        score = media_relevance_score(
+            slot_post_type=slot.post_type.value,
+            slot_topic_hint=slot.topic_hint,
+            asset_tags=a.ai_tags or [],
+            asset_caption=a.ai_caption,
+        )
+        if score > 0:
+            scored.append((score, a))
+    scored.sort(key=lambda t: t[0], reverse=True)
+    out: list[MediaSuggestion] = []
+    for score, a in scored[:limit]:
+        out.append(
+            MediaSuggestion(
+                asset=MediaAssetOut.model_validate(a),
+                score=round(score, 4),
+            )
+        )
+    return out

--- a/backend/app/api/media.py
+++ b/backend/app/api/media.py
@@ -1,0 +1,54 @@
+"""Media upload endpoint. User drops a photo, we save it under data/images/uploads/
+and return a URL the frontend can embed / hand to the extension."""
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+from fastapi import APIRouter, File, HTTPException, UploadFile
+
+from app.schemas import MediaUploadOut
+
+router = APIRouter(prefix="/api/media", tags=["media"])
+
+UPLOADS_DIR = Path("data/images/uploads")
+UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
+
+ALLOWED_MIME = {
+    "image/jpeg",
+    "image/png",
+    "image/webp",
+    "image/gif",
+}
+MAX_BYTES = 10 * 1024 * 1024  # 10 MB for v1 — images only
+
+
+@router.post("/upload", response_model=MediaUploadOut)
+async def upload(file: UploadFile = File(...)) -> MediaUploadOut:
+    mime = file.content_type or "application/octet-stream"
+    if mime not in ALLOWED_MIME:
+        raise HTTPException(status_code=400, detail=f"Unsupported mime type: {mime}")
+
+    data = await file.read()
+    if len(data) > MAX_BYTES:
+        raise HTTPException(status_code=413, detail="File too large (max 10 MB)")
+    if not data:
+        raise HTTPException(status_code=400, detail="Empty file")
+
+    ext_map = {
+        "image/jpeg": ".jpg",
+        "image/png": ".png",
+        "image/webp": ".webp",
+        "image/gif": ".gif",
+    }
+    ext = ext_map[mime]
+    filename = f"{uuid.uuid4().hex}{ext}"
+    out_path = UPLOADS_DIR / filename
+    out_path.write_bytes(data)
+
+    return MediaUploadOut(
+        url=f"/static/images/uploads/{filename}",
+        filename=filename,
+        mime=mime,
+        size_bytes=len(data),
+    )

--- a/backend/app/api/meta_oauth.py
+++ b/backend/app/api/meta_oauth.py
@@ -1,0 +1,215 @@
+"""Meta OAuth endpoints.
+
+Flow for M7:
+1. Dashboard hits `GET /api/meta/oauth/url` → we return a login URL (plus the
+   `state` nonce the caller must round-trip).
+2. User logs in with Facebook, accepts scopes, Meta redirects back to
+   `GET /api/meta/oauth/callback?code=...&state=...`.
+3. We exchange the code for a short-lived token, upgrade to a long-lived one,
+   probe /me/accounts for the IG Business account, and persist two
+   PlatformCredential rows (instagram + threads). Threads reuses the same
+   long-lived token; the account_id is fetched from settings if present.
+
+Scopes requested (v21.0): `instagram_basic`, `instagram_content_publish`,
+`pages_show_list`, `pages_read_engagement`, `threads_basic`,
+`threads_content_publish`, `threads_manage_insights`.
+"""
+from __future__ import annotations
+
+import logging
+import secrets
+from urllib.parse import urlencode
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.db import get_session
+from app.db.models import PlatformCredential
+from app.platforms import meta_graph
+from app.schemas import (
+    MetaManualCredentialIn,
+    MetaOAuthCompleteOut,
+    MetaOAuthUrlOut,
+    PlatformCredentialOut,
+)
+
+log = logging.getLogger("api.meta_oauth")
+
+router = APIRouter(prefix="/api/meta", tags=["meta"])
+
+
+META_OAUTH_SCOPES = [
+    "instagram_basic",
+    "instagram_content_publish",
+    "pages_show_list",
+    "pages_read_engagement",
+    "threads_basic",
+    "threads_content_publish",
+    "threads_manage_insights",
+]
+META_LOGIN_URL = "https://www.facebook.com/v21.0/dialog/oauth"
+
+
+def _upsert_credential(
+    db: Session,
+    platform_id: str,
+    account_id: str,
+    access_token: str,
+    username: str | None = None,
+    extra: dict | None = None,
+) -> PlatformCredential:
+    """Insert or update a PlatformCredential row by (platform_id, account_id)."""
+    row = (
+        db.query(PlatformCredential)
+        .filter(
+            PlatformCredential.platform_id == platform_id,
+            PlatformCredential.account_id == account_id,
+        )
+        .one_or_none()
+    )
+    if row is None:
+        row = PlatformCredential(
+            platform_id=platform_id,
+            account_id=account_id,
+            username=username,
+            access_token=access_token,
+            extra=extra or {},
+        )
+        db.add(row)
+    else:
+        row.access_token = access_token
+        if username:
+            row.username = username
+        if extra is not None:
+            row.extra = extra
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.get("/oauth/url", response_model=MetaOAuthUrlOut)
+def oauth_url() -> MetaOAuthUrlOut:
+    if not settings.meta_app_id:
+        raise HTTPException(
+            status_code=400,
+            detail="META_APP_ID is not configured in .env",
+        )
+    state = secrets.token_urlsafe(24)
+    params = {
+        "client_id": settings.meta_app_id,
+        "redirect_uri": settings.meta_redirect_uri,
+        "state": state,
+        "scope": ",".join(META_OAUTH_SCOPES),
+        "response_type": "code",
+    }
+    return MetaOAuthUrlOut(url=f"{META_LOGIN_URL}?{urlencode(params)}", state=state)
+
+
+@router.get("/oauth/callback", response_model=MetaOAuthCompleteOut)
+def oauth_callback(
+    code: str = Query(..., description="Authorization code from Facebook"),
+    state: str | None = Query(None),
+    db: Session = Depends(get_session),
+) -> MetaOAuthCompleteOut:
+    """Complete the OAuth dance. Called by Facebook's redirect.
+
+    We deliberately don't verify `state` cryptographically — for a single-user
+    localhost tool the CSRF surface is near zero. Any user with a malicious
+    redirect would need to trick YOU into authorising their app; out of scope.
+    """
+    if not settings.meta_app_id or not settings.meta_app_secret:
+        raise HTTPException(status_code=400, detail="Meta App credentials missing")
+
+    try:
+        short = meta_graph.exchange_code_for_token(
+            app_id=settings.meta_app_id,
+            app_secret=settings.meta_app_secret,
+            redirect_uri=settings.meta_redirect_uri,
+            code=code,
+        )
+        long = meta_graph.long_lived_token(
+            app_id=settings.meta_app_id,
+            app_secret=settings.meta_app_secret,
+            short_token=short["access_token"],
+        )
+    except meta_graph.MetaError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    long_token: str = long["access_token"]
+
+    # Probe pages → pull out the first IG Business account id we find.
+    ig_cred: PlatformCredential | None = None
+    threads_cred: PlatformCredential | None = None
+    try:
+        pages = meta_graph.list_pages(long_token)
+    except meta_graph.MetaError as exc:
+        log.warning("list_pages failed post-OAuth: %s", exc)
+        pages = []
+
+    for page in pages:
+        ig = page.get("instagram_business_account")
+        if not ig:
+            continue
+        ig_id = ig.get("id")
+        if not ig_id:
+            continue
+        ig_cred = _upsert_credential(
+            db,
+            platform_id="instagram",
+            account_id=ig_id,
+            access_token=long_token,
+            username=page.get("name"),
+            extra={"page_id": page.get("id"), "page_name": page.get("name")},
+        )
+        break
+
+    # Threads: we don't have a Graph endpoint to enumerate accounts in v1.0,
+    # so we fall back to the configured THREADS_USER_ID.
+    if settings.threads_user_id:
+        threads_cred = _upsert_credential(
+            db,
+            platform_id="threads",
+            account_id=settings.threads_user_id,
+            access_token=long_token,
+        )
+
+    msg_parts = []
+    if ig_cred:
+        msg_parts.append(f"Instagram account {ig_cred.account_id} connected")
+    if threads_cred:
+        msg_parts.append(f"Threads account {threads_cred.account_id} connected")
+    if not msg_parts:
+        msg_parts.append(
+            "Token stored but no IG Business or Threads account was discovered."
+        )
+
+    return MetaOAuthCompleteOut(
+        instagram=PlatformCredentialOut.model_validate(ig_cred) if ig_cred else None,
+        threads=PlatformCredentialOut.model_validate(threads_cred) if threads_cred else None,
+        message=". ".join(msg_parts),
+    )
+
+
+@router.post("/credentials", response_model=PlatformCredentialOut)
+def add_credential(
+    payload: MetaManualCredentialIn,
+    db: Session = Depends(get_session),
+) -> PlatformCredentialOut:
+    """Paste-a-token escape hatch. CLI users who already obtained a long-lived
+    token from the Graph API Explorer can wire it in without going through
+    the OAuth redirect.
+    """
+    if payload.platform_id not in {"instagram", "threads"}:
+        raise HTTPException(
+            status_code=400,
+            detail="platform_id must be 'instagram' or 'threads' for this endpoint",
+        )
+    row = _upsert_credential(
+        db,
+        platform_id=payload.platform_id,
+        account_id=payload.account_id,
+        access_token=payload.access_token,
+        username=payload.username,
+    )
+    return PlatformCredentialOut.model_validate(row)

--- a/backend/app/api/plans.py
+++ b/backend/app/api/plans.py
@@ -1,0 +1,366 @@
+"""Content plans (M1).
+
+Endpoints:
+    POST   /api/plans                     — create empty plan
+    POST   /api/plans/generate            — create + populate via PlannerAgent
+    GET    /api/plans                     — list
+    GET    /api/plans/{id}                — detail with slots
+    PATCH  /api/plans/{id}                — rename/status
+    DELETE /api/plans/{id}
+    POST   /api/plans/{id}/chat           — conversational refinement
+    POST   /api/plans/{id}/slots          — manual slot add
+    PATCH  /api/plans/slots/{slot_id}     — edit (drag-n-drop uses this)
+    DELETE /api/plans/slots/{slot_id}
+    POST   /api/plans/slots/{slot_id}/generate-post
+                                          — spin the slot's post_type + topic_hint
+                                            through `generate_post`, link the Post.
+"""
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session, selectinload
+
+from app.agents.planner import (
+    PlanProposal,
+    RefinementResult,
+    SlotProposal,
+    propose_plan,
+    refine_plan,
+)
+from app.ai.content import generate_post
+from app.db import get_session
+from app.db.models import (
+    BusinessProfile,
+    ContentPlan,
+    PlanSlot,
+    PlanStatus,
+    Post,
+    PostStatus,
+    SlotStatus,
+)
+from app.schemas import (
+    ContentPlanOut,
+    ContentPlanPatch,
+    PlanChatRequest,
+    PlanChatResponse,
+    PlanGenerateRequest,
+    PlanSlotIn,
+    PlanSlotOut,
+    PlanSlotPatch,
+    SlotGeneratePostResponse,
+)
+
+log = logging.getLogger("api.plans")
+
+router = APIRouter(prefix="/api/plans", tags=["plans"])
+
+
+def _eager(db: Session, plan_id: int) -> ContentPlan | None:
+    return (
+        db.query(ContentPlan)
+        .options(selectinload(ContentPlan.slots))
+        .filter(ContentPlan.id == plan_id)
+        .first()
+    )
+
+
+def _require_profile(db: Session) -> BusinessProfile:
+    bp = db.query(BusinessProfile).order_by(BusinessProfile.id.asc()).first()
+    if bp is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Business profile must be set before planning.",
+        )
+    return bp
+
+
+def _apply_slot_proposals(
+    db: Session, plan: ContentPlan, slots: list[SlotProposal], replace: bool
+) -> None:
+    if replace:
+        for existing in list(plan.slots):
+            db.delete(existing)
+        db.flush()
+    for s in slots:
+        db.add(
+            PlanSlot(
+                plan_id=plan.id,
+                scheduled_for=s.scheduled_for,
+                post_type=s.post_type,
+                topic_hint=s.topic_hint,
+                rationale=s.rationale,
+                status=SlotStatus.PLANNED,
+            )
+        )
+
+
+@router.get("", response_model=list[ContentPlanOut])
+def list_plans(
+    status_filter: PlanStatus | None = None,
+    db: Session = Depends(get_session),
+) -> list[ContentPlan]:
+    q = db.query(ContentPlan).options(selectinload(ContentPlan.slots))
+    if status_filter is not None:
+        q = q.filter(ContentPlan.status == status_filter)
+    return q.order_by(ContentPlan.created_at.desc()).all()
+
+
+@router.get("/{plan_id}", response_model=ContentPlanOut)
+def get_plan(plan_id: int, db: Session = Depends(get_session)) -> ContentPlan:
+    plan = _eager(db, plan_id)
+    if plan is None:
+        raise HTTPException(status_code=404, detail="Plan not found")
+    return plan
+
+
+@router.post("", response_model=ContentPlanOut, status_code=status.HTTP_201_CREATED)
+def create_plan_empty(
+    payload: PlanGenerateRequest,
+    db: Session = Depends(get_session),
+) -> ContentPlan:
+    """Create an empty plan (no AI). Slots are added manually later."""
+    plan = ContentPlan(
+        name=payload.name,
+        goal=payload.goal,
+        start_date=payload.start_date,
+        end_date=payload.end_date,
+        status=PlanStatus.DRAFT,
+        generation_params={},
+        chat_history=[],
+    )
+    db.add(plan)
+    db.commit()
+    refreshed = _eager(db, plan.id)
+    assert refreshed is not None
+    return refreshed
+
+
+@router.post(
+    "/generate", response_model=ContentPlanOut, status_code=status.HTTP_201_CREATED
+)
+def generate_plan(
+    payload: PlanGenerateRequest,
+    db: Session = Depends(get_session),
+) -> ContentPlan:
+    """Kick the PlannerAgent and persist the resulting plan + slots."""
+    bp = _require_profile(db)
+    proposal: PlanProposal = propose_plan(
+        business_profile=bp,
+        start_date=payload.start_date,
+        end_date=payload.end_date,
+        goal=payload.goal,
+    )
+    plan = ContentPlan(
+        name=payload.name,
+        goal=payload.goal,
+        start_date=payload.start_date,
+        end_date=payload.end_date,
+        status=PlanStatus.DRAFT,
+        generation_params={
+            "posts_per_day": bp.posts_per_day,
+            "post_type_ratios": bp.post_type_ratios,
+            "posting_window": [
+                bp.posting_window_start_hour,
+                bp.posting_window_end_hour,
+            ],
+            "summary": proposal.summary,
+        },
+        chat_history=[
+            {"role": "assistant", "content": proposal.summary or "Plan drafted."}
+        ],
+        generation_cost_usd=proposal.cost_usd,
+    )
+    db.add(plan)
+    db.flush()
+    _apply_slot_proposals(db, plan, proposal.slots, replace=False)
+    db.commit()
+    refreshed = _eager(db, plan.id)
+    assert refreshed is not None
+    return refreshed
+
+
+@router.patch("/{plan_id}", response_model=ContentPlanOut)
+def patch_plan(
+    plan_id: int,
+    payload: ContentPlanPatch,
+    db: Session = Depends(get_session),
+) -> ContentPlan:
+    plan = db.get(ContentPlan, plan_id)
+    if plan is None:
+        raise HTTPException(status_code=404, detail="Plan not found")
+    for key, value in payload.model_dump(exclude_unset=True).items():
+        setattr(plan, key, value)
+    db.commit()
+    refreshed = _eager(db, plan.id)
+    assert refreshed is not None
+    return refreshed
+
+
+@router.delete("/{plan_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_plan(plan_id: int, db: Session = Depends(get_session)) -> None:
+    plan = db.get(ContentPlan, plan_id)
+    if plan is None:
+        raise HTTPException(status_code=404, detail="Plan not found")
+    db.delete(plan)
+    db.commit()
+
+
+@router.post("/{plan_id}/chat", response_model=PlanChatResponse)
+def chat_refine(
+    plan_id: int,
+    payload: PlanChatRequest,
+    db: Session = Depends(get_session),
+) -> PlanChatResponse:
+    """User chats with Planner. Agent may update the slot list or just reply."""
+    plan = _eager(db, plan_id)
+    if plan is None:
+        raise HTTPException(status_code=404, detail="Plan not found")
+    bp = _require_profile(db)
+
+    current_slots_dump = [
+        {
+            "scheduled_for": s.scheduled_for.isoformat(),
+            "post_type": s.post_type.value,
+            "topic_hint": s.topic_hint,
+            "rationale": s.rationale,
+        }
+        for s in plan.slots
+    ]
+
+    result: RefinementResult = refine_plan(
+        business_profile=bp,
+        start_date=plan.start_date,
+        end_date=plan.end_date,
+        current_slots=current_slots_dump,
+        chat_history=list(plan.chat_history or []),
+        user_message=payload.message,
+    )
+
+    history = list(plan.chat_history or [])
+    history.append({"role": "user", "content": payload.message})
+    history.append({"role": "assistant", "content": result.reply})
+    plan.chat_history = history
+    plan.generation_cost_usd = (plan.generation_cost_usd or 0) + result.cost_usd
+
+    if result.slots:
+        _apply_slot_proposals(db, plan, result.slots, replace=True)
+
+    db.commit()
+    refreshed = _eager(db, plan.id)
+    assert refreshed is not None
+    return PlanChatResponse(
+        reply=result.reply,
+        updated=bool(result.slots),
+        plan=ContentPlanOut.model_validate(refreshed),
+    )
+
+
+@router.post(
+    "/{plan_id}/slots",
+    response_model=PlanSlotOut,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_slot(
+    plan_id: int,
+    payload: PlanSlotIn,
+    db: Session = Depends(get_session),
+) -> PlanSlot:
+    plan = db.get(ContentPlan, plan_id)
+    if plan is None:
+        raise HTTPException(status_code=404, detail="Plan not found")
+    slot = PlanSlot(
+        plan_id=plan.id,
+        scheduled_for=payload.scheduled_for,
+        post_type=payload.post_type,
+        topic_hint=payload.topic_hint,
+        rationale=payload.rationale,
+        notes=payload.notes,
+        status=SlotStatus.PLANNED,
+    )
+    db.add(slot)
+    db.commit()
+    db.refresh(slot)
+    return slot
+
+
+@router.patch("/slots/{slot_id}", response_model=PlanSlotOut)
+def patch_slot(
+    slot_id: int,
+    payload: PlanSlotPatch,
+    db: Session = Depends(get_session),
+) -> PlanSlot:
+    slot = db.get(PlanSlot, slot_id)
+    if slot is None:
+        raise HTTPException(status_code=404, detail="Slot not found")
+    for key, value in payload.model_dump(exclude_unset=True).items():
+        setattr(slot, key, value)
+    db.commit()
+    db.refresh(slot)
+    return slot
+
+
+@router.delete("/slots/{slot_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_slot(slot_id: int, db: Session = Depends(get_session)) -> None:
+    slot = db.get(PlanSlot, slot_id)
+    if slot is None:
+        raise HTTPException(status_code=404, detail="Slot not found")
+    db.delete(slot)
+    db.commit()
+
+
+@router.post(
+    "/slots/{slot_id}/generate-post", response_model=SlotGeneratePostResponse
+)
+def generate_post_from_slot(
+    slot_id: int,
+    db: Session = Depends(get_session),
+) -> SlotGeneratePostResponse:
+    """Generate the post text for a slot and link it."""
+    slot = db.get(PlanSlot, slot_id)
+    if slot is None:
+        raise HTTPException(status_code=404, detail="Slot not found")
+    if slot.post_id is not None:
+        existing_post = db.get(Post, slot.post_id)
+        if existing_post is not None:
+            raise HTTPException(
+                status_code=409,
+                detail="Slot already has a linked post. Delete it first to regenerate.",
+            )
+
+    bp = _require_profile(db)
+    generated = generate_post(
+        db=db,
+        post_type=slot.post_type,
+        business_profile=bp,
+        topic_hint=slot.topic_hint,
+        use_few_shot=True,
+    )
+    post = Post(
+        post_type=slot.post_type,
+        status=PostStatus.DRAFT,
+        text=generated.text,
+        generation_prompt=generated.user_prompt,
+        generation_model=generated.model,
+        generation_cost_usd=generated.cost_usd,
+        scheduled_for=slot.scheduled_for,
+    )
+    db.add(post)
+    db.flush()
+    slot.post_id = post.id
+    slot.status = SlotStatus.GENERATED
+    db.commit()
+    db.refresh(slot)
+    db.refresh(post)
+    return SlotGeneratePostResponse(
+        slot=PlanSlotOut.model_validate(slot),
+        post=_post_out(post),
+    )
+
+
+def _post_out(post: Post):
+    """Late-imported PostOut to avoid circular import at module load."""
+    from app.schemas import PostOut
+
+    return PostOut.model_validate(post)

--- a/backend/app/api/platform_credentials.py
+++ b/backend/app/api/platform_credentials.py
@@ -1,0 +1,34 @@
+"""Platform credentials CRUD (list + delete).
+
+The actual write-path is OAuth (`/api/meta/oauth/*`) or the manual paste
+endpoint (`/api/meta/credentials`). This module just provides read / delete
+for the dashboard Platforms page.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.db import get_session
+from app.db.models import PlatformCredential
+from app.schemas import PlatformCredentialOut
+
+router = APIRouter(prefix="/api/platform-credentials", tags=["platforms"])
+
+
+@router.get("", response_model=list[PlatformCredentialOut])
+def list_credentials(db: Session = Depends(get_session)) -> list[PlatformCredential]:
+    return (
+        db.query(PlatformCredential)
+        .order_by(PlatformCredential.updated_at.desc())
+        .all()
+    )
+
+
+@router.delete("/{credential_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_credential(credential_id: int, db: Session = Depends(get_session)) -> None:
+    row = db.get(PlatformCredential, credential_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Credential not found")
+    db.delete(row)
+    db.commit()

--- a/backend/app/api/posts.py
+++ b/backend/app/api/posts.py
@@ -25,10 +25,14 @@ from app.db.models import (
 )
 from app.platforms.facebook import FacebookPlatform
 from app.schemas import (
+    PostApproveAllRequest,
+    PostApproveRequest,
     PostGenerate,
     PostIn,
     PostOut,
     PostPatch,
+    PostRegenerateRequest,
+    PostRejectRequest,
     PublishRequest,
     PublishResultOut,
 )
@@ -136,9 +140,18 @@ def generate(
         image_prompt = img.prompt
         total_cost += img.cost_usd
 
+    # M5: route to PENDING_REVIEW if the profile asks for it and this post_type
+    # isn't on the auto-approve allow-list.
+    auto_approved = payload.post_type.value in (profile.auto_approve_types or [])
+    initial_status = (
+        PostStatus.PENDING_REVIEW
+        if profile.review_before_posting and not auto_approved
+        else PostStatus.DRAFT
+    )
+
     post = Post(
         post_type=payload.post_type,
-        status=PostStatus.DRAFT,
+        status=initial_status,
         text=generated.text,
         image_url=image_url,
         image_prompt=image_prompt,
@@ -331,3 +344,168 @@ def schedule(
     return refreshed
 
 
+# ---------- Review & Approval (M5) ----------
+
+
+@router.get("/review/pending", response_model=list[PostOut])
+def list_pending_review(
+    limit: int = 100,
+    db: Session = Depends(get_session),
+) -> list[Post]:
+    """Shorthand for `GET /api/posts?status_filter=pending_review` — what the
+    Queue page uses to build the review tab.
+    """
+    return (
+        db.query(Post)
+        .options(selectinload(Post.variants))
+        .filter(Post.status == PostStatus.PENDING_REVIEW)
+        .order_by(Post.created_at.desc())
+        .limit(limit)
+        .all()
+    )
+
+
+def _approve_single(
+    db: Session,
+    post: Post,
+    target_ids: list[int],
+    scheduled_for: datetime | None,
+    profile: BusinessProfile | None,
+) -> Post:
+    """Shared approve implementation (single + bulk). Mutates and commits."""
+    if post.status != PostStatus.PENDING_REVIEW:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Post {post.id} is in status {post.status.value}, not pending_review.",
+        )
+    if scheduled_for is not None:
+        from app.services import humanizer as hz
+
+        humanizer_profile = hz.get_or_create_profile(db)
+        post.scheduled_for = hz.apply_schedule_jitter(scheduled_for, humanizer_profile)
+        if target_ids:
+            _ensure_variants(
+                db,
+                post,
+                target_ids=target_ids,
+                profile=profile,
+                generate_spintax=True,
+            )
+        post.status = PostStatus.SCHEDULED
+    else:
+        post.status = PostStatus.DRAFT
+    db.commit()
+    return post
+
+
+@router.post("/{post_id}/approve", response_model=PostOut)
+def approve_post(
+    post_id: int,
+    payload: PostApproveRequest,
+    db: Session = Depends(get_session),
+) -> Post:
+    post = _eager_load(db, post_id)
+    if post is None:
+        raise HTTPException(status_code=404, detail="Post not found")
+    profile = db.query(BusinessProfile).order_by(BusinessProfile.id.asc()).first()
+    _approve_single(db, post, payload.target_ids, payload.scheduled_for, profile)
+    refreshed = _eager_load(db, post.id)
+    assert refreshed is not None
+    return refreshed
+
+
+@router.post("/{post_id}/reject", response_model=PostOut)
+def reject_post(
+    post_id: int,
+    payload: PostRejectRequest,
+    db: Session = Depends(get_session),
+) -> Post:
+    post = _eager_load(db, post_id)
+    if post is None:
+        raise HTTPException(status_code=404, detail="Post not found")
+    if post.status not in (PostStatus.PENDING_REVIEW, PostStatus.DRAFT):
+        raise HTTPException(
+            status_code=409,
+            detail=f"Cannot reject a post in status {post.status.value}.",
+        )
+    post.status = PostStatus.SKIPPED
+    if payload.reason:
+        # Stash reason inline — we don't have a dedicated column and don't need
+        # one for v1. generation_prompt is an admin/debug field anyway.
+        existing = post.generation_prompt or ""
+        post.generation_prompt = (existing + f"\n[REJECTED] {payload.reason}").strip()
+    db.commit()
+    refreshed = _eager_load(db, post.id)
+    assert refreshed is not None
+    return refreshed
+
+
+@router.post("/{post_id}/regenerate", response_model=PostOut)
+def regenerate_post(
+    post_id: int,
+    payload: PostRegenerateRequest,
+    db: Session = Depends(get_session),
+) -> Post:
+    post = _eager_load(db, post_id)
+    if post is None:
+        raise HTTPException(status_code=404, detail="Post not found")
+    if post.status not in (PostStatus.PENDING_REVIEW, PostStatus.DRAFT):
+        raise HTTPException(
+            status_code=409,
+            detail="Only PENDING_REVIEW / DRAFT posts can be regenerated.",
+        )
+    profile = db.query(BusinessProfile).order_by(BusinessProfile.id.asc()).first()
+    if profile is None:
+        raise HTTPException(status_code=400, detail="Business profile required.")
+
+    generated = generate_post(
+        db=db,
+        post_type=post.post_type,
+        business_profile=profile,
+        topic_hint=payload.topic_hint,
+        use_few_shot=True,
+    )
+    post.text = generated.text
+    post.generation_prompt = generated.user_prompt
+    post.generation_model = generated.model
+    # Bump cost — regenerating isn't free.
+    post.generation_cost_usd = (post.generation_cost_usd or 0.0) + generated.cost_usd
+    if payload.generate_image:
+        img = generate_image(
+            post_text=generated.text,
+            business_desc=profile.description,
+            tone=profile.tone.value,
+        )
+        post.image_url = f"/static/{img.local_path}"
+        post.image_prompt = img.prompt
+        post.generation_cost_usd += img.cost_usd
+    db.commit()
+    refreshed = _eager_load(db, post.id)
+    assert refreshed is not None
+    return refreshed
+
+
+@router.post("/review/approve-all", response_model=list[PostOut])
+def approve_all(
+    payload: PostApproveAllRequest,
+    db: Session = Depends(get_session),
+) -> list[Post]:
+    q = db.query(Post).filter(Post.status == PostStatus.PENDING_REVIEW)
+    if payload.post_type is not None:
+        q = q.filter(Post.post_type == payload.post_type)
+    pending = q.all()
+    profile = db.query(BusinessProfile).order_by(BusinessProfile.id.asc()).first()
+    approved: list[Post] = []
+    for post in pending:
+        _approve_single(db, post, [], payload.scheduled_for, profile)
+        approved.append(post)
+    # Eager-reload all for response.
+    ids = [p.id for p in approved]
+    if not ids:
+        return []
+    return (
+        db.query(Post)
+        .options(selectinload(Post.variants))
+        .filter(Post.id.in_(ids))
+        .all()
+    )

--- a/backend/app/api/posts.py
+++ b/backend/app/api/posts.py
@@ -1,0 +1,329 @@
+"""Post CRUD + generate + publish + schedule.
+
+Core user-visible actions:
+- POST /api/posts/generate — run Claude + (optionally) Gemini, return a draft.
+- POST /api/posts/{id}/publish — publish now to the given target_ids.
+- POST /api/posts/{id}/schedule — set scheduled_for; scheduler picks it up.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session, selectinload
+
+from app.ai.content import generate_post, generate_spintax_variant
+from app.ai.image import generate_image
+from app.db import get_session
+from app.db.models import (
+    BusinessProfile,
+    Post,
+    PostStatus,
+    PostVariant,
+    Target,
+)
+from app.platforms.facebook import FacebookPlatform
+from app.schemas import (
+    PostGenerate,
+    PostIn,
+    PostOut,
+    PostPatch,
+    PublishRequest,
+    PublishResultOut,
+)
+
+log = logging.getLogger("api.posts")
+
+router = APIRouter(prefix="/api/posts", tags=["posts"])
+
+
+def _eager_load(db: Session, post_id: int) -> Post | None:
+    return (
+        db.query(Post)
+        .options(selectinload(Post.variants))
+        .filter(Post.id == post_id)
+        .first()
+    )
+
+
+@router.get("", response_model=list[PostOut])
+def list_posts(
+    status_filter: PostStatus | None = None,
+    limit: int = 100,
+    db: Session = Depends(get_session),
+) -> list[Post]:
+    q = db.query(Post).options(selectinload(Post.variants))
+    if status_filter is not None:
+        q = q.filter(Post.status == status_filter)
+    return q.order_by(Post.created_at.desc()).limit(limit).all()
+
+
+@router.get("/{post_id}", response_model=PostOut)
+def get_post(post_id: int, db: Session = Depends(get_session)) -> Post:
+    post = _eager_load(db, post_id)
+    if post is None:
+        raise HTTPException(status_code=404, detail="Post not found")
+    return post
+
+
+@router.post("", response_model=PostOut, status_code=status.HTTP_201_CREATED)
+def create_post(payload: PostIn, db: Session = Depends(get_session)) -> Post:
+    post = Post(**payload.model_dump(), status=PostStatus.DRAFT)
+    db.add(post)
+    db.commit()
+    post = _eager_load(db, post.id)
+    assert post is not None
+    return post
+
+
+@router.patch("/{post_id}", response_model=PostOut)
+def patch_post(
+    post_id: int,
+    payload: PostPatch,
+    db: Session = Depends(get_session),
+) -> Post:
+    post = db.get(Post, post_id)
+    if post is None:
+        raise HTTPException(status_code=404, detail="Post not found")
+    for key, value in payload.model_dump(exclude_unset=True).items():
+        setattr(post, key, value)
+    db.commit()
+    refreshed = _eager_load(db, post.id)
+    assert refreshed is not None
+    return refreshed
+
+
+@router.delete("/{post_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_post(post_id: int, db: Session = Depends(get_session)) -> None:
+    post = db.get(Post, post_id)
+    if post is None:
+        raise HTTPException(status_code=404, detail="Post not found")
+    db.delete(post)
+    db.commit()
+
+
+@router.post("/generate", response_model=PostOut, status_code=status.HTTP_201_CREATED)
+def generate(
+    payload: PostGenerate,
+    db: Session = Depends(get_session),
+) -> Post:
+    profile = db.query(BusinessProfile).order_by(BusinessProfile.id.asc()).first()
+    if profile is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Business profile must be set before generating posts.",
+        )
+
+    generated = generate_post(
+        db=db,
+        post_type=payload.post_type,
+        business_profile=profile,
+        topic_hint=payload.topic_hint,
+        use_few_shot=payload.use_few_shot,
+    )
+
+    image_url: str | None = None
+    image_prompt: str | None = None
+    total_cost = generated.cost_usd
+    if payload.generate_image:
+        img = generate_image(
+            post_text=generated.text,
+            business_desc=profile.description,
+            tone=profile.tone.value,
+        )
+        image_url = f"/static/{img.local_path}"
+        image_prompt = img.prompt
+        total_cost += img.cost_usd
+
+    post = Post(
+        post_type=payload.post_type,
+        status=PostStatus.DRAFT,
+        text=generated.text,
+        image_url=image_url,
+        image_prompt=image_prompt,
+        generation_prompt=generated.user_prompt,
+        generation_model=generated.model,
+        generation_cost_usd=total_cost,
+    )
+    db.add(post)
+    db.commit()
+    refreshed = _eager_load(db, post.id)
+    assert refreshed is not None
+    return refreshed
+
+
+def _ensure_variants(
+    db: Session,
+    post: Post,
+    target_ids: list[int],
+    profile: BusinessProfile | None,
+    generate_spintax: bool,
+) -> list[PostVariant]:
+    """Create PostVariant rows for each target if they don't exist yet.
+
+    First target uses the main post text as-is. Others get a spintaxed rewrite IF
+    `generate_spintax` is true AND we have a business profile AND an ANTHROPIC key.
+    On spintax failure we fall back to the original text (logged).
+    """
+    existing = {v.target_id: v for v in post.variants}
+    targets: list[Target] = [t for t in (db.get(Target, tid) for tid in target_ids) if t is not None]
+    if not targets:
+        raise HTTPException(status_code=400, detail="No valid targets provided.")
+
+    out: list[PostVariant] = []
+    for idx, target in enumerate(targets):
+        if target.id in existing:
+            out.append(existing[target.id])
+            continue
+        if idx == 0 or not generate_spintax or profile is None:
+            text = post.text
+        else:
+            try:
+                text = generate_spintax_variant(post.text, profile)
+            except Exception as exc:
+                log.warning("Spintax failed for target %s: %s — using original", target.id, exc)
+                text = post.text
+        variant = PostVariant(
+            post_id=post.id,
+            target_id=target.id,
+            text=text,
+            status=PostStatus.SCHEDULED,
+            scheduled_for=post.scheduled_for,
+        )
+        db.add(variant)
+        out.append(variant)
+    db.commit()
+    return out
+
+
+async def _publish_variant(post: Post, variant: PostVariant, target: Target) -> None:
+    """Dispatch one variant through the Facebook platform. Mutates `variant`."""
+    platform = FacebookPlatform()
+    variant.status = PostStatus.POSTING
+    try:
+        synthetic_post = Post(
+            id=post.id,
+            post_type=post.post_type,
+            status=PostStatus.POSTING,
+            text=variant.text,
+            image_url=post.image_url,
+            first_comment=post.first_comment,
+            cta_url=post.cta_url,
+        )
+        result = await platform.publish(synthetic_post, target)
+    except Exception as exc:
+        variant.status = PostStatus.FAILED
+        variant.error = f"Exception: {exc}"
+        return
+
+    if result.ok:
+        variant.status = PostStatus.POSTED
+        variant.external_post_id = result.external_post_id
+        variant.posted_at = datetime.now(UTC)
+        variant.error = None
+    else:
+        variant.status = PostStatus.FAILED
+        variant.error = result.error
+
+
+@router.post("/{post_id}/publish", response_model=PublishResultOut)
+async def publish_now(
+    post_id: int,
+    payload: PublishRequest,
+    db: Session = Depends(get_session),
+) -> PublishResultOut:
+    post = _eager_load(db, post_id)
+    if post is None:
+        raise HTTPException(status_code=404, detail="Post not found")
+
+    target_ids = payload.target_ids
+    if not target_ids:
+        active = db.query(Target).filter(Target.active.is_(True)).all()
+        target_ids = [t.id for t in active]
+        if not target_ids:
+            raise HTTPException(status_code=400, detail="No active targets. Add some first.")
+
+    profile = db.query(BusinessProfile).order_by(BusinessProfile.id.asc()).first()
+
+    variants = _ensure_variants(
+        db,
+        post,
+        target_ids=target_ids,
+        profile=profile,
+        generate_spintax=payload.generate_spintax,
+    )
+
+    post.status = PostStatus.POSTING
+    db.commit()
+
+    for variant in variants:
+        target = db.get(Target, variant.target_id)
+        if target is None:
+            variant.status = PostStatus.FAILED
+            variant.error = "Target row vanished between enqueue and publish."
+            continue
+        await _publish_variant(post, variant, target)
+        db.commit()
+
+    any_ok = any(v.status == PostStatus.POSTED for v in variants)
+    all_ok = all(v.status == PostStatus.POSTED for v in variants)
+    if all_ok:
+        post.status = PostStatus.POSTED
+        post.posted_at = datetime.now(UTC)
+    elif any_ok:
+        post.status = PostStatus.POSTED
+        post.posted_at = datetime.now(UTC)
+    else:
+        post.status = PostStatus.FAILED
+    db.commit()
+
+    refreshed = _eager_load(db, post.id)
+    assert refreshed is not None
+    return PublishResultOut(
+        post_id=refreshed.id,
+        status=refreshed.status,
+        variants=refreshed.variants,  # type: ignore[arg-type]
+    )
+
+
+@router.post("/{post_id}/schedule", response_model=PostOut)
+def schedule(
+    post_id: int,
+    payload: PublishRequest,
+    db: Session = Depends(get_session),
+) -> Post:
+    if payload.scheduled_for is None:
+        raise HTTPException(
+            status_code=400,
+            detail="scheduled_for is required for /schedule. Use /publish for immediate.",
+        )
+
+    post = _eager_load(db, post_id)
+    if post is None:
+        raise HTTPException(status_code=404, detail="Post not found")
+
+    target_ids = payload.target_ids
+    if not target_ids:
+        active = db.query(Target).filter(Target.active.is_(True)).all()
+        target_ids = [t.id for t in active]
+        if not target_ids:
+            raise HTTPException(status_code=400, detail="No active targets. Add some first.")
+
+    post.scheduled_for = payload.scheduled_for
+    profile = db.query(BusinessProfile).order_by(BusinessProfile.id.asc()).first()
+    _ensure_variants(
+        db,
+        post,
+        target_ids=target_ids,
+        profile=profile,
+        generate_spintax=payload.generate_spintax,
+    )
+    post.status = PostStatus.SCHEDULED
+    db.commit()
+
+    refreshed = _eager_load(db, post.id)
+    assert refreshed is not None
+    return refreshed
+
+

--- a/backend/app/api/posts.py
+++ b/backend/app/api/posts.py
@@ -23,7 +23,7 @@ from app.db.models import (
     PostVariant,
     Target,
 )
-from app.platforms.facebook import FacebookPlatform
+from app.platforms.registry import get_platform
 from app.schemas import (
     PostApproveAllRequest,
     PostApproveRequest,
@@ -210,16 +210,22 @@ def _ensure_variants(
     return out
 
 
-async def _publish_variant(post: Post, variant: PostVariant, target: Target) -> None:
-    """Dispatch one variant through the Facebook platform. Mutates `variant`."""
-    platform = FacebookPlatform()
+async def _publish_variant(
+    post: Post, variant: PostVariant, target: Target, db: Session
+) -> None:
+    """Dispatch one variant through the right platform. Mutates `variant`."""
+    platform = get_platform(target.platform_id, db=db)
+    if platform is None:
+        variant.status = PostStatus.FAILED
+        variant.error = f"Unknown platform_id: {target.platform_id}"
+        return
     variant.status = PostStatus.POSTING
     try:
         synthetic_post = Post(
             id=post.id,
             post_type=post.post_type,
             status=PostStatus.POSTING,
-            text=variant.text,
+            text=platform.adapt_content(variant.text),
             image_url=post.image_url,
             first_comment=post.first_comment,
             cta_url=post.cta_url,
@@ -276,7 +282,7 @@ async def publish_now(
             variant.status = PostStatus.FAILED
             variant.error = "Target row vanished between enqueue and publish."
             continue
-        await _publish_variant(post, variant, target)
+        await _publish_variant(post, variant, target, db)
         db.commit()
 
     any_ok = any(v.status == PostStatus.POSTED for v in variants)

--- a/backend/app/api/posts.py
+++ b/backend/app/api/posts.py
@@ -310,7 +310,11 @@ def schedule(
         if not target_ids:
             raise HTTPException(status_code=400, detail="No active targets. Add some first.")
 
-    post.scheduled_for = payload.scheduled_for
+    # Apply humanizer jitter so scheduled times don't look metronomic.
+    from app.services import humanizer as hz
+
+    humanizer_profile = hz.get_or_create_profile(db)
+    post.scheduled_for = hz.apply_schedule_jitter(payload.scheduled_for, humanizer_profile)
     profile = db.query(BusinessProfile).order_by(BusinessProfile.id.asc()).first()
     _ensure_variants(
         db,

--- a/backend/app/api/targets.py
+++ b/backend/app/api/targets.py
@@ -1,0 +1,126 @@
+"""Target CRUD + sync-from-extension.
+
+A Target is a place we post to (FB group URL, Page id, subreddit, LinkedIn url, ...).
+`POST /api/targets/sync` asks the Chrome extension to enumerate joined FB groups and
+upserts them by (platform_id, external_id).
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.db import get_session
+from app.db.models import Target
+from app.platforms.facebook import FacebookPlatform
+from app.schemas import TargetIn, TargetOut, TargetPatch
+
+router = APIRouter(prefix="/api/targets", tags=["targets"])
+
+
+@router.get("", response_model=list[TargetOut])
+def list_targets(
+    platform_id: str | None = None,
+    active_only: bool = False,
+    db: Session = Depends(get_session),
+) -> list[Target]:
+    q = db.query(Target)
+    if platform_id:
+        q = q.filter(Target.platform_id == platform_id)
+    if active_only:
+        q = q.filter(Target.active.is_(True))
+    return q.order_by(Target.created_at.desc()).all()
+
+
+@router.post("", response_model=TargetOut, status_code=status.HTTP_201_CREATED)
+def create_target(payload: TargetIn, db: Session = Depends(get_session)) -> Target:
+    existing = (
+        db.query(Target)
+        .filter(Target.platform_id == payload.platform_id)
+        .filter(Target.external_id == payload.external_id)
+        .first()
+    )
+    if existing is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Target already exists with id={existing.id}",
+        )
+    target = Target(**payload.model_dump())
+    db.add(target)
+    db.commit()
+    db.refresh(target)
+    return target
+
+
+@router.get("/{target_id}", response_model=TargetOut)
+def get_target(target_id: int, db: Session = Depends(get_session)) -> Target:
+    target = db.get(Target, target_id)
+    if target is None:
+        raise HTTPException(status_code=404, detail="Target not found")
+    return target
+
+
+@router.patch("/{target_id}", response_model=TargetOut)
+def patch_target(
+    target_id: int,
+    payload: TargetPatch,
+    db: Session = Depends(get_session),
+) -> Target:
+    target = db.get(Target, target_id)
+    if target is None:
+        raise HTTPException(status_code=404, detail="Target not found")
+    for key, value in payload.model_dump(exclude_unset=True).items():
+        setattr(target, key, value)
+    db.commit()
+    db.refresh(target)
+    return target
+
+
+@router.delete("/{target_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_target(target_id: int, db: Session = Depends(get_session)) -> None:
+    target = db.get(Target, target_id)
+    if target is None:
+        raise HTTPException(status_code=404, detail="Target not found")
+    db.delete(target)
+    db.commit()
+
+
+@router.post("/sync", response_model=list[TargetOut])
+async def sync_targets_from_extension(db: Session = Depends(get_session)) -> list[Target]:
+    """Ask the connected Chrome extension to list joined FB groups, upsert them."""
+    platform = FacebookPlatform()
+    try:
+        discovered = await platform.list_targets()
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(exc),
+        ) from exc
+
+    result: list[Target] = []
+    for item in discovered:
+        existing = (
+            db.query(Target)
+            .filter(Target.platform_id == "facebook")
+            .filter(Target.external_id == item["external_id"])
+            .first()
+        )
+        if existing is None:
+            target = Target(
+                platform_id="facebook",
+                external_id=item["external_id"],
+                name=item["name"],
+                member_count=item.get("member_count"),
+                active=True,
+            )
+            db.add(target)
+            result.append(target)
+        else:
+            existing.name = item["name"]
+            if item.get("member_count") is not None:
+                existing.member_count = item["member_count"]
+            result.append(existing)
+
+    db.commit()
+    for t in result:
+        db.refresh(t)
+    return result

--- a/backend/app/api/targets.py
+++ b/backend/app/api/targets.py
@@ -1,26 +1,65 @@
-"""Target CRUD + sync-from-extension.
+"""Target CRUD, discovery, AI scoring + clustering (M3).
 
-A Target is a place we post to (FB group URL, Page id, subreddit, LinkedIn url, ...).
-`POST /api/targets/sync` asks the Chrome extension to enumerate joined FB groups and
-upserts them by (platform_id, external_id).
+Endpoints:
+- CRUD: list/create/get/patch/delete
+- POST /sync: enumerate joined FB groups via extension, upsert as source="scraped_joined"
+- POST /discover: enumerate suggested FB groups via extension, upsert as
+  source="scraped_suggested"
+- POST /score: run TargetAgent over a batch (default: all unscored pending)
+- POST /cluster: run TargetAgent clustering over approved targets, writes list_name
+- POST /bulk-review: set review_status on many ids at once
 """
 from __future__ import annotations
+
+import logging
+import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
+from app.agents.targets import cluster_targets, score_targets
 from app.db import get_session
-from app.db.models import Target
+from app.db.models import BusinessProfile, Target, TargetReviewStatus
 from app.platforms.facebook import FacebookPlatform
-from app.schemas import TargetIn, TargetOut, TargetPatch
+from app.schemas import (
+    TargetBulkReviewRequest,
+    TargetClusterGroup,
+    TargetClusterRequest,
+    TargetClusterResponse,
+    TargetDiscoverResult,
+    TargetIn,
+    TargetOut,
+    TargetPatch,
+    TargetScoreItem,
+    TargetScoreRequest,
+    TargetScoreResponse,
+)
+from app.ws.extension_bridge import bridge
+
+log = logging.getLogger("api.targets")
 
 router = APIRouter(prefix="/api/targets", tags=["targets"])
+
+
+def _require_profile(db: Session) -> BusinessProfile:
+    profile = db.query(BusinessProfile).first()
+    if profile is None:
+        raise HTTPException(
+            status_code=400,
+            detail="BusinessProfile is required — set it first via PUT /api/business-profile",
+        )
+    return profile
+
+
+# ---------- CRUD ----------
 
 
 @router.get("", response_model=list[TargetOut])
 def list_targets(
     platform_id: str | None = None,
     active_only: bool = False,
+    review_status: TargetReviewStatus | None = None,
+    list_name: str | None = None,
     db: Session = Depends(get_session),
 ) -> list[Target]:
     q = db.query(Target)
@@ -28,7 +67,11 @@ def list_targets(
         q = q.filter(Target.platform_id == platform_id)
     if active_only:
         q = q.filter(Target.active.is_(True))
-    return q.order_by(Target.created_at.desc()).all()
+    if review_status is not None:
+        q = q.filter(Target.review_status == review_status)
+    if list_name is not None:
+        q = q.filter(Target.list_name == list_name)
+    return q.order_by(Target.relevance_score.desc().nullslast(), Target.created_at.desc()).all()
 
 
 @router.post("", response_model=TargetOut, status_code=status.HTTP_201_CREATED)
@@ -45,6 +88,9 @@ def create_target(payload: TargetIn, db: Session = Depends(get_session)) -> Targ
             detail=f"Target already exists with id={existing.id}",
         )
     target = Target(**payload.model_dump())
+    # Manually-added targets are approved by default.
+    if payload.source == "manual":
+        target.review_status = TargetReviewStatus.APPROVED
     db.add(target)
     db.commit()
     db.refresh(target)
@@ -84,43 +130,186 @@ def delete_target(target_id: int, db: Session = Depends(get_session)) -> None:
     db.commit()
 
 
-@router.post("/sync", response_model=list[TargetOut])
-async def sync_targets_from_extension(db: Session = Depends(get_session)) -> list[Target]:
-    """Ask the connected Chrome extension to list joined FB groups, upsert them."""
-    platform = FacebookPlatform()
-    try:
-        discovered = await platform.list_targets()
-    except RuntimeError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail=str(exc),
-        ) from exc
+# ---------- Discovery via extension ----------
 
-    result: list[Target] = []
+
+def _upsert_fb_targets(
+    db: Session, discovered: list[dict], source: str
+) -> tuple[list[Target], int, int]:
+    """Upsert a batch of scraped FB groups. Returns (rows, created, updated)."""
+    created = 0
+    updated = 0
+    rows: list[Target] = []
     for item in discovered:
+        external_id = item.get("external_id") or item.get("url")
+        if not external_id:
+            continue
         existing = (
             db.query(Target)
             .filter(Target.platform_id == "facebook")
-            .filter(Target.external_id == item["external_id"])
+            .filter(Target.external_id == external_id)
             .first()
         )
         if existing is None:
             target = Target(
                 platform_id="facebook",
-                external_id=item["external_id"],
-                name=item["name"],
+                external_id=external_id,
+                name=item.get("name", external_id),
                 member_count=item.get("member_count"),
+                description_snippet=item.get("description"),
+                category=item.get("category"),
                 active=True,
+                source=source,
+                review_status=(
+                    TargetReviewStatus.APPROVED
+                    if source == "scraped_joined"
+                    else TargetReviewStatus.PENDING
+                ),
             )
             db.add(target)
-            result.append(target)
+            rows.append(target)
+            created += 1
         else:
-            existing.name = item["name"]
+            if item.get("name"):
+                existing.name = item["name"]
             if item.get("member_count") is not None:
                 existing.member_count = item["member_count"]
-            result.append(existing)
+            if item.get("description"):
+                existing.description_snippet = item["description"]
+            if item.get("category"):
+                existing.category = item["category"]
+            rows.append(existing)
+            updated += 1
+    return rows, created, updated
 
+
+@router.post("/sync", response_model=list[TargetOut])
+async def sync_targets_from_extension(db: Session = Depends(get_session)) -> list[Target]:
+    """List joined FB groups via extension, upsert with source=scraped_joined."""
+    platform = FacebookPlatform()
+    try:
+        discovered = await platform.list_targets()
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)
+        ) from exc
+    rows, _, _ = _upsert_fb_targets(db, discovered, source="scraped_joined")
     db.commit()
-    for t in result:
+    for t in rows:
         db.refresh(t)
-    return result
+    return rows
+
+
+@router.post("/discover", response_model=TargetDiscoverResult)
+async def discover_suggested_groups(db: Session = Depends(get_session)) -> TargetDiscoverResult:
+    """Ask extension to scrape SUGGESTED groups (discovery feed). Inserts as pending."""
+    request_id = uuid.uuid4().hex
+    try:
+        response = await bridge.request(
+            {"type": "list_suggested_groups", "request_id": request_id}, timeout=60
+        )
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)
+        ) from exc
+    except TimeoutError as exc:
+        raise HTTPException(status_code=504, detail="Extension timed out") from exc
+    if not response.get("ok", True):
+        raise HTTPException(
+            status_code=502, detail=response.get("error", "Extension returned error")
+        )
+    discovered = response.get("groups", [])
+    rows, created, updated = _upsert_fb_targets(db, discovered, source="scraped_suggested")
+    db.commit()
+    for t in rows:
+        db.refresh(t)
+    return TargetDiscoverResult(created=created, updated=updated, targets=rows)
+
+
+# ---------- AI: score + cluster ----------
+
+
+@router.post("/score", response_model=TargetScoreResponse)
+def score_pending_targets(
+    payload: TargetScoreRequest, db: Session = Depends(get_session)
+) -> TargetScoreResponse:
+    profile = _require_profile(db)
+    q = db.query(Target)
+    if payload.target_ids:
+        q = q.filter(Target.id.in_(payload.target_ids))
+    else:
+        # Default: all pending targets that haven't been scored yet.
+        q = q.filter(Target.review_status == TargetReviewStatus.PENDING)
+        q = q.filter(Target.relevance_score.is_(None))
+    targets = q.all()
+    if not targets:
+        return TargetScoreResponse(scored=[], cost_usd=0.0)
+
+    try:
+        result = score_targets(profile, targets)
+    except Exception as exc:
+        log.exception("TargetAgent.score_targets failed")
+        raise HTTPException(status_code=502, detail=f"TargetAgent failed: {exc}") from exc
+
+    by_id = {t.id: t for t in targets}
+    out: list[TargetScoreItem] = []
+    for s in result.scores:
+        row = by_id.get(s.target_id)
+        if row is None:
+            continue
+        row.relevance_score = s.score
+        row.ai_reasoning = s.reasoning
+        out.append(TargetScoreItem(target_id=s.target_id, score=s.score, reasoning=s.reasoning))
+    db.commit()
+    return TargetScoreResponse(scored=out, cost_usd=result.cost_usd)
+
+
+@router.post("/cluster", response_model=TargetClusterResponse)
+def cluster_approved_targets(
+    payload: TargetClusterRequest, db: Session = Depends(get_session)
+) -> TargetClusterResponse:
+    profile = _require_profile(db)
+    q = db.query(Target)
+    if payload.target_ids:
+        q = q.filter(Target.id.in_(payload.target_ids))
+    else:
+        q = q.filter(Target.review_status == TargetReviewStatus.APPROVED)
+    targets = q.all()
+    if not targets:
+        return TargetClusterResponse(lists=[], cost_usd=0.0)
+
+    try:
+        result = cluster_targets(profile, targets)
+    except Exception as exc:
+        log.exception("TargetAgent.cluster_targets failed")
+        raise HTTPException(status_code=502, detail=f"TargetAgent failed: {exc}") from exc
+
+    by_id = {t.id: t for t in targets}
+    for group in result.lists:
+        for tid in group.target_ids:
+            t = by_id.get(tid)
+            if t is not None:
+                t.list_name = group.list_name
+    db.commit()
+    return TargetClusterResponse(
+        lists=[
+            TargetClusterGroup(list_name=g.list_name, target_ids=g.target_ids)
+            for g in result.lists
+        ],
+        cost_usd=result.cost_usd,
+    )
+
+
+@router.post("/bulk-review", response_model=list[TargetOut])
+def bulk_review(
+    payload: TargetBulkReviewRequest, db: Session = Depends(get_session)
+) -> list[Target]:
+    if not payload.target_ids:
+        return []
+    targets = db.query(Target).filter(Target.id.in_(payload.target_ids)).all()
+    for t in targets:
+        t.review_status = payload.review_status
+    db.commit()
+    for t in targets:
+        db.refresh(t)
+    return targets

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -51,5 +51,18 @@ class Settings(BaseSettings):
     # The Threads user id (numeric).
     threads_user_id: str = ""
 
+    # M8 — Security
+    # Empty = auth disabled (single-user localhost default). Set to any
+    # 4–32 char string to require `X-Dashboard-Pin` or a `/api/auth/login`
+    # cookie on every /api/* request.
+    dashboard_pin: str = ""
+    # Fernet key for encryption-at-rest (44-char urlsafe base64). Empty = we
+    # auto-generate one into `data/.fernet.key` and use that.
+    fernet_key: str = ""
+
+    # M8 — Backups
+    backup_dir: str = "data/backups"
+    backup_keep_days: int = 14
+
 
 settings = Settings()

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -34,5 +34,22 @@ class Settings(BaseSettings):
     max_delay_between_posts_sec: int = 300
     max_posts_per_day: int = 50
 
+    # M7 — Meta (Instagram + Threads) OAuth
+    # Values come from the Facebook Developers console (Meta App). All
+    # optional — the IG/Threads platforms just refuse to publish if the
+    # corresponding long-lived token isn't set.
+    meta_app_id: str = ""
+    meta_app_secret: str = ""
+    meta_redirect_uri: str = "http://localhost:8787/api/meta/oauth/callback"
+    # Long-lived user access token — populated via the /api/meta/oauth/callback
+    # flow; we persist it on the PlatformCredential row too, but keep this
+    # setting as an escape hatch for CLI users who'd rather paste a token.
+    meta_access_token: str = ""
+    # The Instagram Business Account id (numeric). One per Meta App; if the
+    # user has multiple we pick the first unless they override.
+    instagram_account_id: str = ""
+    # The Threads user id (numeric).
+    threads_user_id: str = ""
+
 
 settings = Settings()

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -534,6 +534,32 @@ class OptimizerProposal(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
 
 
+class PlatformCredential(Base):
+    """Per-platform OAuth credential. One row per (platform_id, account_id).
+
+    For M7 this covers Meta (Instagram + Threads — both live under the same
+    App, so in practice one long-lived token serves both). For later
+    platforms (LinkedIn, X, Reddit) the same shape works.
+
+    Storage: plaintext for v1; M8 adds Fernet-at-rest encryption to
+    `access_token`.
+    """
+
+    __tablename__ = "platform_credentials"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    platform_id: Mapped[str] = mapped_column(String(50), index=True)
+    account_id: Mapped[str] = mapped_column(String(100))
+    username: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    access_token: Mapped[str] = mapped_column(Text)
+    token_expires_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    extra: Mapped[dict] = mapped_column(JSON, default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), onupdate=func.now()
+    )
+
+
 class FewShotExample(Base):
     """Curated top-performing posts used as few-shot examples for Writer.
 

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -226,3 +226,78 @@ class LogEntry(Base):
     message: Mapped[str] = mapped_column(Text)
     meta: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+
+
+# ---------- Content Planner (M1) ----------
+
+
+class PlanStatus(str, enum.Enum):
+    DRAFT = "draft"
+    ACTIVE = "active"
+    ARCHIVED = "archived"
+
+
+class SlotStatus(str, enum.Enum):
+    PLANNED = "planned"       # Slot exists, no Post yet
+    GENERATED = "generated"   # Post drafted from slot
+    SCHEDULED = "scheduled"   # Post scheduled for publishing
+    POSTED = "posted"         # Published
+    SKIPPED = "skipped"       # User chose to skip
+
+
+class ContentPlan(Base):
+    """A content plan covers a date range and groups many PlanSlots.
+
+    One business profile can have many plans (e.g. "Q2 launch", "July specials").
+    Only one is usually `active` at a time, but that's not enforced — the user is free.
+    """
+    __tablename__ = "content_plans"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(255))
+    goal: Mapped[str | None] = mapped_column(Text, nullable=True)
+    start_date: Mapped[datetime] = mapped_column(DateTime)
+    end_date: Mapped[datetime] = mapped_column(DateTime)
+    status: Mapped[PlanStatus] = mapped_column(Enum(PlanStatus), default=PlanStatus.DRAFT)
+    # Snapshot of knobs at generation time (tone, posts_per_day, ratios, ...)
+    generation_params: Mapped[dict] = mapped_column(JSON, default=dict)
+    # Transcript of planner chat turns: [{"role": "user"|"assistant", "content": "..."}]
+    chat_history: Mapped[list] = mapped_column(JSON, default=list)
+    generation_cost_usd: Mapped[float] = mapped_column(Float, default=0.0)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), onupdate=func.now()
+    )
+
+    slots: Mapped[list[PlanSlot]] = relationship(
+        back_populates="plan",
+        cascade="all, delete-orphan",
+        order_by="PlanSlot.scheduled_for.asc()",
+    )
+
+
+class PlanSlot(Base):
+    """A single slot inside a ContentPlan.
+
+    A slot is a "plan to write a post of type X on date Y about topic Z". Once the user
+    generates the actual post text for this slot, `post_id` is filled and `status`
+    moves to GENERATED/SCHEDULED/POSTED.
+    """
+    __tablename__ = "plan_slots"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    plan_id: Mapped[int] = mapped_column(ForeignKey("content_plans.id"))
+    scheduled_for: Mapped[datetime] = mapped_column(DateTime)
+    post_type: Mapped[PostType] = mapped_column(Enum(PostType))
+    topic_hint: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Planner's rationale for picking this slot — why this type, why this time
+    rationale: Mapped[str | None] = mapped_column(Text, nullable=True)
+    status: Mapped[SlotStatus] = mapped_column(Enum(SlotStatus), default=SlotStatus.PLANNED)
+    post_id: Mapped[int | None] = mapped_column(ForeignKey("posts.id"), nullable=True)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+
+    plan: Mapped[ContentPlan] = relationship(back_populates="slots")
+    post: Mapped[Post | None] = relationship()

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -448,3 +448,106 @@ class SessionHealth(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime, server_default=func.now(), onupdate=func.now()
     )
+
+
+# ---------- M6: Metrics / Analyst / Optimizer ----------
+
+
+class MetricsWindow(str, enum.Enum):
+    """When after posting we took the snapshot. Fixed buckets keep comparison fair."""
+
+    ONE_HOUR = "1h"
+    ONE_DAY = "24h"
+    SEVEN_DAY = "7d"
+
+
+class PostMetrics(Base):
+    """One row per (variant, window). Scheduler fills these in over the lifespan
+    of a posted variant (1h, 24h, 7d).
+    """
+
+    __tablename__ = "post_metrics"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    variant_id: Mapped[int] = mapped_column(
+        ForeignKey("post_variants.id", ondelete="CASCADE"), index=True
+    )
+    window: Mapped[MetricsWindow] = mapped_column(Enum(MetricsWindow))
+    likes: Mapped[int] = mapped_column(Integer, default=0)
+    comments: Mapped[int] = mapped_column(Integer, default=0)
+    shares: Mapped[int] = mapped_column(Integer, default=0)
+    reach: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # Computed engagement score = likes + 2*comments + 3*shares (shares weigh most)
+    engagement_score: Mapped[float] = mapped_column(Float, default=0.0)
+    collected_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+
+
+class AnalystReport(Base):
+    """Weekly AI-generated report. The Analyst agent writes a structured JSON
+    body (top/bottom performers, patterns, hypotheses) — we store it verbatim
+    plus short summary text for the dashboard overview.
+    """
+
+    __tablename__ = "analyst_reports"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    period_start: Mapped[datetime] = mapped_column(DateTime)
+    period_end: Mapped[datetime] = mapped_column(DateTime)
+    summary: Mapped[str] = mapped_column(Text)
+    body: Mapped[dict] = mapped_column(JSON, default=dict)
+    cost_usd: Mapped[float] = mapped_column(Float, default=0.0)
+    model: Mapped[str] = mapped_column(String(100), default="")
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+
+
+class ProposalStatus(str, enum.Enum):
+    PENDING = "pending"
+    APPLIED = "applied"
+    REJECTED = "rejected"
+
+
+class OptimizerProposal(Base):
+    """A single mutation proposal (field = new value) emitted by the Analyst.
+
+    Minor changes (posting window +/- 1h, small ratio shifts) can be auto-applied
+    if `confidence >= 0.75`. Tone / length / big ratio shifts always wait for
+    human approval.
+    """
+
+    __tablename__ = "optimizer_proposals"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    report_id: Mapped[int | None] = mapped_column(
+        ForeignKey("analyst_reports.id", ondelete="SET NULL"), nullable=True
+    )
+    # Dot-path on BusinessProfile, e.g. "post_type_ratios", "posting_window_start_hour".
+    field: Mapped[str] = mapped_column(String(100))
+    current_value: Mapped[dict] = mapped_column(JSON, default=dict)
+    proposed_value: Mapped[dict] = mapped_column(JSON, default=dict)
+    reasoning: Mapped[str] = mapped_column(Text)
+    confidence: Mapped[float] = mapped_column(Float, default=0.5)
+    status: Mapped[ProposalStatus] = mapped_column(
+        Enum(ProposalStatus), default=ProposalStatus.PENDING
+    )
+    auto_applied: Mapped[bool] = mapped_column(Boolean, default=False)
+    applied_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+
+
+class FewShotExample(Base):
+    """Curated top-performing posts used as few-shot examples for Writer.
+
+    Refreshed periodically from PostMetrics — the N highest-engagement posts per
+    post_type stay in the store; others rotate out.
+    """
+
+    __tablename__ = "few_shot_examples"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    post_id: Mapped[int] = mapped_column(
+        ForeignKey("posts.id", ondelete="CASCADE"), index=True
+    )
+    post_type: Mapped[PostType] = mapped_column(Enum(PostType), index=True)
+    text: Mapped[str] = mapped_column(Text)
+    engagement_score: Mapped[float] = mapped_column(Float, default=0.0)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -369,3 +369,79 @@ class MediaAsset(Base):
     tagged_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+
+
+# ---------- Humanizer (M4) ----------
+
+
+class HumanizerProfile(Base):
+    """Configuration for how "human" the posting simulation should feel.
+
+    Singleton for v1 (like BusinessProfile). Holds all tunable knobs: typing speed,
+    per-char variance, mistake/correction rate, mouse-path curvature, idle scroll
+    time before opening composer, and the jitter window for scheduled times.
+
+    ## Smart pause
+    `consecutive_failures_threshold` / `smart_pause_minutes` drive the
+    "3 fails in a row → cool down 2h" safety. Scheduler reads `smart_pause_until`
+    and skips all work while it's in the future.
+    """
+    __tablename__ = "humanizer_profiles"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+
+    # Typing simulation (extension side)
+    typing_wpm_min: Mapped[int] = mapped_column(Integer, default=35)
+    typing_wpm_max: Mapped[int] = mapped_column(Integer, default=70)
+    mistake_rate: Mapped[float] = mapped_column(Float, default=0.02)  # 2% chars typo'd
+    pause_between_sentences_ms_min: Mapped[int] = mapped_column(Integer, default=250)
+    pause_between_sentences_ms_max: Mapped[int] = mapped_column(Integer, default=900)
+
+    # Mouse / scroll (extension side)
+    mouse_path_curvature: Mapped[float] = mapped_column(Float, default=0.35)
+    idle_scroll_before_post_sec_min: Mapped[int] = mapped_column(Integer, default=3)
+    idle_scroll_before_post_sec_max: Mapped[int] = mapped_column(Integer, default=12)
+
+    # Scheduling jitter (backend side)
+    schedule_jitter_minutes: Mapped[int] = mapped_column(Integer, default=7)
+
+    # Smart pause
+    consecutive_failures_threshold: Mapped[int] = mapped_column(Integer, default=3)
+    smart_pause_minutes: Mapped[int] = mapped_column(Integer, default=120)
+    smart_pause_until: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    smart_pause_reason: Mapped[str | None] = mapped_column(String(500), nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), onupdate=func.now()
+    )
+
+
+class SessionHealthStatus(str, enum.Enum):
+    HEALTHY = "healthy"
+    WARNING = "warning"          # >=1 failure but under threshold
+    CHECKPOINT = "checkpoint"    # FB asking for auth / captcha
+    SHADOW_BAN_SUSPECTED = "shadow_ban_suspected"
+    PAUSED = "paused"            # Smart pause is active
+
+
+class SessionHealth(Base):
+    """Per-platform running health counter. One row per platform_id.
+
+    Scheduler reads/writes this every tick. If status goes non-HEALTHY we stop
+    publishing for that platform and surface an alert in the dashboard status widget.
+    """
+    __tablename__ = "session_health"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    platform_id: Mapped[str] = mapped_column(String(50), unique=True)
+    status: Mapped[SessionHealthStatus] = mapped_column(
+        Enum(SessionHealthStatus), default=SessionHealthStatus.HEALTHY
+    )
+    consecutive_failures: Mapped[int] = mapped_column(Integer, default=0)
+    last_failure_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    last_failure_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    last_success_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), onupdate=func.now()
+    )

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -151,6 +151,9 @@ class Post(Base):
     text: Mapped[str] = mapped_column(Text)
     image_url: Mapped[str | None] = mapped_column(String(1000), nullable=True)
     image_prompt: Mapped[str | None] = mapped_column(Text, nullable=True)
+    media_asset_id: Mapped[int | None] = mapped_column(
+        ForeignKey("media_assets.id"), nullable=True
+    )
     first_comment: Mapped[str | None] = mapped_column(Text, nullable=True)
     cta_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
 
@@ -295,9 +298,52 @@ class PlanSlot(Base):
     rationale: Mapped[str | None] = mapped_column(Text, nullable=True)
     status: Mapped[SlotStatus] = mapped_column(Enum(SlotStatus), default=SlotStatus.PLANNED)
     post_id: Mapped[int | None] = mapped_column(ForeignKey("posts.id"), nullable=True)
+    media_asset_id: Mapped[int | None] = mapped_column(
+        ForeignKey("media_assets.id"), nullable=True
+    )
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
 
     plan: Mapped[ContentPlan] = relationship(back_populates="slots")
     post: Mapped[Post | None] = relationship()
+    media_asset: Mapped[MediaAsset | None] = relationship(foreign_keys=[media_asset_id])
+
+
+# ---------- Media Library (M2) ----------
+
+
+class MediaKind(str, enum.Enum):
+    IMAGE = "image"
+    VIDEO = "video"
+
+
+class MediaAsset(Base):
+    """Uploaded image/video with AI-derived metadata.
+
+    `local_path` is relative to `data/` (so we serve via the /static mount). We keep
+    the raw file; derived transcodes (IG-aspect, Reels-length, etc.) land in
+    `variants_json` as {"ig_square": "...", "reels_9x16": "..."}.
+
+    `ai_tags` is a shortlist of semantic tags Claude Vision produced (e.g.
+    ["basil", "windowsill", "morning-light"]). `ai_caption` is a one-sentence
+    description. Together they drive the top-3 suggestion feature for PlanSlots.
+    """
+    __tablename__ = "media_assets"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    kind: Mapped[MediaKind] = mapped_column(Enum(MediaKind), default=MediaKind.IMAGE)
+    mime: Mapped[str] = mapped_column(String(100))
+    local_path: Mapped[str] = mapped_column(String(500))
+    filename: Mapped[str] = mapped_column(String(255))
+    size_bytes: Mapped[int] = mapped_column(Integer)
+    width: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    height: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    duration_sec: Mapped[float | None] = mapped_column(Float, nullable=True)
+    ai_caption: Mapped[str | None] = mapped_column(Text, nullable=True)
+    ai_tags: Mapped[list[str]] = mapped_column(JSON, default=list)
+    tags_user: Mapped[list[str]] = mapped_column(JSON, default=list)
+    variants_json: Mapped[dict] = mapped_column(JSON, default=dict)
+    tagged_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -117,12 +117,24 @@ class BusinessProfile(Base):
     )
 
 
+class TargetReviewStatus(str, enum.Enum):
+    """M3: user decision on a scraped target."""
+    PENDING = "pending"      # Scraped but user hasn't seen it yet
+    APPROVED = "approved"    # User wants to post here
+    REJECTED = "rejected"    # User does NOT want to post here
+
+
 class Target(Base):
     """A place to post to: FB group, FB page, LinkedIn profile, X account, subreddit, etc.
 
     Platform-agnostic on purpose. `platform_id` is FK to Platform registry key
     ("facebook", "linkedin"...). `external_id` is what the platform uses (group URL,
     page ID, subreddit name, Telegram chat ID, ...).
+
+    M3 fields: `description_snippet` / `category` are scraped from FB; `relevance_score`
+    and `ai_reasoning` are the TargetAgent's judgement; `review_status` tracks whether
+    the user has approved this target. `source` = "manual" | "scraped_joined" |
+    "scraped_suggested".
     """
     __tablename__ = "targets"
 
@@ -135,6 +147,16 @@ class Target(Base):
     list_name: Mapped[str | None] = mapped_column(String(100), nullable=True)
     member_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
     active: Mapped[bool] = mapped_column(Boolean, default=True)
+
+    # M3 — discovery + AI scoring
+    description_snippet: Mapped[str | None] = mapped_column(Text, nullable=True)
+    category: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    relevance_score: Mapped[int | None] = mapped_column(Integer, nullable=True)  # 0-100
+    ai_reasoning: Mapped[str | None] = mapped_column(Text, nullable=True)
+    review_status: Mapped[TargetReviewStatus] = mapped_column(
+        Enum(TargetReviewStatus), default=TargetReviewStatus.PENDING
+    )
+    source: Mapped[str] = mapped_column(String(30), default="manual")
 
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
 

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -110,6 +110,9 @@ class BusinessProfile(Base):
     timezone: Mapped[str] = mapped_column(String(50), default="UTC")
     posts_per_day: Mapped[int] = mapped_column(Integer, default=3)
     review_before_posting: Mapped[bool] = mapped_column(Boolean, default=True)
+    # M5 — auto-approve list: post_type values that skip the review queue
+    # entirely (e.g. ["informative", "motivational"] after you trust the agent).
+    auto_approve_types: Mapped[list[str]] = mapped_column(JSON, default=list)
 
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -541,8 +541,10 @@ class PlatformCredential(Base):
     App, so in practice one long-lived token serves both). For later
     platforms (LinkedIn, X, Reddit) the same shape works.
 
-    Storage: plaintext for v1; M8 adds Fernet-at-rest encryption to
-    `access_token`.
+    Storage: M8 adds Fernet-at-rest encryption to `access_token`. The column
+    is named `access_token_encrypted` on disk; the `access_token` property
+    transparently encrypts on write and decrypts on read. Old plaintext rows
+    (pre-M8) still work — decrypt_str returns them as-is.
     """
 
     __tablename__ = "platform_credentials"
@@ -551,13 +553,25 @@ class PlatformCredential(Base):
     platform_id: Mapped[str] = mapped_column(String(50), index=True)
     account_id: Mapped[str] = mapped_column(String(100))
     username: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    access_token: Mapped[str] = mapped_column(Text)
+    access_token_encrypted: Mapped[str] = mapped_column("access_token", Text)
     token_expires_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     extra: Mapped[dict] = mapped_column(JSON, default=dict)
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(
         DateTime, server_default=func.now(), onupdate=func.now()
     )
+
+    @property
+    def access_token(self) -> str:
+        from app.security import decrypt_str
+
+        return decrypt_str(self.access_token_encrypted)
+
+    @access_token.setter
+    def access_token(self, value: str) -> None:
+        from app.security import encrypt_str
+
+        self.access_token_encrypted = encrypt_str(value)
 
 
 class FewShotExample(Base):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,16 +2,12 @@
 
 Run: `uvicorn app.main:app --reload --port 8787`
 
-What's wired up in this skeleton:
-- DB init on startup
-- /healthz
-- /ws/ext — WebSocket endpoint for the Chrome extension
-- /static — serves generated images from data/images/
+Startup order:
+1. init_db() — create tables if missing.
+2. scheduler.start() — kick off APScheduler tick loop.
+3. include_router(api_router) — mount /api/* and /healthz.
 
-What's NOT yet wired (add as you build each slice):
-- REST endpoints for business profile, posts, targets, feedback
-- Scheduler startup
-- Auth (not needed for localhost-personal; add for cloud)
+The Chrome extension connects to /ws/ext for command dispatch.
 """
 from __future__ import annotations
 
@@ -23,8 +19,10 @@ from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
+from app.api import api_router
 from app.config import settings
 from app.db import init_db
+from app.scheduler import scheduler
 from app.ws.extension_bridge import bridge
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(name)s] %(message)s")
@@ -35,34 +33,36 @@ log = logging.getLogger("main")
 async def lifespan(app: FastAPI):
     log.info("Starting backend on port %d", settings.backend_port)
     init_db()
-    yield
-    log.info("Shutting down")
+    scheduler.start()
+    try:
+        yield
+    finally:
+        scheduler.shutdown(wait=False)
+        log.info("Shutting down")
 
 
 app = FastAPI(title="autoposter-AI backend", version="0.1.0", lifespan=lifespan)
 
-# CORS — dashboard on :3000 needs to hit API on :8787 from browser
+# CORS — dashboard on :3000 needs to hit API on :8787 from browser.
+# allow_origin_regex handles chrome-extension:// (origin wildcard not supported
+# in allow_origins).
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000", "chrome-extension://*"],
+    allow_origins=["http://localhost:3000", "http://127.0.0.1:3000"],
+    allow_origin_regex=r"chrome-extension://.*",
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
 
-# Serve generated images
+# Serve generated images and user uploads
 images_dir = Path("data/images")
 images_dir.mkdir(parents=True, exist_ok=True)
+uploads_dir = images_dir / "uploads"
+uploads_dir.mkdir(parents=True, exist_ok=True)
 app.mount("/static", StaticFiles(directory="data"), name="static")
 
-
-@app.get("/healthz")
-def healthz() -> dict:
-    return {
-        "ok": True,
-        "extension_connected": bridge.connected,
-        "version": "0.1.0",
-    }
+app.include_router(api_router)
 
 
 @app.websocket("/ws/ext")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,14 +15,16 @@ import logging
 from contextlib import asynccontextmanager
 from pathlib import Path
 
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, Response, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
 from app.api import api_router
 from app.config import settings
 from app.db import init_db
+from app.observability import RequestContextMiddleware, render_prometheus
 from app.scheduler import scheduler
+from app.security import DashboardAuthMiddleware
 from app.ws.extension_bridge import bridge
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(name)s] %(message)s")
@@ -54,6 +56,11 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+# Request IDs + access log + counters (runs after CORS since middlewares
+# register LIFO).
+app.add_middleware(RequestContextMiddleware)
+# PIN auth — no-op when DASHBOARD_PIN is empty (dev default).
+app.add_middleware(DashboardAuthMiddleware)
 
 # Serve generated images and user uploads
 images_dir = Path("data/images")
@@ -63,6 +70,15 @@ uploads_dir.mkdir(parents=True, exist_ok=True)
 app.mount("/static", StaticFiles(directory="data"), name="static")
 
 app.include_router(api_router)
+
+
+@app.get("/metrics", include_in_schema=False)
+def prometheus_metrics() -> Response:
+    """Prometheus scrape endpoint. Plain text exposition format."""
+    return Response(
+        content=render_prometheus(),
+        media_type="text/plain; version=0.0.4",
+    )
 
 
 @app.websocket("/ws/ext")

--- a/backend/app/observability.py
+++ b/backend/app/observability.py
@@ -1,0 +1,121 @@
+"""Observability helpers — request IDs, access log, Prometheus-ish metrics.
+
+No external deps. Structured logs are pipe-separated key=value pairs; easy to
+grep and still parseable with a small awk script.
+
+`/metrics` returns a Prometheus exposition-format text body. We count:
+- http_requests_total{path,method,status}
+- publish_attempts_total{platform,ok}
+- metrics_rows_collected_total
+
+Counters live in-process; restarting the backend resets them. Good enough for
+a self-hosted tool.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from collections import defaultdict
+from threading import Lock
+
+from fastapi import Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from app.security import new_request_id
+
+log = logging.getLogger("http")
+
+
+# ---------- Counters ----------
+
+
+_lock = Lock()
+_counters: dict[str, dict[tuple[tuple[str, str], ...], int]] = defaultdict(dict)
+
+
+def counter_inc(name: str, labels: dict[str, str] | None = None, by: int = 1) -> None:
+    key = tuple(sorted((labels or {}).items()))
+    with _lock:
+        bucket = _counters[name]
+        bucket[key] = bucket.get(key, 0) + by
+
+
+def _normalize_path(path: str) -> str:
+    """Collapse numeric path segments so cardinality stays bounded."""
+    parts = []
+    for p in path.split("/"):
+        if p.isdigit():
+            parts.append(":id")
+        else:
+            parts.append(p)
+    return "/".join(parts)
+
+
+def render_prometheus() -> str:
+    """Emit counters in Prometheus exposition format."""
+    lines: list[str] = []
+    with _lock:
+        for name, bucket in _counters.items():
+            lines.append(f"# TYPE {name} counter")
+            for labels, value in bucket.items():
+                if labels:
+                    lbl = ",".join(f'{k}="{_escape(v)}"' for k, v in labels)
+                    lines.append(f"{name}{{{lbl}}} {value}")
+                else:
+                    lines.append(f"{name} {value}")
+    return "\n".join(lines) + "\n"
+
+
+def _escape(v: str) -> str:
+    return v.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+# ---------- Middleware ----------
+
+
+class RequestContextMiddleware(BaseHTTPMiddleware):
+    """Attaches a request_id to each request/response; logs access line."""
+
+    async def dispatch(self, request: Request, call_next):
+        rid = request.headers.get("X-Request-ID") or new_request_id()
+        start = time.perf_counter()
+        request.state.request_id = rid
+        try:
+            response: Response = await call_next(request)
+        except Exception:
+            duration = (time.perf_counter() - start) * 1000
+            log.exception(
+                "rid=%s method=%s path=%s status=500 ms=%.1f",
+                rid,
+                request.method,
+                request.url.path,
+                duration,
+            )
+            counter_inc(
+                "http_requests_total",
+                {
+                    "path": _normalize_path(request.url.path),
+                    "method": request.method,
+                    "status": "500",
+                },
+            )
+            raise
+        duration = (time.perf_counter() - start) * 1000
+        response.headers["X-Request-ID"] = rid
+        log.info(
+            "rid=%s method=%s path=%s status=%d ms=%.1f",
+            rid,
+            request.method,
+            request.url.path,
+            response.status_code,
+            duration,
+        )
+        counter_inc(
+            "http_requests_total",
+            {
+                "path": _normalize_path(request.url.path),
+                "method": request.method,
+                "status": str(response.status_code),
+            },
+        )
+        return response

--- a/backend/app/platforms/base.py
+++ b/backend/app/platforms/base.py
@@ -62,6 +62,15 @@ class Platform(ABC):
         content script; API-based platforms can ignore it.
         """
 
+    async def fetch_metrics(self, external_post_id: str) -> dict | None:
+        """Return engagement metrics for a posted item, or None if unsupported.
+
+        Returned dict keys (all optional): `likes`, `comments`, `shares`,
+        `reach`. Platforms may return partial data — callers fill the rest
+        with zeros / NULL.
+        """
+        return None
+
     def adapt_content(self, text: str) -> str:
         """Platform-specific content tweaks.
 

--- a/backend/app/platforms/base.py
+++ b/backend/app/platforms/base.py
@@ -51,8 +51,16 @@ class Platform(ABC):
         """
 
     @abstractmethod
-    async def publish(self, post: Post, target: Target) -> PublishResult:
-        """Post the given content to the target."""
+    async def publish(
+        self, post: Post, target: Target, humanizer: dict | None = None
+    ) -> PublishResult:
+        """Post the given content to the target.
+
+        `humanizer` is a JSON-serializable dict of per-character typing speed,
+        mistake rate, mouse curvature, idle-scroll durations, etc. Platforms
+        that use a browser (Chrome extension) forward it verbatim to the
+        content script; API-based platforms can ignore it.
+        """
 
     def adapt_content(self, text: str) -> str:
         """Platform-specific content tweaks.

--- a/backend/app/platforms/facebook.py
+++ b/backend/app/platforms/facebook.py
@@ -73,3 +73,34 @@ class FacebookPlatform(Platform):
             error=response.get("error", "Unknown error from extension"),
             raw=response,
         )
+
+    async def fetch_metrics(self, external_post_id: str) -> dict | None:
+        """Ask the extension to scrape likes/comments/shares from a post URL.
+
+        external_post_id is the full permalink we captured during publish. The
+        extension opens the page (or reuses an existing tab) and scrapes the
+        reaction / comment / share counters.
+        """
+        if not external_post_id or not external_post_id.startswith("http"):
+            return None
+        request_id = uuid.uuid4().hex
+        try:
+            response = await bridge.request(
+                {
+                    "type": "fetch_metrics",
+                    "request_id": request_id,
+                    "post_url": external_post_id,
+                },
+                timeout=60,
+            )
+        except TimeoutError:
+            return None
+        if not response.get("ok"):
+            return None
+        m = response.get("metrics", {})
+        return {
+            "likes": int(m.get("likes") or 0),
+            "comments": int(m.get("comments") or 0),
+            "shares": int(m.get("shares") or 0),
+            "reach": m.get("reach"),
+        }

--- a/backend/app/platforms/facebook.py
+++ b/backend/app/platforms/facebook.py
@@ -43,7 +43,9 @@ class FacebookPlatform(Platform):
             for g in groups
         ]
 
-    async def publish(self, post: Post, target: Target) -> PublishResult:
+    async def publish(
+        self, post: Post, target: Target, humanizer: dict | None = None
+    ) -> PublishResult:
         """Send a publish command to the extension."""
         request_id = uuid.uuid4().hex
         payload = {
@@ -53,9 +55,10 @@ class FacebookPlatform(Platform):
             "text": post.text,
             "image_url": post.image_url,  # local URL served by backend /static
             "first_comment": post.first_comment,
+            "humanizer": humanizer,  # content script uses it to pace typing/mouse
         }
         try:
-            response = await bridge.request(payload, timeout=180)
+            response = await bridge.request(payload, timeout=240)
         except TimeoutError:
             return PublishResult(ok=False, error="Extension did not respond in time")
 

--- a/backend/app/platforms/facebook.py
+++ b/backend/app/platforms/facebook.py
@@ -11,7 +11,6 @@ or profile:
 """
 from __future__ import annotations
 
-import asyncio
 import uuid
 
 from app.db.models import Post, Target
@@ -57,7 +56,7 @@ class FacebookPlatform(Platform):
         }
         try:
             response = await bridge.request(payload, timeout=180)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             return PublishResult(ok=False, error="Extension did not respond in time")
 
         if response.get("ok"):

--- a/backend/app/platforms/instagram.py
+++ b/backend/app/platforms/instagram.py
@@ -1,0 +1,173 @@
+"""Instagram platform (via Meta Graph API v21.0).
+
+Publishing flow is two-step:
+    1. POST /{ig_user_id}/media        (container creation, returns creation_id)
+    2. POST /{ig_user_id}/media_publish (publish the container, returns media id)
+
+Requirements before publishing:
+- A PlatformCredential row with `platform_id="instagram"` and a long-lived
+  user access token. The `account_id` is the IG Business account numeric id.
+- `post.image_url` must be PUBLICLY reachable — Meta fetches it server-side.
+  For v1 the user is expected to host it themselves (Cloudinary, ImageKit,
+  or an ngrok tunnel over our `/static` mount). Local `file://` or
+  `localhost` URLs won't work.
+
+Fetching metrics uses the same access token and the /{media_id}/insights
+endpoint.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from typing import ClassVar
+
+from sqlalchemy.orm import Session
+
+from app.db.models import Post, Target
+from app.platforms import meta_graph
+from app.platforms.base import Platform, PublishResult
+
+log = logging.getLogger("platforms.instagram")
+
+
+# Instagram has a hard 2200-char caption limit.
+IG_CAPTION_MAX = 2200
+# And a hashtag cap of 30 per caption.
+IG_HASHTAG_MAX = 30
+
+
+def _get_credential(db: Session):
+    """Fetch the single Instagram credential row.
+
+    Deferred import so the module stays importable without the DB loaded.
+    """
+    from app.db.models import PlatformCredential
+
+    return (
+        db.query(PlatformCredential)
+        .filter(PlatformCredential.platform_id == "instagram")
+        .order_by(PlatformCredential.updated_at.desc())
+        .first()
+    )
+
+
+def _trim_hashtags(text: str, max_tags: int = IG_HASHTAG_MAX) -> str:
+    """Keep only the first `max_tags` hashtags; strip the rest silently."""
+    tags_seen = 0
+
+    def _repl(match: re.Match) -> str:
+        nonlocal tags_seen
+        tags_seen += 1
+        return match.group(0) if tags_seen <= max_tags else ""
+
+    return re.sub(r"#[\w\d_]+", _repl, text)
+
+
+class InstagramPlatform(Platform):
+    id: ClassVar[str] = "instagram"
+    name: ClassVar[str] = "Instagram"
+    max_length: ClassVar[int | None] = IG_CAPTION_MAX
+    supports_images: ClassVar[bool] = True
+    supports_first_comment: ClassVar[bool] = True
+
+    def __init__(self, db: Session | None = None) -> None:
+        # db is optional at construction — list_targets/publish/fetch_metrics
+        # accept a db parameter too for when the caller already has a session.
+        self._db = db
+
+    # ------- Content adaptation -------
+
+    def adapt_content(self, text: str) -> str:
+        """IG caption tweaks: trim hashtag count, then length-truncate.
+
+        Facebook's editor is fine with 30+ hashtags; IG shadow-bans captions
+        that spam them. We cap at 30 and truncate the whole caption at
+        2200 chars.
+        """
+        text = _trim_hashtags(text, IG_HASHTAG_MAX)
+        if self.max_length and len(text) > self.max_length:
+            text = text[: self.max_length - 1] + "\u2026"  # …
+        return text
+
+    # ------- Targets -------
+
+    async def list_targets(self, db: Session | None = None) -> list[dict]:
+        """Return a single pseudo-target representing the connected IG Business
+        account. IG has no "groups" concept — every publish goes to the account.
+        """
+        session = db or self._db
+        if session is None:
+            return []
+        cred = _get_credential(session)
+        if cred is None:
+            return []
+        return [
+            {
+                "external_id": cred.account_id,
+                "name": cred.username or f"Instagram ({cred.account_id})",
+                "meta": {"source": "meta_oauth"},
+            }
+        ]
+
+    # ------- Publishing -------
+
+    async def publish(
+        self,
+        post: Post,
+        target: Target,
+        humanizer: dict | None = None,
+        db: Session | None = None,
+    ) -> PublishResult:
+        session = db or self._db
+        if session is None:
+            return PublishResult(ok=False, error="No DB session for Instagram publish")
+        cred = _get_credential(session)
+        if cred is None:
+            return PublishResult(ok=False, error="No Instagram credential configured")
+        if not post.image_url or not post.image_url.startswith(("http://", "https://")):
+            return PublishResult(
+                ok=False,
+                error="Instagram requires a publicly-reachable image_url (http/https).",
+            )
+
+        caption = self.adapt_content(post.text)
+        try:
+            creation_id = meta_graph.ig_create_container(
+                ig_user_id=target.external_id,
+                access_token=cred.access_token,
+                image_url=post.image_url,
+                caption=caption,
+            )
+            media_id = meta_graph.ig_publish_container(
+                ig_user_id=target.external_id,
+                access_token=cred.access_token,
+                creation_id=creation_id,
+            )
+        except meta_graph.MetaError as exc:
+            return PublishResult(ok=False, error=str(exc))
+        except Exception as exc:
+            log.exception("Unexpected IG publish failure")
+            return PublishResult(ok=False, error=f"Unexpected: {exc}")
+
+        return PublishResult(
+            ok=True,
+            external_post_id=media_id,
+            raw={"creation_id": creation_id, "media_id": media_id},
+        )
+
+    # ------- Metrics -------
+
+    async def fetch_metrics(
+        self, external_post_id: str, db: Session | None = None
+    ) -> dict | None:
+        session = db or self._db
+        if session is None:
+            return None
+        cred = _get_credential(session)
+        if cred is None:
+            return None
+        try:
+            return meta_graph.ig_insights(external_post_id, cred.access_token)
+        except meta_graph.MetaError as exc:
+            log.warning("IG insights failed for %s: %s", external_post_id, exc)
+            return None

--- a/backend/app/platforms/meta_graph.py
+++ b/backend/app/platforms/meta_graph.py
@@ -1,0 +1,230 @@
+"""Thin wrapper around the Meta Graph + Threads APIs.
+
+Every method is one HTTP call (plus obvious wrappers). Nothing stateful —
+the token is passed in. That makes the platforms trivially mockable in
+tests.
+
+Endpoints we rely on (v21.0, unchanged for the foreseeable future):
+
+Graph / Instagram publishing (two-step "container" flow):
+- POST /{ig_user_id}/media                  → creation_id
+- POST /{ig_user_id}/media_publish          → published media id
+- GET  /{media_id}/insights                 → reach, impressions, etc.
+
+Graph / OAuth:
+- GET  /oauth/access_token                  → exchange code for token
+- GET  /me/accounts                         → pages the user manages
+- GET  /{page_id}?fields=instagram_business_account
+
+Threads (base URL is `graph.threads.net`, same OAuth scheme):
+- POST /{threads_user_id}/threads           → creation_id
+- POST /{threads_user_id}/threads_publish   → published media id
+- GET  /{media_id}/insights                 → views, likes, replies
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import httpx
+
+log = logging.getLogger("platforms.meta")
+
+
+GRAPH_BASE = "https://graph.facebook.com/v21.0"
+THREADS_BASE = "https://graph.threads.net/v1.0"
+
+
+@dataclass
+class MetaError(Exception):
+    status: int
+    code: str
+    message: str
+
+    def __str__(self) -> str:
+        return f"[{self.status}/{self.code}] {self.message}"
+
+
+def _raise_if_error(resp: httpx.Response) -> dict:
+    try:
+        data = resp.json()
+    except ValueError:
+        raise MetaError(status=resp.status_code, code="invalid_json", message=resp.text[:200])
+    if resp.status_code >= 400 or (isinstance(data, dict) and data.get("error")):
+        err = data.get("error") if isinstance(data, dict) else {}
+        raise MetaError(
+            status=resp.status_code,
+            code=str(err.get("code", "unknown")) if err else "http_error",
+            message=(err.get("message") if err else None) or resp.text[:300],
+        )
+    return data
+
+
+# ---------- OAuth ----------
+
+
+def exchange_code_for_token(
+    app_id: str, app_secret: str, redirect_uri: str, code: str
+) -> dict:
+    """Exchange an OAuth code (from the FB redirect) for a short-lived token.
+
+    Returns the JSON as-is. Caller should immediately upgrade to a long-lived
+    token via `long_lived_token`.
+    """
+    with httpx.Client(timeout=30) as c:
+        resp = c.get(
+            f"{GRAPH_BASE}/oauth/access_token",
+            params={
+                "client_id": app_id,
+                "client_secret": app_secret,
+                "redirect_uri": redirect_uri,
+                "code": code,
+            },
+        )
+    return _raise_if_error(resp)
+
+
+def long_lived_token(app_id: str, app_secret: str, short_token: str) -> dict:
+    with httpx.Client(timeout=30) as c:
+        resp = c.get(
+            f"{GRAPH_BASE}/oauth/access_token",
+            params={
+                "grant_type": "fb_exchange_token",
+                "client_id": app_id,
+                "client_secret": app_secret,
+                "fb_exchange_token": short_token,
+            },
+        )
+    return _raise_if_error(resp)
+
+
+def list_pages(access_token: str) -> list[dict]:
+    """Return the Facebook Pages the user manages. Each page may have an
+    `instagram_business_account` that we need for IG publishing.
+    """
+    with httpx.Client(timeout=30) as c:
+        resp = c.get(
+            f"{GRAPH_BASE}/me/accounts",
+            params={"access_token": access_token, "fields": "id,name,access_token,instagram_business_account"},
+        )
+    data = _raise_if_error(resp)
+    return data.get("data", [])
+
+
+# ---------- Instagram publishing ----------
+
+
+def ig_create_container(
+    ig_user_id: str,
+    access_token: str,
+    image_url: str,
+    caption: str,
+    is_carousel_item: bool = False,
+) -> str:
+    payload = {
+        "access_token": access_token,
+        "image_url": image_url,
+        "caption": caption,
+    }
+    if is_carousel_item:
+        payload["is_carousel_item"] = "true"
+    with httpx.Client(timeout=60) as c:
+        resp = c.post(f"{GRAPH_BASE}/{ig_user_id}/media", data=payload)
+    data = _raise_if_error(resp)
+    return data["id"]
+
+
+def ig_publish_container(ig_user_id: str, access_token: str, creation_id: str) -> str:
+    with httpx.Client(timeout=60) as c:
+        resp = c.post(
+            f"{GRAPH_BASE}/{ig_user_id}/media_publish",
+            data={"access_token": access_token, "creation_id": creation_id},
+        )
+    data = _raise_if_error(resp)
+    return data["id"]
+
+
+def ig_insights(media_id: str, access_token: str) -> dict:
+    """Minimal insights: we ask for like_count, comments_count, reach, impressions.
+    IG returns these as a list of {name, values[{value}]}."""
+    with httpx.Client(timeout=30) as c:
+        resp = c.get(
+            f"{GRAPH_BASE}/{media_id}/insights",
+            params={
+                "access_token": access_token,
+                "metric": "likes,comments,reach,impressions",
+            },
+        )
+    data = _raise_if_error(resp)
+    out: dict[str, int | None] = {"likes": 0, "comments": 0, "reach": None}
+    for row in data.get("data", []):
+        name = row.get("name")
+        values = row.get("values") or []
+        value = values[0].get("value") if values else None
+        if name == "likes":
+            out["likes"] = int(value or 0)
+        elif name == "comments":
+            out["comments"] = int(value or 0)
+        elif name == "reach":
+            out["reach"] = int(value) if value is not None else None
+    return out
+
+
+# ---------- Threads publishing ----------
+
+
+def threads_create_container(
+    threads_user_id: str,
+    access_token: str,
+    text: str,
+    image_url: str | None = None,
+) -> str:
+    payload: dict = {
+        "access_token": access_token,
+        "text": text,
+        "media_type": "IMAGE" if image_url else "TEXT",
+    }
+    if image_url:
+        payload["image_url"] = image_url
+    with httpx.Client(timeout=60) as c:
+        resp = c.post(f"{THREADS_BASE}/{threads_user_id}/threads", data=payload)
+    data = _raise_if_error(resp)
+    return data["id"]
+
+
+def threads_publish_container(
+    threads_user_id: str, access_token: str, creation_id: str
+) -> str:
+    with httpx.Client(timeout=60) as c:
+        resp = c.post(
+            f"{THREADS_BASE}/{threads_user_id}/threads_publish",
+            data={"access_token": access_token, "creation_id": creation_id},
+        )
+    data = _raise_if_error(resp)
+    return data["id"]
+
+
+def threads_insights(media_id: str, access_token: str) -> dict:
+    with httpx.Client(timeout=30) as c:
+        resp = c.get(
+            f"{THREADS_BASE}/{media_id}/insights",
+            params={
+                "access_token": access_token,
+                "metric": "likes,replies,reposts,views",
+            },
+        )
+    data = _raise_if_error(resp)
+    out: dict[str, int | None] = {"likes": 0, "comments": 0, "shares": 0, "reach": None}
+    for row in data.get("data", []):
+        name = row.get("name")
+        values = row.get("values") or []
+        value = values[0].get("value") if values else None
+        if name == "likes":
+            out["likes"] = int(value or 0)
+        elif name == "replies":
+            out["comments"] = int(value or 0)
+        elif name == "reposts":
+            out["shares"] = int(value or 0)
+        elif name == "views":
+            out["reach"] = int(value) if value is not None else None
+    return out

--- a/backend/app/platforms/registry.py
+++ b/backend/app/platforms/registry.py
@@ -1,0 +1,42 @@
+"""Platform registry — single source of truth for platform dispatch.
+
+Every Target row has a `platform_id` string. The scheduler, metrics service,
+and posts API look up the right Platform class here instead of hard-coding
+`FacebookPlatform()` everywhere.
+
+Adding a new platform (LinkedIn, X, Telegram, VK) = add it to `PLATFORMS`.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.platforms.base import Platform
+from app.platforms.facebook import FacebookPlatform
+from app.platforms.instagram import InstagramPlatform
+from app.platforms.threads import ThreadsPlatform
+
+
+# Keys MUST match `Target.platform_id`.
+PLATFORMS: dict[str, type[Platform]] = {
+    "facebook": FacebookPlatform,
+    "instagram": InstagramPlatform,
+    "threads": ThreadsPlatform,
+}
+
+
+def get_platform(platform_id: str, db: Session | None = None) -> Platform | None:
+    """Return a Platform instance for `platform_id`, or None.
+
+    IG / Threads need a DB session to look up credentials; Facebook ignores
+    the parameter. Callers should always pass `db` — it's harmless when the
+    platform doesn't use it.
+    """
+    cls = PLATFORMS.get(platform_id)
+    if cls is None:
+        return None
+    # IG / Threads accept an optional session in their ctor. FacebookPlatform
+    # doesn't, so we try both signatures cleanly.
+    try:
+        return cls(db=db)  # type: ignore[call-arg]
+    except TypeError:
+        return cls()

--- a/backend/app/platforms/threads.py
+++ b/backend/app/platforms/threads.py
@@ -1,0 +1,153 @@
+"""Threads platform (via Meta Threads API v1.0).
+
+Same two-step container flow as Instagram:
+    1. POST /{threads_user_id}/threads         → creation_id
+    2. POST /{threads_user_id}/threads_publish → media_id
+
+Unlike IG, Threads supports text-only posts (media_type=TEXT) and posts with
+a single image (media_type=IMAGE). Carousels and video (media_type=VIDEO /
+CAROUSEL) are deliberately not wired for v1 — we can add them when the user
+feature-flag-requests it.
+
+The credential lives in PlatformCredential with platform_id="threads" (one row).
+"""
+from __future__ import annotations
+
+import logging
+import re
+from typing import ClassVar
+
+from sqlalchemy.orm import Session
+
+from app.db.models import Post, Target
+from app.platforms import meta_graph
+from app.platforms.base import Platform, PublishResult
+
+log = logging.getLogger("platforms.threads")
+
+
+# Threads hard limit is 500 chars.
+THREADS_MAX = 500
+
+
+def _get_credential(db: Session):
+    from app.db.models import PlatformCredential
+
+    return (
+        db.query(PlatformCredential)
+        .filter(PlatformCredential.platform_id == "threads")
+        .order_by(PlatformCredential.updated_at.desc())
+        .first()
+    )
+
+
+class ThreadsPlatform(Platform):
+    id: ClassVar[str] = "threads"
+    name: ClassVar[str] = "Threads"
+    max_length: ClassVar[int | None] = THREADS_MAX
+    supports_images: ClassVar[bool] = True
+    supports_first_comment: ClassVar[bool] = False
+
+    def __init__(self, db: Session | None = None) -> None:
+        self._db = db
+
+    # ------- Content adaptation -------
+
+    def adapt_content(self, text: str) -> str:
+        """Threads truncation. Hashtag handling is lenient on Threads — we
+        leave the tags alone and only chop length.
+        """
+        text = text.strip()
+        if self.max_length and len(text) > self.max_length:
+            # Try to trim on a word boundary so we don't leave half-words.
+            cutoff = self.max_length - 1
+            slice_ = text[:cutoff]
+            last_space = slice_.rfind(" ")
+            if last_space > cutoff - 40:  # only if we don't lose too much
+                slice_ = slice_[:last_space]
+            text = slice_ + "\u2026"
+        # Threads recommends no leading whitespace; the regex below just makes
+        # consecutive newlines less aggressive (>2 → 2).
+        text = re.sub(r"\n{3,}", "\n\n", text)
+        return text
+
+    # ------- Targets -------
+
+    async def list_targets(self, db: Session | None = None) -> list[dict]:
+        session = db or self._db
+        if session is None:
+            return []
+        cred = _get_credential(session)
+        if cred is None:
+            return []
+        return [
+            {
+                "external_id": cred.account_id,
+                "name": cred.username or f"Threads ({cred.account_id})",
+                "meta": {"source": "meta_oauth"},
+            }
+        ]
+
+    # ------- Publishing -------
+
+    async def publish(
+        self,
+        post: Post,
+        target: Target,
+        humanizer: dict | None = None,
+        db: Session | None = None,
+    ) -> PublishResult:
+        session = db or self._db
+        if session is None:
+            return PublishResult(ok=False, error="No DB session for Threads publish")
+        cred = _get_credential(session)
+        if cred is None:
+            return PublishResult(ok=False, error="No Threads credential configured")
+
+        text = self.adapt_content(post.text)
+        image_url = post.image_url
+        if image_url and not image_url.startswith(("http://", "https://")):
+            # Threads, like IG, needs a public URL.
+            log.info("Dropping non-public image_url for Threads: %s", image_url)
+            image_url = None
+
+        try:
+            creation_id = meta_graph.threads_create_container(
+                threads_user_id=target.external_id,
+                access_token=cred.access_token,
+                text=text,
+                image_url=image_url,
+            )
+            media_id = meta_graph.threads_publish_container(
+                threads_user_id=target.external_id,
+                access_token=cred.access_token,
+                creation_id=creation_id,
+            )
+        except meta_graph.MetaError as exc:
+            return PublishResult(ok=False, error=str(exc))
+        except Exception as exc:
+            log.exception("Unexpected Threads publish failure")
+            return PublishResult(ok=False, error=f"Unexpected: {exc}")
+
+        return PublishResult(
+            ok=True,
+            external_post_id=media_id,
+            raw={"creation_id": creation_id, "media_id": media_id},
+        )
+
+    # ------- Metrics -------
+
+    async def fetch_metrics(
+        self, external_post_id: str, db: Session | None = None
+    ) -> dict | None:
+        session = db or self._db
+        if session is None:
+            return None
+        cred = _get_credential(session)
+        if cred is None:
+            return None
+        try:
+            return meta_graph.threads_insights(external_post_id, cred.access_token)
+        except meta_graph.MetaError as exc:
+            log.warning("Threads insights failed for %s: %s", external_post_id, exc)
+            return None

--- a/backend/app/scheduler/__init__.py
+++ b/backend/app/scheduler/__init__.py
@@ -29,7 +29,11 @@ class SchedulerSingleton:
             log.warning("Scheduler already running; skipping start")
             return
         # Late import: jobs.py imports models, which require db init first.
-        from app.scheduler.jobs import publish_due_posts
+        from app.scheduler.jobs import (
+            collect_metrics_tick,
+            publish_due_posts,
+            weekly_analyst_tick,
+        )
 
         self._impl = AsyncIOScheduler(timezone="UTC")
         self._impl.add_job(
@@ -41,8 +45,29 @@ class SchedulerSingleton:
             max_instances=1,
             next_run_time=datetime.utcnow(),
         )
+        # Metrics collection (M6) — hourly, best effort.
+        self._impl.add_job(
+            collect_metrics_tick,
+            trigger="interval",
+            hours=1,
+            id="collect_metrics",
+            coalesce=True,
+            max_instances=1,
+        )
+        # Weekly Analyst (M6) — Sundays at 21:00 UTC. A no-op if profile or
+        # metrics are missing.
+        self._impl.add_job(
+            weekly_analyst_tick,
+            trigger="cron",
+            day_of_week="sun",
+            hour=21,
+            minute=0,
+            id="weekly_analyst",
+            coalesce=True,
+            max_instances=1,
+        )
         self._impl.start()
-        log.info("Scheduler started (tick = 30s)")
+        log.info("Scheduler started (tick = 30s, metrics hourly, analyst Sun 21:00)")
 
     def shutdown(self, wait: bool = False) -> None:
         if self._impl is None:

--- a/backend/app/scheduler/__init__.py
+++ b/backend/app/scheduler/__init__.py
@@ -1,0 +1,60 @@
+"""Scheduler singleton. APScheduler AsyncIO flavour — runs inside the FastAPI loop.
+
+Lifecycle (see main.py lifespan):
+    scheduler.start()        # on app startup
+    scheduler.shutdown(...)  # on app shutdown
+
+Tick job: `publish_due_posts` runs every 30 s, looks at Posts where status=SCHEDULED
+and scheduled_for <= now, and publishes them through the Facebook platform.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+log = logging.getLogger("scheduler")
+
+
+class SchedulerSingleton:
+    def __init__(self) -> None:
+        self._impl: AsyncIOScheduler | None = None
+
+    def is_running(self) -> bool:
+        return self._impl is not None and self._impl.running
+
+    def start(self) -> None:
+        if self.is_running():
+            log.warning("Scheduler already running; skipping start")
+            return
+        # Late import: jobs.py imports models, which require db init first.
+        from app.scheduler.jobs import publish_due_posts
+
+        self._impl = AsyncIOScheduler(timezone="UTC")
+        self._impl.add_job(
+            publish_due_posts,
+            trigger="interval",
+            seconds=30,
+            id="publish_due_posts",
+            coalesce=True,
+            max_instances=1,
+            next_run_time=datetime.utcnow(),
+        )
+        self._impl.start()
+        log.info("Scheduler started (tick = 30s)")
+
+    def shutdown(self, wait: bool = False) -> None:
+        if self._impl is None:
+            return
+        try:
+            self._impl.shutdown(wait=wait)
+        except Exception as exc:  # noqa: BLE001
+            log.warning("Scheduler shutdown error: %s", exc)
+        self._impl = None
+        log.info("Scheduler stopped")
+
+
+scheduler = SchedulerSingleton()
+
+__all__ = ["scheduler"]

--- a/backend/app/scheduler/__init__.py
+++ b/backend/app/scheduler/__init__.py
@@ -31,6 +31,7 @@ class SchedulerSingleton:
         # Late import: jobs.py imports models, which require db init first.
         from app.scheduler.jobs import (
             collect_metrics_tick,
+            daily_backup_tick,
             publish_due_posts,
             weekly_analyst_tick,
         )
@@ -66,8 +67,20 @@ class SchedulerSingleton:
             coalesce=True,
             max_instances=1,
         )
+        # Daily backup (M8) — 03:00 UTC.
+        self._impl.add_job(
+            daily_backup_tick,
+            trigger="cron",
+            hour=3,
+            minute=0,
+            id="daily_backup",
+            coalesce=True,
+            max_instances=1,
+        )
         self._impl.start()
-        log.info("Scheduler started (tick = 30s, metrics hourly, analyst Sun 21:00)")
+        log.info(
+            "Scheduler started (publish 30s, metrics 1h, analyst Sun 21:00, backup 03:00)"
+        )
 
     def shutdown(self, wait: bool = False) -> None:
         if self._impl is None:

--- a/backend/app/scheduler/jobs.py
+++ b/backend/app/scheduler/jobs.py
@@ -211,6 +211,16 @@ async def collect_metrics_tick() -> None:
         db.close()
 
 
+async def daily_backup_tick() -> None:
+    """Daily zip backup (SQLite + media) to `settings.backup_dir`."""
+    from app.services import backups
+
+    try:
+        await asyncio.to_thread(backups.run_backup)
+    except Exception:
+        log.exception("daily_backup_tick crashed")
+
+
 async def weekly_analyst_tick() -> None:
     """Weekly Analyst run. No-op if profile or fresh metrics are missing."""
     from datetime import timedelta

--- a/backend/app/scheduler/jobs.py
+++ b/backend/app/scheduler/jobs.py
@@ -1,0 +1,142 @@
+"""Scheduler jobs.
+
+`publish_due_posts` — called every 30 s by APScheduler. For each Post in SCHEDULED
+whose `scheduled_for` is past, walk its PostVariants and publish through the
+Facebook platform (via the Chrome extension bridge). Sleeps a randomised delay
+between variants in the range [min_delay_between_posts_sec, max_delay...]
+so that a large batch doesn't hit FB in the same second.
+
+Idempotency: posts are promoted to POSTING before dispatch so a second tick
+doesn't grab the same row. Per-day rate limiting uses `max_posts_per_day`.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from datetime import UTC, date, datetime
+
+from sqlalchemy import func
+from sqlalchemy.orm import selectinload
+
+from app.config import settings
+from app.db import SessionLocal
+from app.db.models import Post, PostStatus, PostVariant, Target
+from app.platforms.facebook import FacebookPlatform
+
+log = logging.getLogger("scheduler.jobs")
+
+
+def _posts_today(db) -> int:
+    """Count successfully posted variants whose posted_at is today (UTC)."""
+    today = date.today()
+    return (
+        db.query(func.count(PostVariant.id))
+        .filter(PostVariant.status == PostStatus.POSTED)
+        .filter(func.date(PostVariant.posted_at) == today)
+        .scalar()
+        or 0
+    )
+
+
+async def _publish_one(post: Post, variant: PostVariant, target: Target) -> None:
+    platform = FacebookPlatform()
+    synthetic = Post(
+        id=post.id,
+        post_type=post.post_type,
+        status=PostStatus.POSTING,
+        text=variant.text,
+        image_url=post.image_url,
+        first_comment=post.first_comment,
+        cta_url=post.cta_url,
+    )
+    try:
+        result = await platform.publish(synthetic, target)
+    except Exception as exc:  # noqa: BLE001
+        variant.status = PostStatus.FAILED
+        variant.error = f"Exception: {exc}"
+        return
+
+    if result.ok:
+        variant.status = PostStatus.POSTED
+        variant.external_post_id = result.external_post_id
+        variant.posted_at = datetime.now(UTC)
+        variant.error = None
+    else:
+        variant.status = PostStatus.FAILED
+        variant.error = result.error
+
+
+async def publish_due_posts() -> None:
+    """One tick of the scheduler."""
+    now = datetime.now(UTC)
+    db = SessionLocal()
+    try:
+        due = (
+            db.query(Post)
+            .options(selectinload(Post.variants))
+            .filter(Post.status == PostStatus.SCHEDULED)
+            .filter(Post.scheduled_for.isnot(None))
+            .filter(Post.scheduled_for <= now)
+            .order_by(Post.scheduled_for.asc())
+            .all()
+        )
+        if not due:
+            return
+
+        rate_limit = settings.max_posts_per_day
+        posted_today = _posts_today(db)
+
+        for post in due:
+            if posted_today >= rate_limit:
+                log.info(
+                    "Daily rate limit reached (%d/%d) — skipping remaining due posts",
+                    posted_today,
+                    rate_limit,
+                )
+                break
+
+            post.status = PostStatus.POSTING
+            db.commit()
+
+            pending_variants = [
+                v
+                for v in post.variants
+                if v.status in (PostStatus.SCHEDULED, PostStatus.DRAFT)
+            ]
+
+            for idx, variant in enumerate(pending_variants):
+                if posted_today >= rate_limit:
+                    break
+                target = db.get(Target, variant.target_id)
+                if target is None:
+                    variant.status = PostStatus.FAILED
+                    variant.error = "Target vanished."
+                    db.commit()
+                    continue
+
+                await _publish_one(post, variant, target)
+                db.commit()
+                if variant.status == PostStatus.POSTED:
+                    posted_today += 1
+
+                if idx < len(pending_variants) - 1:
+                    delay = random.randint(
+                        settings.min_delay_between_posts_sec,
+                        settings.max_delay_between_posts_sec,
+                    )
+                    log.info("Sleeping %d s before next variant", delay)
+                    await asyncio.sleep(delay)
+
+            db.refresh(post)
+            fresh_variants = list(post.variants)
+            if any(v.status == PostStatus.POSTED for v in fresh_variants):
+                post.status = PostStatus.POSTED
+                post.posted_at = datetime.now(UTC)
+            elif all(v.status == PostStatus.FAILED for v in fresh_variants):
+                post.status = PostStatus.FAILED
+            else:
+                post.status = PostStatus.SCHEDULED  # some variants still pending
+            db.commit()
+    finally:
+        db.close()

--- a/backend/app/scheduler/jobs.py
+++ b/backend/app/scheduler/jobs.py
@@ -174,3 +174,56 @@ async def publish_due_posts() -> None:
                 break
     finally:
         db.close()
+
+
+# ---------- M6: Metrics + Analyst ticks ----------
+
+
+async def collect_metrics_tick() -> None:
+    """Hourly. Fetch whatever 1h/24h/7d windows are due across all POSTED variants."""
+    from app.services import metrics
+
+    db = SessionLocal()
+    try:
+        result = await metrics.collect_metrics(db)
+        if result["rows_created"]:
+            log.info(
+                "Metrics tick: touched %d variants, created %d rows",
+                result["variants_touched"],
+                result["rows_created"],
+            )
+    except Exception:
+        log.exception("collect_metrics_tick crashed")
+    finally:
+        db.close()
+
+
+async def weekly_analyst_tick() -> None:
+    """Weekly Analyst run. No-op if profile or fresh metrics are missing."""
+    from datetime import timedelta
+
+    from app.agents import analyst
+    from app.db.models import BusinessProfile, PostMetrics
+    from app.services import few_shot
+
+    db = SessionLocal()
+    try:
+        profile = db.query(BusinessProfile).order_by(BusinessProfile.id.asc()).first()
+        if profile is None:
+            log.info("weekly_analyst_tick: no profile, skipping")
+            return
+        has_metrics = db.query(PostMetrics.id).first() is not None
+        if not has_metrics:
+            log.info("weekly_analyst_tick: no metrics yet, skipping")
+            return
+        end = datetime.now(UTC)
+        start = end - timedelta(days=7)
+        # Heavy Claude call — dispatch to a thread.
+        output = await asyncio.to_thread(analyst.run_analysis, db, profile, start, end)
+        analyst.persist_report_and_proposals(db, profile, output, start, end)
+        few_shot.refresh_few_shot_store(db)
+        log.info("weekly_analyst_tick: generated report (cost=$%.4f)", output.cost_usd)
+    except Exception:
+        log.exception("weekly_analyst_tick crashed")
+    finally:
+        db.close()

--- a/backend/app/scheduler/jobs.py
+++ b/backend/app/scheduler/jobs.py
@@ -23,6 +23,7 @@ from app.config import settings
 from app.db import SessionLocal
 from app.db.models import Post, PostStatus, PostVariant, Target
 from app.platforms.facebook import FacebookPlatform
+from app.services import humanizer as hz
 
 log = logging.getLogger("scheduler.jobs")
 
@@ -39,7 +40,9 @@ def _posts_today(db) -> int:
     )
 
 
-async def _publish_one(post: Post, variant: PostVariant, target: Target) -> None:
+async def _publish_one(
+    post: Post, variant: PostVariant, target: Target, humanizer_config: dict | None = None
+) -> None:
     platform = FacebookPlatform()
     synthetic = Post(
         id=post.id,
@@ -51,7 +54,7 @@ async def _publish_one(post: Post, variant: PostVariant, target: Target) -> None
         cta_url=post.cta_url,
     )
     try:
-        result = await platform.publish(synthetic, target)
+        result = await platform.publish(synthetic, target, humanizer=humanizer_config)
     except Exception as exc:  # noqa: BLE001
         variant.status = PostStatus.FAILED
         variant.error = f"Exception: {exc}"
@@ -72,6 +75,17 @@ async def publish_due_posts() -> None:
     now = datetime.now(UTC)
     db = SessionLocal()
     try:
+        # Smart pause: while active, scheduler is idle.
+        pause_until = hz.check_pause(db, now=now)
+        if pause_until is not None:
+            log.info("Smart pause active until %s — skipping tick", pause_until.isoformat())
+            return
+
+        # Blackout: if today is a blackout day, don't post.
+        if hz.in_blackout(db, now) is not None:
+            log.info("Blackout date matches today — skipping tick")
+            return
+
         due = (
             db.query(Post)
             .options(selectinload(Post.variants))
@@ -83,6 +97,9 @@ async def publish_due_posts() -> None:
         )
         if not due:
             return
+
+        profile = hz.get_or_create_profile(db)
+        humanizer_config = hz.humanizer_config_for_extension(profile)
 
         rate_limit = settings.max_posts_per_day
         posted_today = _posts_today(db)
@@ -105,9 +122,17 @@ async def publish_due_posts() -> None:
                 if v.status in (PostStatus.SCHEDULED, PostStatus.DRAFT)
             ]
 
+            aborted_due_to_pause = False
             for idx, variant in enumerate(pending_variants):
                 if posted_today >= rate_limit:
                     break
+                # Re-check pause between each variant — a mid-run checkpoint detection
+                # could activate it.
+                if hz.check_pause(db) is not None:
+                    log.warning("Smart pause triggered mid-run; aborting remaining variants")
+                    aborted_due_to_pause = True
+                    break
+
                 target = db.get(Target, variant.target_id)
                 if target is None:
                     variant.status = PostStatus.FAILED
@@ -115,10 +140,15 @@ async def publish_due_posts() -> None:
                     db.commit()
                     continue
 
-                await _publish_one(post, variant, target)
+                await _publish_one(post, variant, target, humanizer_config=humanizer_config)
                 db.commit()
                 if variant.status == PostStatus.POSTED:
                     posted_today += 1
+                    hz.on_success(db, platform_id="facebook")
+                else:
+                    hz.on_failure(db, platform_id="facebook", reason=variant.error or "")
+                    # on_failure may have activated a pause — next loop iteration
+                    # picks that up and aborts.
 
                 if idx < len(pending_variants) - 1:
                     delay = random.randint(
@@ -133,10 +163,14 @@ async def publish_due_posts() -> None:
             if any(v.status == PostStatus.POSTED for v in fresh_variants):
                 post.status = PostStatus.POSTED
                 post.posted_at = datetime.now(UTC)
-            elif all(v.status == PostStatus.FAILED for v in fresh_variants):
+            elif all(
+                v.status == PostStatus.FAILED for v in fresh_variants
+            ) and not aborted_due_to_pause:
                 post.status = PostStatus.FAILED
             else:
                 post.status = PostStatus.SCHEDULED  # some variants still pending
             db.commit()
+            if aborted_due_to_pause:
+                break
     finally:
         db.close()

--- a/backend/app/scheduler/jobs.py
+++ b/backend/app/scheduler/jobs.py
@@ -22,7 +22,7 @@ from sqlalchemy.orm import selectinload
 from app.config import settings
 from app.db import SessionLocal
 from app.db.models import Post, PostStatus, PostVariant, Target
-from app.platforms.facebook import FacebookPlatform
+from app.platforms.registry import get_platform
 from app.services import humanizer as hz
 
 log = logging.getLogger("scheduler.jobs")
@@ -41,14 +41,22 @@ def _posts_today(db) -> int:
 
 
 async def _publish_one(
-    post: Post, variant: PostVariant, target: Target, humanizer_config: dict | None = None
+    post: Post,
+    variant: PostVariant,
+    target: Target,
+    humanizer_config: dict | None = None,
+    db=None,
 ) -> None:
-    platform = FacebookPlatform()
+    platform = get_platform(target.platform_id, db=db)
+    if platform is None:
+        variant.status = PostStatus.FAILED
+        variant.error = f"Unknown platform_id: {target.platform_id}"
+        return
     synthetic = Post(
         id=post.id,
         post_type=post.post_type,
         status=PostStatus.POSTING,
-        text=variant.text,
+        text=platform.adapt_content(variant.text),
         image_url=post.image_url,
         first_comment=post.first_comment,
         cta_url=post.cta_url,
@@ -140,13 +148,18 @@ async def publish_due_posts() -> None:
                     db.commit()
                     continue
 
-                await _publish_one(post, variant, target, humanizer_config=humanizer_config)
+                await _publish_one(
+                    post, variant, target, humanizer_config=humanizer_config, db=db
+                )
                 db.commit()
+                platform_id = target.platform_id
                 if variant.status == PostStatus.POSTED:
                     posted_today += 1
-                    hz.on_success(db, platform_id="facebook")
+                    hz.on_success(db, platform_id=platform_id)
                 else:
-                    hz.on_failure(db, platform_id="facebook", reason=variant.error or "")
+                    hz.on_failure(
+                        db, platform_id=platform_id, reason=variant.error or ""
+                    )
                     # on_failure may have activated a pause — next loop iteration
                     # picks that up and aborts.
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -565,3 +565,47 @@ class OptimizerProposalOut(BaseModel):
     auto_applied: bool
     applied_at: datetime | None
     created_at: datetime
+
+
+# ---------- Platform credentials + OAuth (M7) ----------
+
+
+class PlatformCredentialOut(BaseModel):
+    """Safe view of a PlatformCredential — never returns the access_token."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    platform_id: str
+    account_id: str
+    username: str | None
+    token_expires_at: datetime | None
+    extra: dict
+    created_at: datetime
+    updated_at: datetime
+
+
+class MetaOAuthUrlOut(BaseModel):
+    """The login URL we redirect the user to. `state` is random per request."""
+
+    url: str
+    state: str
+
+
+class MetaOAuthCompleteOut(BaseModel):
+    """Summary of what the callback stored."""
+
+    instagram: PlatformCredentialOut | None = None
+    threads: PlatformCredentialOut | None = None
+    message: str
+
+
+class MetaManualCredentialIn(BaseModel):
+    """Escape hatch for CLI users — paste a long-lived token + account id(s)
+    directly without running through the OAuth redirect.
+    """
+
+    platform_id: str  # "instagram" or "threads"
+    account_id: str
+    username: str | None = None
+    access_token: str

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -46,6 +46,7 @@ class BusinessProfileIn(BaseModel):
     timezone: str = "UTC"
     posts_per_day: int = 3
     review_before_posting: bool = True
+    auto_approve_types: list[str] = Field(default_factory=list)
 
 
 class BusinessProfileOut(BusinessProfileIn):
@@ -462,3 +463,29 @@ class BlackoutDateOut(BaseModel):
     id: int
     date: datetime
     reason: str | None
+
+
+# ---------- Review & Approval (M5) ----------
+
+
+class PostApproveRequest(BaseModel):
+    """Approve a PENDING_REVIEW post. If `scheduled_for` is set, the post is
+    scheduled with variants; otherwise it transitions to DRAFT for later action.
+    """
+
+    target_ids: list[int] = Field(default_factory=list)
+    scheduled_for: datetime | None = None
+
+
+class PostRejectRequest(BaseModel):
+    reason: str | None = None
+
+
+class PostRegenerateRequest(BaseModel):
+    topic_hint: str | None = None
+    generate_image: bool = False
+
+
+class PostApproveAllRequest(BaseModel):
+    post_type: PostType | None = None
+    scheduled_for: datetime | None = None

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -14,8 +14,10 @@ from app.db.models import (
     EmojiDensity,
     FeedbackRating,
     Length,
+    PlanStatus,
     PostStatus,
     PostType,
+    SlotStatus,
     Tone,
 )
 
@@ -202,3 +204,92 @@ class StatusOut(BaseModel):
     scheduler_running: bool
     next_scheduled_post_at: datetime | None
     pending_posts: int
+
+
+# ---------- Content Plan (M1) ----------
+
+
+class PlanSlotOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    plan_id: int
+    scheduled_for: datetime
+    post_type: PostType
+    topic_hint: str | None
+    rationale: str | None
+    status: SlotStatus
+    post_id: int | None
+    notes: str | None
+    created_at: datetime
+
+
+class PlanSlotIn(BaseModel):
+    scheduled_for: datetime
+    post_type: PostType
+    topic_hint: str | None = None
+    rationale: str | None = None
+    notes: str | None = None
+
+
+class PlanSlotPatch(BaseModel):
+    scheduled_for: datetime | None = None
+    post_type: PostType | None = None
+    topic_hint: str | None = None
+    rationale: str | None = None
+    notes: str | None = None
+    status: SlotStatus | None = None
+
+
+class ContentPlanOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    name: str
+    goal: str | None
+    start_date: datetime
+    end_date: datetime
+    status: PlanStatus
+    generation_params: dict
+    chat_history: list
+    generation_cost_usd: float
+    created_at: datetime
+    updated_at: datetime
+    slots: list[PlanSlotOut] = Field(default_factory=list)
+
+
+class ContentPlanPatch(BaseModel):
+    name: str | None = None
+    goal: str | None = None
+    status: PlanStatus | None = None
+
+
+class PlanGenerateRequest(BaseModel):
+    """Ask the PlannerAgent to generate a new plan.
+
+    `replace_existing_slots` — if true and the plan already has slots, delete them
+    before inserting new ones.
+    """
+
+    name: str
+    goal: str | None = None
+    start_date: datetime
+    end_date: datetime
+    replace_existing_slots: bool = True
+
+
+class PlanChatRequest(BaseModel):
+    message: str
+
+
+class PlanChatResponse(BaseModel):
+    reply: str
+    updated: bool
+    plan: ContentPlanOut
+
+
+class SlotGeneratePostResponse(BaseModel):
+    """Returned after generating a Post from a slot."""
+
+    slot: PlanSlotOut
+    post: PostOut

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -18,6 +18,7 @@ from app.db.models import (
     PlanStatus,
     PostStatus,
     PostType,
+    SessionHealthStatus,
     SlotStatus,
     TargetReviewStatus,
     Tone,
@@ -395,3 +396,69 @@ class SlotGeneratePostResponse(BaseModel):
 
     slot: PlanSlotOut
     post: PostOut
+
+
+# ---------- Humanizer (M4) ----------
+
+
+class HumanizerProfileOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    typing_wpm_min: int
+    typing_wpm_max: int
+    mistake_rate: float
+    pause_between_sentences_ms_min: int
+    pause_between_sentences_ms_max: int
+    mouse_path_curvature: float
+    idle_scroll_before_post_sec_min: int
+    idle_scroll_before_post_sec_max: int
+    schedule_jitter_minutes: int
+    consecutive_failures_threshold: int
+    smart_pause_minutes: int
+    smart_pause_until: datetime | None
+    smart_pause_reason: str | None
+
+
+class HumanizerProfileIn(BaseModel):
+    typing_wpm_min: int | None = None
+    typing_wpm_max: int | None = None
+    mistake_rate: float | None = None
+    pause_between_sentences_ms_min: int | None = None
+    pause_between_sentences_ms_max: int | None = None
+    mouse_path_curvature: float | None = None
+    idle_scroll_before_post_sec_min: int | None = None
+    idle_scroll_before_post_sec_max: int | None = None
+    schedule_jitter_minutes: int | None = None
+    consecutive_failures_threshold: int | None = None
+    smart_pause_minutes: int | None = None
+
+
+class SessionHealthOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    platform_id: str
+    status: SessionHealthStatus
+    consecutive_failures: int
+    last_failure_at: datetime | None
+    last_failure_reason: str | None
+    last_success_at: datetime | None
+
+
+class SmartPauseInfo(BaseModel):
+    paused: bool
+    until: datetime | None
+    reason: str | None
+
+
+class BlackoutDateIn(BaseModel):
+    date: datetime
+    reason: str | None = None
+
+
+class BlackoutDateOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    date: datetime
+    reason: str | None

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,204 @@
+"""Pydantic schemas for REST API I/O.
+
+Naming: `FooIn` = request body, `FooOut` = response body, `FooPatch` = partial update.
+We deliberately don't use SQLAlchemy models in responses — the API surface should
+be independently versioned from the DB schema.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.db.models import (
+    EmojiDensity,
+    FeedbackRating,
+    Length,
+    PostStatus,
+    PostType,
+    Tone,
+)
+
+# ---------- BusinessProfile ----------
+
+
+class BusinessProfileIn(BaseModel):
+    name: str
+    description: str
+    website_url: str | None = None
+    products: str | None = None
+    target_audience: str | None = None
+    call_to_action_url: str | None = None
+
+    tone: Tone = Tone.CASUAL
+    length: Length = Length.MEDIUM
+    emoji_density: EmojiDensity = EmojiDensity.LIGHT
+    language: str = "en"
+
+    post_type_ratios: dict = Field(default_factory=dict)
+    posting_window_start_hour: int = 9
+    posting_window_end_hour: int = 20
+    timezone: str = "UTC"
+    posts_per_day: int = 3
+    review_before_posting: bool = True
+
+
+class BusinessProfileOut(BusinessProfileIn):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+
+# ---------- Target ----------
+
+
+class TargetIn(BaseModel):
+    platform_id: str = "facebook"
+    external_id: str
+    name: str
+    tags: list[str] = Field(default_factory=list)
+    list_name: str | None = None
+    member_count: int | None = None
+    active: bool = True
+
+
+class TargetPatch(BaseModel):
+    name: str | None = None
+    tags: list[str] | None = None
+    list_name: str | None = None
+    member_count: int | None = None
+    active: bool | None = None
+
+
+class TargetOut(TargetIn):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    created_at: datetime
+
+
+# ---------- Post ----------
+
+
+class PostIn(BaseModel):
+    post_type: PostType
+    text: str
+    image_url: str | None = None
+    image_prompt: str | None = None
+    first_comment: str | None = None
+    cta_url: str | None = None
+    scheduled_for: datetime | None = None
+
+
+class PostPatch(BaseModel):
+    post_type: PostType | None = None
+    status: PostStatus | None = None
+    text: str | None = None
+    image_url: str | None = None
+    image_prompt: str | None = None
+    first_comment: str | None = None
+    cta_url: str | None = None
+    scheduled_for: datetime | None = None
+
+
+class PostGenerate(BaseModel):
+    post_type: PostType
+    topic_hint: str | None = None
+    generate_image: bool = False
+    use_few_shot: bool = True
+
+
+class PostVariantOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    post_id: int
+    target_id: int
+    text: str
+    status: PostStatus
+    scheduled_for: datetime | None
+    posted_at: datetime | None
+    external_post_id: str | None
+    error: str | None
+
+
+class PostOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    post_type: PostType
+    status: PostStatus
+    text: str
+    image_url: str | None
+    image_prompt: str | None
+    first_comment: str | None
+    cta_url: str | None
+    scheduled_for: datetime | None
+    posted_at: datetime | None
+    generation_model: str | None
+    generation_cost_usd: float | None
+    created_at: datetime
+    variants: list[PostVariantOut] = Field(default_factory=list)
+
+
+class PublishRequest(BaseModel):
+    """Payload for POST /api/posts/{id}/publish and /schedule.
+
+    `target_ids` — which Target rows to post to. If empty, use all active targets
+    matching the post's platform. For /schedule, `scheduled_for` is required.
+    """
+
+    target_ids: list[int] = Field(default_factory=list)
+    scheduled_for: datetime | None = None
+    generate_spintax: bool = True
+
+
+class PublishResultOut(BaseModel):
+    post_id: int
+    status: PostStatus
+    variants: list[PostVariantOut]
+
+
+# ---------- Feedback ----------
+
+
+class FeedbackIn(BaseModel):
+    post_id: int
+    rating: FeedbackRating
+    comment: str | None = None
+
+
+class FeedbackOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    post_id: int
+    rating: FeedbackRating
+    comment: str | None
+    created_at: datetime
+
+
+# ---------- Media ----------
+
+
+class MediaUploadOut(BaseModel):
+    """Returned after a successful /api/media/upload."""
+
+    url: str  # relative to backend root, e.g. "/static/images/uploads/abc.png"
+    filename: str
+    mime: str
+    size_bytes: int
+
+
+# ---------- Status ----------
+
+
+class StatusOut(BaseModel):
+    ok: bool
+    version: str
+    extension_connected: bool
+    scheduler_running: bool
+    next_scheduled_post_at: datetime | None
+    pending_posts: int

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -15,9 +15,11 @@ from app.db.models import (
     FeedbackRating,
     Length,
     MediaKind,
+    MetricsWindow,
     PlanStatus,
     PostStatus,
     PostType,
+    ProposalStatus,
     SessionHealthStatus,
     SlotStatus,
     TargetReviewStatus,
@@ -489,3 +491,77 @@ class PostRegenerateRequest(BaseModel):
 class PostApproveAllRequest(BaseModel):
     post_type: PostType | None = None
     scheduled_for: datetime | None = None
+
+
+# ---------- Analytics & Analyst (M6) ----------
+
+
+class PostMetricsOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    variant_id: int
+    window: MetricsWindow
+    likes: int
+    comments: int
+    shares: int
+    reach: int | None
+    engagement_score: float
+    collected_at: datetime
+
+
+class MetricsCollectResult(BaseModel):
+    variants_touched: int
+    rows_created: int
+
+
+class AnalyticsSummaryOut(BaseModel):
+    period_days: int
+    posts: int
+    likes: int
+    comments: int
+    shares: int
+    avg_engagement_score: float
+
+
+class TopPerformerOut(BaseModel):
+    post_id: int
+    post_type: PostType
+    posted_at: datetime | None
+    text_preview: str
+    engagement_score: float
+
+
+class AnalystReportOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    period_start: datetime
+    period_end: datetime
+    summary: str
+    body: dict
+    cost_usd: float
+    model: str
+    created_at: datetime
+
+
+class AnalystGenerateRequest(BaseModel):
+    days: int | None = 7
+    period_start: datetime | None = None
+    period_end: datetime | None = None
+
+
+class OptimizerProposalOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    report_id: int | None
+    field: str
+    current_value: dict
+    proposed_value: dict
+    reasoning: str
+    confidence: float
+    status: ProposalStatus
+    auto_applied: bool
+    applied_at: datetime | None
+    created_at: datetime

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -14,6 +14,7 @@ from app.db.models import (
     EmojiDensity,
     FeedbackRating,
     Length,
+    MediaKind,
     PlanStatus,
     PostStatus,
     PostType,
@@ -135,6 +136,7 @@ class PostOut(BaseModel):
     text: str
     image_url: str | None
     image_prompt: str | None
+    media_asset_id: int | None = None
     first_comment: str | None
     cta_url: str | None
     scheduled_for: datetime | None
@@ -188,10 +190,52 @@ class FeedbackOut(BaseModel):
 class MediaUploadOut(BaseModel):
     """Returned after a successful /api/media/upload."""
 
+    id: int
     url: str  # relative to backend root, e.g. "/static/images/uploads/abc.png"
     filename: str
     mime: str
     size_bytes: int
+    width: int | None = None
+    height: int | None = None
+
+
+class MediaAssetOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    kind: MediaKind
+    mime: str
+    local_path: str
+    filename: str
+    size_bytes: int
+    width: int | None
+    height: int | None
+    duration_sec: float | None
+    ai_caption: str | None
+    ai_tags: list[str]
+    tags_user: list[str]
+    tagged_at: datetime | None
+    created_at: datetime
+
+    @property
+    def url(self) -> str:
+        return f"/static/{self.local_path}"
+
+
+class MediaAssetPatch(BaseModel):
+    tags_user: list[str] | None = None
+    ai_caption: str | None = None
+
+
+class MediaTagResult(BaseModel):
+    caption: str
+    tags: list[str]
+    cost_usd: float
+
+
+class MediaSuggestion(BaseModel):
+    asset: MediaAssetOut
+    score: float
 
 
 # ---------- Status ----------
@@ -220,6 +264,7 @@ class PlanSlotOut(BaseModel):
     rationale: str | None
     status: SlotStatus
     post_id: int | None
+    media_asset_id: int | None = None
     notes: str | None
     created_at: datetime
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -19,6 +19,7 @@ from app.db.models import (
     PostStatus,
     PostType,
     SlotStatus,
+    TargetReviewStatus,
     Tone,
 )
 
@@ -65,6 +66,9 @@ class TargetIn(BaseModel):
     list_name: str | None = None
     member_count: int | None = None
     active: bool = True
+    description_snippet: str | None = None
+    category: str | None = None
+    source: str = "manual"
 
 
 class TargetPatch(BaseModel):
@@ -73,6 +77,9 @@ class TargetPatch(BaseModel):
     list_name: str | None = None
     member_count: int | None = None
     active: bool | None = None
+    description_snippet: str | None = None
+    category: str | None = None
+    review_status: TargetReviewStatus | None = None
 
 
 class TargetOut(TargetIn):
@@ -80,6 +87,56 @@ class TargetOut(TargetIn):
 
     id: int
     created_at: datetime
+    relevance_score: int | None = None
+    ai_reasoning: str | None = None
+    review_status: TargetReviewStatus = TargetReviewStatus.PENDING
+
+
+# ---------- M3: Target Agent ----------
+
+
+class TargetDiscoverResult(BaseModel):
+    created: int
+    updated: int
+    targets: list[TargetOut]
+
+
+class TargetScoreRequest(BaseModel):
+    """Score a specific subset. Empty = score all unscored pending targets."""
+
+    target_ids: list[int] = Field(default_factory=list)
+
+
+class TargetScoreItem(BaseModel):
+    target_id: int
+    score: int
+    reasoning: str
+
+
+class TargetScoreResponse(BaseModel):
+    scored: list[TargetScoreItem]
+    cost_usd: float
+
+
+class TargetClusterRequest(BaseModel):
+    """Cluster approved targets. Empty `target_ids` = all approved."""
+
+    target_ids: list[int] = Field(default_factory=list)
+
+
+class TargetClusterGroup(BaseModel):
+    list_name: str
+    target_ids: list[int]
+
+
+class TargetClusterResponse(BaseModel):
+    lists: list[TargetClusterGroup]
+    cost_usd: float
+
+
+class TargetBulkReviewRequest(BaseModel):
+    target_ids: list[int]
+    review_status: TargetReviewStatus
 
 
 # ---------- Post ----------

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -1,0 +1,191 @@
+"""Security helpers — PIN auth + Fernet-at-rest encryption.
+
+## PIN auth
+Single-user localhost tool. We ship a single shared PIN (env `DASHBOARD_PIN`,
+blank = disabled). Requests to `/api/*` carry the PIN via the
+`X-Dashboard-Pin` header OR a signed cookie the dashboard sets after
+`POST /api/auth/login`.
+
+The auth surface is deliberately narrow — this is a hobby tool meant to run on
+`localhost:8787`. We do NOT claim to be safe on a public interface; if you
+expose the dashboard through a tunnel, run it behind nginx + basic auth or a
+proper auth proxy.
+
+## Fernet encryption
+Long-lived OAuth tokens (`PlatformCredential.access_token`) and API keys
+should not be stored as plaintext in the SQLite file. We derive a Fernet key
+from `BACKUP_FERNET_KEY` (or a file inside `data/` we generate on first boot)
+and expose `encrypt_str` / `decrypt_str` helpers. Backwards-compatible: a
+value that fails to decrypt is returned as-is (assumed pre-encryption
+plaintext), so existing data keeps working while migration happens
+opportunistically on next write.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import logging
+import os
+import secrets
+from pathlib import Path
+
+from cryptography.fernet import Fernet, InvalidToken
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from app.config import settings
+
+log = logging.getLogger("security")
+
+
+# ---------- Fernet at rest ----------
+
+
+_FERNET_KEY_FILE = Path("data/.fernet.key")
+
+
+def _load_or_create_fernet_key() -> bytes:
+    """Priority: settings.fernet_key env → data/.fernet.key file → generate."""
+    env_key = settings.fernet_key.strip() if settings.fernet_key else ""
+    if env_key:
+        return env_key.encode("ascii")
+    if _FERNET_KEY_FILE.exists():
+        return _FERNET_KEY_FILE.read_bytes().strip()
+    _FERNET_KEY_FILE.parent.mkdir(parents=True, exist_ok=True)
+    key = Fernet.generate_key()
+    _FERNET_KEY_FILE.write_bytes(key)
+    # tighten perms — only current user can read.
+    try:
+        os.chmod(_FERNET_KEY_FILE, 0o600)
+    except OSError:
+        pass
+    log.warning(
+        "Generated a new Fernet key at %s. Back it up — losing it makes "
+        "encrypted values unrecoverable.",
+        _FERNET_KEY_FILE,
+    )
+    return key
+
+
+_fernet: Fernet | None = None
+
+
+def fernet() -> Fernet:
+    global _fernet
+    if _fernet is None:
+        _fernet = Fernet(_load_or_create_fernet_key())
+    return _fernet
+
+
+_FERNET_PREFIX = "fernet:v1:"
+
+
+def encrypt_str(plain: str) -> str:
+    """Encrypt and tag with a prefix so we can distinguish from legacy
+    plaintext on read.
+    """
+    if not plain:
+        return plain
+    if plain.startswith(_FERNET_PREFIX):
+        return plain  # already encrypted
+    token = fernet().encrypt(plain.encode("utf-8")).decode("ascii")
+    return f"{_FERNET_PREFIX}{token}"
+
+
+def decrypt_str(value: str) -> str:
+    """Decrypt if prefix is present; otherwise return as-is (legacy)."""
+    if not value or not value.startswith(_FERNET_PREFIX):
+        return value
+    token = value[len(_FERNET_PREFIX):]
+    try:
+        return fernet().decrypt(token.encode("ascii")).decode("utf-8")
+    except InvalidToken:
+        log.error("Fernet token failed to decrypt — wrong key?")
+        return value
+
+
+# ---------- PIN auth ----------
+
+
+# Paths that never require the PIN. Keep this tiny.
+_PUBLIC_PATHS = {
+    "/",
+    "/healthz",
+    "/api/status",
+    "/api/auth/login",
+    "/api/auth/status",
+    "/api/meta/oauth/callback",  # Meta redirects hit this directly
+}
+
+# Path prefixes that bypass auth.
+_PUBLIC_PREFIXES = ("/static/", "/ws/")
+
+_COOKIE_NAME = "dashboard_session"
+_COOKIE_MAX_AGE = 60 * 60 * 24 * 30  # 30 days
+
+
+def _hmac_sign(pin: str) -> str:
+    """Short opaque session cookie. It's just HMAC(pin) — anyone with the PIN
+    can forge it, but they already have the PIN, so that's fine.
+    """
+    mac = hmac.new(pin.encode("utf-8"), b"dashboard-session", hashlib.sha256).digest()
+    return base64.urlsafe_b64encode(mac).decode("ascii").rstrip("=")
+
+
+def _verify_session(cookie_value: str, pin: str) -> bool:
+    return hmac.compare_digest(cookie_value, _hmac_sign(pin))
+
+
+def _is_public(path: str) -> bool:
+    if path in _PUBLIC_PATHS:
+        return True
+    return any(path.startswith(p) for p in _PUBLIC_PREFIXES)
+
+
+class DashboardAuthMiddleware(BaseHTTPMiddleware):
+    """Blocks /api/* unless the request is authenticated.
+
+    Disabled entirely when `settings.dashboard_pin` is empty (dev default).
+    Accepts either an `X-Dashboard-Pin` header matching the configured PIN or
+    a valid `dashboard_session` cookie (set by /api/auth/login).
+    """
+
+    async def dispatch(self, request: Request, call_next):
+        pin = settings.dashboard_pin.strip()
+        if not pin:
+            return await call_next(request)  # auth disabled
+        path = request.url.path
+        if _is_public(path) or not path.startswith("/api/"):
+            return await call_next(request)
+        # CORS preflight needs to go through (OPTIONS gets handled by the CORS
+        # middleware which runs first, but some reverse proxies strip it).
+        if request.method == "OPTIONS":
+            return await call_next(request)
+
+        header = request.headers.get("X-Dashboard-Pin", "")
+        if header and hmac.compare_digest(header, pin):
+            return await call_next(request)
+        cookie = request.cookies.get(_COOKIE_NAME, "")
+        if cookie and _verify_session(cookie, pin):
+            return await call_next(request)
+        return JSONResponse(
+            status_code=401,
+            content={"detail": "Authentication required"},
+        )
+
+
+def make_session_cookie(pin: str) -> str:
+    return _hmac_sign(pin)
+
+
+def verify_pin(candidate: str) -> bool:
+    pin = settings.dashboard_pin.strip()
+    if not pin:
+        return True
+    return hmac.compare_digest(candidate or "", pin)
+
+
+def new_request_id() -> str:
+    return secrets.token_hex(8)

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,0 +1,1 @@
+"""Backend services — cross-cutting logic outside the api/agents/platforms layers."""

--- a/backend/app/services/backups.py
+++ b/backend/app/services/backups.py
@@ -1,0 +1,94 @@
+"""Daily backup — zip the SQLite DB + media assets to `settings.backup_dir`.
+
+The scheduler calls `run_backup()` once a day (cron 03:00 UTC). We keep the
+last N archives (`settings.backup_keep_days`) and prune older ones.
+
+Backup layout:
+    data/backups/autoposter-2026-04-19T03-00-00Z.zip
+        ├─ app.db
+        └─ images/...        (only if `data/images` exists)
+
+SQLite needs a consistent snapshot — we use the `.backup` method via a direct
+sqlite3 connection, which works while the app is running.
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+import time
+import zipfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+from app.config import settings
+
+log = logging.getLogger("services.backups")
+
+
+def _iter_files(root: Path):
+    for p in root.rglob("*"):
+        if p.is_file():
+            yield p
+
+
+def _sqlite_path() -> Path:
+    """Resolve the SQLite DB path from the db_url. Supports
+    `sqlite:///./data/app.db` and absolute forms.
+    """
+    url = settings.db_url
+    if not url.startswith("sqlite"):
+        raise RuntimeError(f"Backups only support sqlite; got {url}")
+    # Strip sqlite:///, keep whatever's left. The triple slash convention
+    # means a relative path starts with "./".
+    remainder = url.split("sqlite:///", 1)[-1]
+    return Path(remainder).resolve()
+
+
+def run_backup() -> Path:
+    """Create a zip archive and return its path."""
+    backup_root = Path(settings.backup_dir)
+    backup_root.mkdir(parents=True, exist_ok=True)
+
+    stamp = datetime.now(UTC).strftime("%Y-%m-%dT%H-%M-%SZ")
+    out_path = backup_root / f"autoposter-{stamp}.zip"
+
+    db_path = _sqlite_path()
+    # Use sqlite .backup for a consistent snapshot. Connect read-only via URI.
+    snap_path = backup_root / f".{stamp}-app.db"
+    src = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    dst = sqlite3.connect(str(snap_path))
+    try:
+        with dst:
+            src.backup(dst)
+    finally:
+        src.close()
+        dst.close()
+
+    images = Path("data/images")
+    with zipfile.ZipFile(out_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.write(snap_path, arcname="app.db")
+        if images.exists():
+            for f in _iter_files(images):
+                zf.write(f, arcname=str(f.relative_to(Path("data"))))
+    try:
+        snap_path.unlink()
+    except OSError:
+        pass
+
+    prune_old_backups(backup_root)
+    log.info("Backup written to %s (%.1f MB)", out_path, out_path.stat().st_size / 1e6)
+    return out_path
+
+
+def prune_old_backups(root: Path) -> int:
+    """Delete archives older than `settings.backup_keep_days`. Returns count."""
+    cutoff = time.time() - settings.backup_keep_days * 24 * 3600
+    pruned = 0
+    for p in root.glob("autoposter-*.zip"):
+        try:
+            if p.stat().st_mtime < cutoff:
+                p.unlink()
+                pruned += 1
+        except OSError:
+            continue
+    return pruned

--- a/backend/app/services/few_shot.py
+++ b/backend/app/services/few_shot.py
@@ -1,0 +1,97 @@
+"""Few-shot example store.
+
+We maintain a curated set of top-performing posts per post_type. The Writer
+pulls from this store (instead of just thumbs-up posts) so the examples are
+based on real engagement, not user opinion.
+
+Refresh policy: keep the top N per post_type ranked by highest PostMetrics
+engagement_score across any window. Called by the scheduler weekly; also via
+`/api/analyst/generate` as a side-effect.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.db.models import (
+    FewShotExample,
+    Post,
+    PostMetrics,
+    PostStatus,
+    PostType,
+    PostVariant,
+)
+
+
+# How many examples to keep per post_type. 3 is plenty — more dilutes voice.
+DEFAULT_PER_TYPE = 3
+
+
+def _best_score_per_post(db: Session) -> dict[int, float]:
+    """Max engagement_score across any window for each POSTED post."""
+    rows = (
+        db.query(
+            PostVariant.post_id,
+            func.max(PostMetrics.engagement_score),
+        )
+        .join(PostMetrics, PostMetrics.variant_id == PostVariant.id)
+        .group_by(PostVariant.post_id)
+        .all()
+    )
+    return {post_id: float(score or 0.0) for post_id, score in rows}
+
+
+def refresh_few_shot_store(db: Session, per_type: int = DEFAULT_PER_TYPE) -> int:
+    """Recompute and replace the FewShotExample store. Returns rows inserted."""
+    scores = _best_score_per_post(db)
+    if not scores:
+        return 0
+
+    # Fetch posts we have scores for.
+    post_ids = list(scores.keys())
+    posts: list[Post] = (
+        db.query(Post)
+        .filter(Post.id.in_(post_ids))
+        .filter(Post.status == PostStatus.POSTED)
+        .all()
+    )
+    by_type: dict[PostType, list[tuple[Post, float]]] = defaultdict(list)
+    for post in posts:
+        by_type[post.post_type].append((post, scores.get(post.id, 0.0)))
+
+    # Nuke old store; a fresh rewrite is simpler and low cost at v1 scale.
+    db.query(FewShotExample).delete()
+    inserted = 0
+    for post_type, items in by_type.items():
+        items.sort(key=lambda x: x[1], reverse=True)
+        for post, score in items[:per_type]:
+            db.add(
+                FewShotExample(
+                    post_id=post.id,
+                    post_type=post_type,
+                    text=post.text,
+                    engagement_score=score,
+                )
+            )
+            inserted += 1
+    db.commit()
+    return inserted
+
+
+def fetch_few_shot_examples(
+    db: Session, post_type: PostType, limit: int = 3
+) -> list[str]:
+    """Pull examples for a given post_type ranked by engagement_score.
+
+    Falls back to an empty list — the Writer simply skips the few-shot prefix.
+    """
+    rows = (
+        db.query(FewShotExample)
+        .filter(FewShotExample.post_type == post_type)
+        .order_by(FewShotExample.engagement_score.desc())
+        .limit(limit)
+        .all()
+    )
+    return [r.text for r in rows]

--- a/backend/app/services/humanizer.py
+++ b/backend/app/services/humanizer.py
@@ -1,0 +1,217 @@
+"""Humanizer service (M4).
+
+Central place for the "pretend to be a human" logic that lives on the backend:
+
+- `get_or_create_profile()` — singleton access.
+- `apply_schedule_jitter(when)` — ±N minutes of random offset on scheduled_for.
+- `in_blackout(when)` — returns the BlackoutDate that blocks `when`, if any.
+- `on_failure(platform_id, reason)` / `on_success(platform_id)` — adjust
+  SessionHealth and, if the failure counter crosses the threshold, activate the
+  smart pause.
+- `check_pause(now)` — is the system currently paused? Returns the end-time
+  of the pause if so.
+- `detect_checkpoint(reason)` — classify a variant's error string as a FB
+  auth challenge / shadow-ban suspicion / unrelated transient.
+
+All functions are sync (plain Session) so they compose with the existing
+synchronous SQLAlchemy setup.
+"""
+from __future__ import annotations
+
+import logging
+import random
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy.orm import Session
+
+from app.db.models import (
+    BlackoutDate,
+    HumanizerProfile,
+    SessionHealth,
+    SessionHealthStatus,
+)
+
+log = logging.getLogger("services.humanizer")
+
+
+# Patterns the extension reports when FB shows an auth / captcha screen.
+CHECKPOINT_PATTERNS = (
+    re.compile(r"checkpoint", re.I),
+    re.compile(r"captcha", re.I),
+    re.compile(r"re.?enter.*password", re.I),
+    re.compile(r"two.?factor|2fa", re.I),
+    re.compile(r"\bconfirm your identity\b", re.I),
+)
+
+SHADOW_BAN_PATTERNS = (
+    re.compile(r"unavailable", re.I),
+    re.compile(r"restricted", re.I),
+    re.compile(r"temporarily blocked", re.I),
+    re.compile(r"violat", re.I),
+)
+
+
+@dataclass
+class FailureClassification:
+    kind: str  # "checkpoint" | "shadow_ban" | "unknown"
+    raw: str
+
+
+def classify_failure(error: str | None) -> FailureClassification:
+    if not error:
+        return FailureClassification(kind="unknown", raw="")
+    for p in CHECKPOINT_PATTERNS:
+        if p.search(error):
+            return FailureClassification(kind="checkpoint", raw=error)
+    for p in SHADOW_BAN_PATTERNS:
+        if p.search(error):
+            return FailureClassification(kind="shadow_ban", raw=error)
+    return FailureClassification(kind="unknown", raw=error)
+
+
+def get_or_create_profile(db: Session) -> HumanizerProfile:
+    row = db.query(HumanizerProfile).first()
+    if row is not None:
+        return row
+    row = HumanizerProfile()
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def apply_schedule_jitter(when: datetime, profile: HumanizerProfile) -> datetime:
+    """Return a new datetime within ±jitter_minutes of `when`.
+
+    Falls back to `when` unchanged when jitter is 0 (useful in tests).
+    """
+    j = max(0, profile.schedule_jitter_minutes)
+    if j == 0:
+        return when
+    offset_sec = random.randint(-j * 60, j * 60)
+    return when + timedelta(seconds=offset_sec)
+
+
+def in_blackout(db: Session, when: datetime) -> BlackoutDate | None:
+    """Return the BlackoutDate covering `when`, if any. We consider it a match if
+    the blackout row's date is the same calendar day (UTC)."""
+    day_start = when.replace(hour=0, minute=0, second=0, microsecond=0)
+    day_end = day_start + timedelta(days=1)
+    return (
+        db.query(BlackoutDate)
+        .filter(BlackoutDate.date >= day_start)
+        .filter(BlackoutDate.date < day_end)
+        .first()
+    )
+
+
+def _get_health(db: Session, platform_id: str) -> SessionHealth:
+    row = (
+        db.query(SessionHealth)
+        .filter(SessionHealth.platform_id == platform_id)
+        .first()
+    )
+    if row is None:
+        row = SessionHealth(platform_id=platform_id)
+        db.add(row)
+        db.flush()
+    return row
+
+
+def on_success(db: Session, platform_id: str) -> SessionHealth:
+    health = _get_health(db, platform_id)
+    health.consecutive_failures = 0
+    health.status = SessionHealthStatus.HEALTHY
+    health.last_success_at = datetime.now(UTC)
+    db.commit()
+    return health
+
+
+def on_failure(
+    db: Session,
+    platform_id: str,
+    reason: str,
+) -> tuple[SessionHealth, HumanizerProfile]:
+    """Record a failure. If the counter reaches the threshold OR we detect a
+    checkpoint / shadow-ban signal, activate the smart pause."""
+    profile = get_or_create_profile(db)
+    health = _get_health(db, platform_id)
+    health.consecutive_failures += 1
+    health.last_failure_at = datetime.now(UTC)
+    health.last_failure_reason = reason
+
+    classification = classify_failure(reason)
+    if classification.kind == "checkpoint":
+        health.status = SessionHealthStatus.CHECKPOINT
+        _activate_pause(profile, reason=f"checkpoint detected: {reason[:200]}")
+    elif classification.kind == "shadow_ban":
+        health.status = SessionHealthStatus.SHADOW_BAN_SUSPECTED
+        _activate_pause(profile, reason=f"shadow-ban pattern: {reason[:200]}")
+    elif health.consecutive_failures >= profile.consecutive_failures_threshold:
+        health.status = SessionHealthStatus.PAUSED
+        _activate_pause(
+            profile,
+            reason=(
+                f"{health.consecutive_failures} consecutive failures "
+                f"(threshold {profile.consecutive_failures_threshold})"
+            ),
+        )
+    else:
+        health.status = SessionHealthStatus.WARNING
+
+    db.commit()
+    return health, profile
+
+
+def _activate_pause(profile: HumanizerProfile, reason: str) -> None:
+    profile.smart_pause_until = datetime.now(UTC) + timedelta(
+        minutes=profile.smart_pause_minutes
+    )
+    profile.smart_pause_reason = reason
+    log.warning(
+        "Smart pause activated: %s (until %s)", reason, profile.smart_pause_until
+    )
+
+
+def check_pause(db: Session, now: datetime | None = None) -> datetime | None:
+    """Return the pause end-time if we're currently paused, else None."""
+    profile = get_or_create_profile(db)
+    now = now or datetime.now(UTC)
+    if profile.smart_pause_until is None:
+        return None
+    pause_until = profile.smart_pause_until
+    if pause_until.tzinfo is None:
+        pause_until = pause_until.replace(tzinfo=UTC)
+    if pause_until > now:
+        return pause_until
+    # Pause expired — auto-clear.
+    profile.smart_pause_until = None
+    profile.smart_pause_reason = None
+    db.commit()
+    return None
+
+
+def clear_pause(db: Session) -> None:
+    profile = get_or_create_profile(db)
+    profile.smart_pause_until = None
+    profile.smart_pause_reason = None
+    db.commit()
+
+
+def humanizer_config_for_extension(profile: HumanizerProfile) -> dict:
+    """Serialize the subset of knobs the extension's content script cares about.
+
+    Kept JSON-friendly so it ships verbatim via the publish command.
+    """
+    return {
+        "typing_wpm_min": profile.typing_wpm_min,
+        "typing_wpm_max": profile.typing_wpm_max,
+        "mistake_rate": profile.mistake_rate,
+        "pause_between_sentences_ms_min": profile.pause_between_sentences_ms_min,
+        "pause_between_sentences_ms_max": profile.pause_between_sentences_ms_max,
+        "mouse_path_curvature": profile.mouse_path_curvature,
+        "idle_scroll_before_post_sec_min": profile.idle_scroll_before_post_sec_min,
+        "idle_scroll_before_post_sec_max": profile.idle_scroll_before_post_sec_max,
+    }

--- a/backend/app/services/metrics.py
+++ b/backend/app/services/metrics.py
@@ -26,7 +26,7 @@ from app.db.models import (
     PostVariant,
     Target,
 )
-from app.platforms.facebook import FacebookPlatform
+from app.platforms.registry import get_platform
 
 log = logging.getLogger("services.metrics")
 
@@ -49,11 +49,9 @@ def compute_engagement_score(
     return float(likes) + 2.0 * float(comments) + 3.0 * float(shares)
 
 
-def _platform_for(platform_id: str):
-    """Factory. Keep small; real multi-platform dispatch lives in registry."""
-    if platform_id == "facebook":
-        return FacebookPlatform()
-    return None
+def _platform_for(platform_id: str, db: Session | None = None):
+    """Resolve a platform instance via the shared registry."""
+    return get_platform(platform_id, db=db)
 
 
 def _pending_windows(variant: PostVariant, existing: set[MetricsWindow]) -> list[MetricsWindow]:
@@ -97,7 +95,7 @@ async def collect_for_variant(
     target = db.get(Target, variant.target_id)
     if target is None:
         return []
-    platform = _platform_for(target.platform_id)
+    platform = _platform_for(target.platform_id, db=db)
     if platform is None:
         log.info(
             "No metrics fetcher for platform %s (variant %s)",

--- a/backend/app/services/metrics.py
+++ b/backend/app/services/metrics.py
@@ -1,0 +1,154 @@
+"""Metrics collection service.
+
+One row per (variant, window). Windows are fixed buckets — 1h, 24h, 7d — so
+Analyst comparisons stay apples-to-apples.
+
+A tick is scheduled hourly. For each POSTED variant:
+- compute age since `posted_at`
+- pick the next un-collected window whose threshold has been crossed
+- fetch metrics from the platform and write a PostMetrics row.
+
+Scoring: `engagement_score = likes + 2*comments + 3*shares`. Shares weigh most
+because they require effort; comments more than passive likes. Reach is stored
+but not yet mixed in — too platform-dependent to normalize naively.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy.orm import Session
+
+from app.db.models import (
+    MetricsWindow,
+    PostMetrics,
+    PostStatus,
+    PostVariant,
+    Target,
+)
+from app.platforms.facebook import FacebookPlatform
+
+log = logging.getLogger("services.metrics")
+
+
+# How old a variant must be before we collect that window.
+WINDOW_THRESHOLDS: dict[MetricsWindow, timedelta] = {
+    MetricsWindow.ONE_HOUR: timedelta(hours=1),
+    MetricsWindow.ONE_DAY: timedelta(hours=24),
+    MetricsWindow.SEVEN_DAY: timedelta(days=7),
+}
+
+# After this age we stop polling — a 10-day-old post isn't going to budge
+# numbers in a meaningful way and we'd just burn extension cycles.
+MAX_AGE = timedelta(days=10)
+
+
+def compute_engagement_score(
+    likes: int, comments: int, shares: int
+) -> float:
+    return float(likes) + 2.0 * float(comments) + 3.0 * float(shares)
+
+
+def _platform_for(platform_id: str):
+    """Factory. Keep small; real multi-platform dispatch lives in registry."""
+    if platform_id == "facebook":
+        return FacebookPlatform()
+    return None
+
+
+def _pending_windows(variant: PostVariant, existing: set[MetricsWindow]) -> list[MetricsWindow]:
+    if variant.posted_at is None:
+        return []
+    posted_at = variant.posted_at
+    # Normalize to UTC-aware for arithmetic.
+    if posted_at.tzinfo is None:
+        posted_at = posted_at.replace(tzinfo=UTC)
+    age = datetime.now(UTC) - posted_at
+    if age > MAX_AGE:
+        return []
+    out = []
+    for window, threshold in WINDOW_THRESHOLDS.items():
+        if window in existing:
+            continue
+        if age >= threshold:
+            out.append(window)
+    return out
+
+
+async def collect_for_variant(
+    db: Session,
+    variant: PostVariant,
+) -> list[PostMetrics]:
+    """Collect any due windows for a single variant. Returns new rows.
+
+    Re-entrant: skips windows already captured. Quiet on platform errors — the
+    next tick will retry.
+    """
+    if variant.status != PostStatus.POSTED or not variant.external_post_id:
+        return []
+    existing = {
+        row.window
+        for row in db.query(PostMetrics).filter(PostMetrics.variant_id == variant.id).all()
+    }
+    windows = _pending_windows(variant, existing)
+    if not windows:
+        return []
+
+    target = db.get(Target, variant.target_id)
+    if target is None:
+        return []
+    platform = _platform_for(target.platform_id)
+    if platform is None:
+        log.info(
+            "No metrics fetcher for platform %s (variant %s)",
+            target.platform_id,
+            variant.id,
+        )
+        return []
+
+    try:
+        raw = await platform.fetch_metrics(variant.external_post_id)
+    except Exception as exc:
+        log.warning("fetch_metrics failed for variant %s: %s", variant.id, exc)
+        return []
+    if raw is None:
+        return []
+
+    likes = int(raw.get("likes") or 0)
+    comments = int(raw.get("comments") or 0)
+    shares = int(raw.get("shares") or 0)
+    reach = raw.get("reach")
+    score = compute_engagement_score(likes, comments, shares)
+    new_rows: list[PostMetrics] = []
+    for window in windows:
+        row = PostMetrics(
+            variant_id=variant.id,
+            window=window,
+            likes=likes,
+            comments=comments,
+            shares=shares,
+            reach=reach,
+            engagement_score=score,
+        )
+        db.add(row)
+        new_rows.append(row)
+    db.commit()
+    return new_rows
+
+
+async def collect_metrics(db: Session) -> dict:
+    """Run a full metrics-collection pass. Returns simple counters for logging."""
+    candidates: list[PostVariant] = (
+        db.query(PostVariant)
+        .filter(PostVariant.status == PostStatus.POSTED)
+        .filter(PostVariant.external_post_id.is_not(None))
+        .all()
+    )
+    collected = 0
+    variants_touched = 0
+    for variant in candidates:
+        rows = await collect_for_variant(db, variant)
+        if rows:
+            variants_touched += 1
+            collected += len(rows)
+    return {"variants_touched": variants_touched, "rows_created": collected}

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -2,7 +2,7 @@
 name = "pilotposter-clone-backend"
 version = "0.1.0"
 description = "Self-hosted AI social media poster"
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.115",
     "uvicorn[standard]>=0.32",
@@ -40,7 +40,11 @@ include = ["app*"]
 
 [tool.ruff]
 line-length = 100
-target-version = "py312"
+target-version = "py311"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "W", "B", "UP"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -21,6 +21,8 @@ dependencies = [
     "beautifulsoup4>=4.12",
     "python-multipart>=0.0.12",
     "aiosqlite>=0.20",
+    "Pillow>=10.4",
+    "cryptography>=43.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,64 @@
+"""Shared test fixtures.
+
+- Use an in-memory SQLite per test run — no touching the real data/app.db.
+- Stub out the APScheduler in main.lifespan (no background ticks during tests).
+- Provide a FastAPI TestClient with the DB dependency pointing at our in-mem engine.
+"""
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.db import session as db_session
+from app.db.models import Base
+
+
+@pytest.fixture()
+def engine():
+    eng = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        future=True,
+    )
+    Base.metadata.create_all(eng)
+    yield eng
+    eng.dispose()
+
+
+@pytest.fixture()
+def session_maker(engine):
+    return sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+
+@pytest.fixture()
+def db(session_maker) -> Iterator[Session]:
+    s = session_maker()
+    try:
+        yield s
+    finally:
+        s.close()
+
+
+@pytest.fixture()
+def client(engine, session_maker, monkeypatch) -> Iterator[TestClient]:
+    # Swap the module-level SessionLocal that get_session pulls from.
+    monkeypatch.setattr(db_session, "engine", engine, raising=True)
+    monkeypatch.setattr(db_session, "SessionLocal", session_maker, raising=True)
+
+    # Stub scheduler so lifespan doesn't spawn background jobs.
+    from app.scheduler import scheduler as app_scheduler
+
+    monkeypatch.setattr(app_scheduler, "start", lambda: None, raising=False)
+    monkeypatch.setattr(app_scheduler, "shutdown", lambda wait=False: None, raising=False)
+
+    # Import app AFTER patches so its dependencies resolve against the test engine.
+    from app.main import app
+
+    with TestClient(app) as c:
+        yield c

--- a/backend/tests/test_analyst_flow.py
+++ b/backend/tests/test_analyst_flow.py
@@ -1,0 +1,434 @@
+"""M6 — Metrics + Analyst + Optimizer + Few-shot store.
+
+We mock the platform's `fetch_metrics` and the Anthropic call in the Analyst
+agent so tests don't hit external services. Coverage:
+
+- engagement_score formula
+- collect_metrics picks the right windows as the variant ages
+- MAX_AGE cutoff
+- top/bottom performers endpoint
+- analyst output → AnalystReport + OptimizerProposal rows
+- auto-apply eligible proposals flip the BusinessProfile
+- proposal apply/reject endpoints
+- few-shot store refresh picks top N per post_type
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.agents import analyst as analyst_agent
+from app.db.models import (
+    BusinessProfile,
+    FewShotExample,
+    MetricsWindow,
+    OptimizerProposal,
+    Post,
+    PostMetrics,
+    PostStatus,
+    PostType,
+    PostVariant,
+    ProposalStatus,
+    Target,
+)
+from app.services import few_shot, metrics as metrics_service
+
+
+# ---------- helpers ----------
+
+
+def _create_profile(db):
+    profile = BusinessProfile(
+        name="Acme",
+        description="We make things.",
+        review_before_posting=False,
+        posting_window_start_hour=9,
+        posting_window_end_hour=20,
+        posts_per_day=3,
+        post_type_ratios={"informative": 0.5, "hard_sell": 0.3, "engagement": 0.2},
+    )
+    db.add(profile)
+    db.commit()
+    db.refresh(profile)
+    return profile
+
+
+def _create_target(db, name="Group X"):
+    t = Target(
+        platform_id="facebook",
+        external_id=f"https://www.facebook.com/groups/{name.lower().replace(' ', '')}",
+        name=name,
+    )
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t
+
+
+def _posted_variant(db, target, post_type=PostType.INFORMATIVE, posted_ago: timedelta = timedelta(hours=2)):
+    post = Post(
+        post_type=post_type,
+        status=PostStatus.POSTED,
+        text=f"A post about {post_type.value}.",
+        posted_at=datetime.now(UTC) - posted_ago,
+    )
+    db.add(post)
+    db.flush()
+    variant = PostVariant(
+        post_id=post.id,
+        target_id=target.id,
+        text=post.text,
+        status=PostStatus.POSTED,
+        posted_at=post.posted_at,
+        external_post_id=f"https://www.facebook.com/groups/fake/posts/{post.id}",
+    )
+    db.add(variant)
+    db.commit()
+    db.refresh(variant)
+    return post, variant
+
+
+# ---------- tests ----------
+
+
+def test_engagement_score_formula():
+    assert metrics_service.compute_engagement_score(0, 0, 0) == 0
+    assert metrics_service.compute_engagement_score(10, 0, 0) == 10
+    assert metrics_service.compute_engagement_score(0, 5, 0) == 10
+    assert metrics_service.compute_engagement_score(0, 0, 3) == 9
+    assert metrics_service.compute_engagement_score(10, 2, 1) == 17
+
+
+@pytest.mark.asyncio
+async def test_collect_metrics_writes_one_hour_row(db):
+    profile = _create_profile(db)  # noqa: F841
+    t = _create_target(db)
+    _post, variant = _posted_variant(db, t, posted_ago=timedelta(hours=2))
+
+    async def fake_fetch(self, external_post_id):
+        return {"likes": 10, "comments": 2, "shares": 1, "reach": None}
+
+    with patch(
+        "app.services.metrics.FacebookPlatform.fetch_metrics",
+        new=fake_fetch,
+    ):
+        result = await metrics_service.collect_metrics(db)
+
+    assert result["variants_touched"] == 1
+    # At 2h old, only the 1h window is due (24h, 7d still pending).
+    rows = db.query(PostMetrics).filter(PostMetrics.variant_id == variant.id).all()
+    assert len(rows) == 1
+    assert rows[0].window == MetricsWindow.ONE_HOUR
+    assert rows[0].likes == 10
+    assert rows[0].engagement_score == 17  # 10 + 2*2 + 3*1
+
+
+@pytest.mark.asyncio
+async def test_collect_metrics_idempotent(db):
+    _create_profile(db)
+    t = _create_target(db)
+    _, variant = _posted_variant(db, t, posted_ago=timedelta(hours=3))
+
+    async def fake_fetch(self, external_post_id):
+        return {"likes": 5, "comments": 1, "shares": 0, "reach": None}
+
+    with patch("app.services.metrics.FacebookPlatform.fetch_metrics", new=fake_fetch):
+        await metrics_service.collect_metrics(db)
+        await metrics_service.collect_metrics(db)  # second call — no new rows
+
+    rows = db.query(PostMetrics).filter(PostMetrics.variant_id == variant.id).all()
+    assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_collect_metrics_respects_max_age(db):
+    _create_profile(db)
+    t = _create_target(db)
+    _, variant = _posted_variant(db, t, posted_ago=timedelta(days=30))
+
+    async def fake_fetch(self, external_post_id):
+        return {"likes": 1000}
+
+    with patch("app.services.metrics.FacebookPlatform.fetch_metrics", new=fake_fetch):
+        result = await metrics_service.collect_metrics(db)
+
+    assert result["rows_created"] == 0
+    assert db.query(PostMetrics).count() == 0
+
+
+@pytest.mark.asyncio
+async def test_collect_metrics_multiple_windows_at_8_days(db):
+    _create_profile(db)
+    t = _create_target(db)
+    _, variant = _posted_variant(db, t, posted_ago=timedelta(days=8))
+
+    async def fake_fetch(self, external_post_id):
+        return {"likes": 20, "comments": 4, "shares": 2}
+
+    with patch("app.services.metrics.FacebookPlatform.fetch_metrics", new=fake_fetch):
+        await metrics_service.collect_metrics(db)
+
+    windows = {
+        r.window
+        for r in db.query(PostMetrics).filter(PostMetrics.variant_id == variant.id).all()
+    }
+    assert windows == {
+        MetricsWindow.ONE_HOUR,
+        MetricsWindow.ONE_DAY,
+        MetricsWindow.SEVEN_DAY,
+    }
+
+
+def test_analytics_summary_endpoint(client, db):
+    _create_profile(db)
+    t = _create_target(db)
+    _, variant = _posted_variant(db, t, posted_ago=timedelta(hours=2))
+    row = PostMetrics(
+        variant_id=variant.id,
+        window=MetricsWindow.ONE_HOUR,
+        likes=50,
+        comments=10,
+        shares=2,
+        engagement_score=76,
+    )
+    db.add(row)
+    db.commit()
+
+    r = client.get("/api/analytics/summary?days=7")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["posts"] == 1
+    assert body["likes"] == 50
+    assert body["comments"] == 10
+    assert body["shares"] == 2
+    assert body["avg_engagement_score"] == pytest.approx(76.0)
+
+
+def test_top_performers_endpoint(client, db):
+    _create_profile(db)
+    t = _create_target(db)
+    # Two posts — one strong, one weak.
+    _strong, v_strong = _posted_variant(db, t, posted_ago=timedelta(hours=2))
+    _weak, v_weak = _posted_variant(db, t, posted_ago=timedelta(hours=3))
+
+    db.add(
+        PostMetrics(
+            variant_id=v_strong.id,
+            window=MetricsWindow.ONE_HOUR,
+            likes=100,
+            comments=20,
+            shares=5,
+            engagement_score=155,
+        )
+    )
+    db.add(
+        PostMetrics(
+            variant_id=v_weak.id,
+            window=MetricsWindow.ONE_HOUR,
+            likes=1,
+            comments=0,
+            shares=0,
+            engagement_score=1,
+        )
+    )
+    db.commit()
+
+    r = client.get("/api/analytics/top-performers?limit=2")
+    assert r.status_code == 200
+    body = r.json()
+    assert body[0]["engagement_score"] > body[1]["engagement_score"]
+
+    r_rev = client.get("/api/analytics/top-performers?limit=2&reverse=true")
+    assert r_rev.status_code == 200
+    assert r_rev.json()[0]["engagement_score"] == 1
+
+
+def test_analyst_persist_creates_proposals_and_auto_applies(db):
+    profile = _create_profile(db)
+    period_start = datetime.now(UTC) - timedelta(days=7)
+    period_end = datetime.now(UTC)
+
+    output = analyst_agent.AnalystOutput(
+        summary="Morning slots outperform evening.",
+        body={"summary": "x"},
+        proposals=[
+            # Eligible for auto-apply (safe field + high confidence)
+            analyst_agent.ProposalPayload(
+                field="posting_window_start_hour",
+                current_value=9,
+                proposed_value=10,
+                reasoning="Evidence: 3 of 4 top posts posted >= 10am.",
+                confidence=0.85,
+            ),
+            # Not eligible (confidence below threshold)
+            analyst_agent.ProposalPayload(
+                field="posts_per_day",
+                current_value=3,
+                proposed_value=4,
+                reasoning="Weak signal.",
+                confidence=0.5,
+            ),
+            # Not eligible (tone isn't auto-appliable)
+            analyst_agent.ProposalPayload(
+                field="tone",
+                current_value="casual",
+                proposed_value="professional",
+                reasoning="Hard-sell underperforms casual.",
+                confidence=0.95,
+            ),
+        ],
+        input_tokens=100,
+        output_tokens=200,
+        cost_usd=0.01,
+        model="stub",
+    )
+    report = analyst_agent.persist_report_and_proposals(
+        db, profile, output, period_start, period_end
+    )
+
+    proposals = db.query(OptimizerProposal).filter(OptimizerProposal.report_id == report.id).all()
+    assert len(proposals) == 3
+
+    by_field = {p.field: p for p in proposals}
+    # Auto-applied one
+    assert by_field["posting_window_start_hour"].status == ProposalStatus.APPLIED
+    assert by_field["posting_window_start_hour"].auto_applied is True
+    # Confidence below threshold → pending
+    assert by_field["posts_per_day"].status == ProposalStatus.PENDING
+    # Tone not in AUTO_APPLIABLE_FIELDS → pending
+    assert by_field["tone"].status == ProposalStatus.PENDING
+
+    db.refresh(profile)
+    assert profile.posting_window_start_hour == 10
+    assert profile.posts_per_day == 3  # Unchanged
+    assert profile.tone.value == "casual"  # Unchanged
+
+
+def test_apply_proposal_endpoint(client, db):
+    profile = _create_profile(db)
+    p = OptimizerProposal(
+        field="posts_per_day",
+        current_value={"value": 3},
+        proposed_value={"value": 5},
+        reasoning="test",
+        confidence=0.6,
+        status=ProposalStatus.PENDING,
+    )
+    db.add(p)
+    db.commit()
+    db.refresh(p)
+
+    r = client.post(f"/api/optimizer/proposals/{p.id}/apply")
+    assert r.status_code == 200, r.text
+    assert r.json()["status"] == "applied"
+
+    db.refresh(profile)
+    assert profile.posts_per_day == 5
+
+
+def test_reject_proposal_endpoint(client, db):
+    _create_profile(db)
+    p = OptimizerProposal(
+        field="tone",
+        current_value={"value": "casual"},
+        proposed_value={"value": "fun"},
+        reasoning="test",
+        confidence=0.5,
+        status=ProposalStatus.PENDING,
+    )
+    db.add(p)
+    db.commit()
+
+    r = client.post(f"/api/optimizer/proposals/{p.id}/reject")
+    assert r.status_code == 200
+    assert r.json()["status"] == "rejected"
+
+
+def test_cannot_apply_twice(client, db):
+    _create_profile(db)
+    p = OptimizerProposal(
+        field="posts_per_day",
+        current_value={"value": 3},
+        proposed_value={"value": 4},
+        reasoning="test",
+        confidence=0.6,
+        status=ProposalStatus.APPLIED,
+        applied_at=datetime.now(UTC),
+    )
+    db.add(p)
+    db.commit()
+    r = client.post(f"/api/optimizer/proposals/{p.id}/apply")
+    assert r.status_code == 409
+
+
+def test_few_shot_refresh_ranks_and_trims(db):
+    _create_profile(db)
+    t = _create_target(db)
+    # 5 informative posts with escalating scores.
+    for i in range(5):
+        _, v = _posted_variant(db, t, post_type=PostType.INFORMATIVE, posted_ago=timedelta(hours=2))
+        db.add(
+            PostMetrics(
+                variant_id=v.id,
+                window=MetricsWindow.ONE_HOUR,
+                likes=i * 10,
+                engagement_score=float(i * 10),
+            )
+        )
+    db.commit()
+
+    inserted = few_shot.refresh_few_shot_store(db, per_type=3)
+    assert inserted == 3
+
+    stored = (
+        db.query(FewShotExample)
+        .filter(FewShotExample.post_type == PostType.INFORMATIVE)
+        .order_by(FewShotExample.engagement_score.desc())
+        .all()
+    )
+    assert len(stored) == 3
+    # Only the top 3 by score.
+    assert [s.engagement_score for s in stored] == [40.0, 30.0, 20.0]
+
+
+def test_analyst_generate_endpoint_with_mock(client, db, monkeypatch):
+    _create_profile(db)
+
+    def fake_run_analysis(db_arg, profile, start, end):
+        return analyst_agent.AnalystOutput(
+            summary="Mocked summary.",
+            body={"summary": "Mocked summary.", "proposals": []},
+            proposals=[
+                analyst_agent.ProposalPayload(
+                    field="posting_window_start_hour",
+                    current_value=9,
+                    proposed_value=10,
+                    reasoning="stub",
+                    confidence=0.8,
+                )
+            ],
+            input_tokens=10,
+            output_tokens=20,
+            cost_usd=0.002,
+            model="stub-model",
+        )
+
+    monkeypatch.setattr(
+        "app.api.analytics.analyst_agent.run_analysis",
+        fake_run_analysis,
+    )
+    # Skip few-shot (no posts) — it would return 0 quietly anyway.
+
+    r = client.post("/api/analyst/generate", json={"days": 7})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["summary"] == "Mocked summary."
+    assert body["model"] == "stub-model"
+
+    # Proposal was persisted and auto-applied.
+    proposals = client.get("/api/optimizer/proposals").json()
+    assert len(proposals) == 1
+    assert proposals[0]["status"] == "applied"
+    assert proposals[0]["auto_applied"] is True

--- a/backend/tests/test_analyst_flow.py
+++ b/backend/tests/test_analyst_flow.py
@@ -111,7 +111,7 @@ async def test_collect_metrics_writes_one_hour_row(db):
         return {"likes": 10, "comments": 2, "shares": 1, "reach": None}
 
     with patch(
-        "app.services.metrics.FacebookPlatform.fetch_metrics",
+        "app.platforms.facebook.FacebookPlatform.fetch_metrics",
         new=fake_fetch,
     ):
         result = await metrics_service.collect_metrics(db)
@@ -134,7 +134,7 @@ async def test_collect_metrics_idempotent(db):
     async def fake_fetch(self, external_post_id):
         return {"likes": 5, "comments": 1, "shares": 0, "reach": None}
 
-    with patch("app.services.metrics.FacebookPlatform.fetch_metrics", new=fake_fetch):
+    with patch("app.platforms.facebook.FacebookPlatform.fetch_metrics", new=fake_fetch):
         await metrics_service.collect_metrics(db)
         await metrics_service.collect_metrics(db)  # second call — no new rows
 
@@ -151,7 +151,7 @@ async def test_collect_metrics_respects_max_age(db):
     async def fake_fetch(self, external_post_id):
         return {"likes": 1000}
 
-    with patch("app.services.metrics.FacebookPlatform.fetch_metrics", new=fake_fetch):
+    with patch("app.platforms.facebook.FacebookPlatform.fetch_metrics", new=fake_fetch):
         result = await metrics_service.collect_metrics(db)
 
     assert result["rows_created"] == 0
@@ -167,7 +167,7 @@ async def test_collect_metrics_multiple_windows_at_8_days(db):
     async def fake_fetch(self, external_post_id):
         return {"likes": 20, "comments": 4, "shares": 2}
 
-    with patch("app.services.metrics.FacebookPlatform.fetch_metrics", new=fake_fetch):
+    with patch("app.platforms.facebook.FacebookPlatform.fetch_metrics", new=fake_fetch):
         await metrics_service.collect_metrics(db)
 
     windows = {

--- a/backend/tests/test_api_smoke.py
+++ b/backend/tests/test_api_smoke.py
@@ -163,14 +163,14 @@ def test_full_publish_flow(client, fake_generate_post, fake_spintax):
     post_id = post["id"]
 
     # 4. Publish now — patch FacebookPlatform.publish to avoid touching the bridge.
-    async def fake_publish(self, post, target):
+    async def fake_publish(self, post, target, humanizer=None):
         return PublishResult(
             ok=True,
             external_post_id=f"https://www.facebook.com/groups/{target.id}/posts/fake",
         )
 
     with patch(
-        "app.api.posts.FacebookPlatform.publish",
+        "app.platforms.facebook.FacebookPlatform.publish",
         new=fake_publish,
     ):
         r = client.post(

--- a/backend/tests/test_api_smoke.py
+++ b/backend/tests/test_api_smoke.py
@@ -124,10 +124,14 @@ def test_generate_requires_profile(client, fake_generate_post):
 
 
 def test_full_publish_flow(client, fake_generate_post, fake_spintax):
-    # 1. Profile
+    # 1. Profile — turn off review so generate() returns DRAFT directly
     r = client.put(
         "/api/business-profile",
-        json={"name": "Acme", "description": "We make things."},
+        json={
+            "name": "Acme",
+            "description": "We make things.",
+            "review_before_posting": False,
+        },
     )
     assert r.status_code == 200
 

--- a/backend/tests/test_api_smoke.py
+++ b/backend/tests/test_api_smoke.py
@@ -1,0 +1,285 @@
+"""End-to-end-ish smoke test for the M0 REST surface.
+
+Stubs:
+- Anthropic Claude -> generate_post returns a canned GeneratedPost.
+- Gemini -> generate_image is not called (generate_image=False here).
+- Facebook extension bridge -> FacebookPlatform.publish returns a success dict.
+
+Golden path:
+    PUT /api/business-profile            -> 200, row saved
+    POST /api/targets                    -> 201
+    POST /api/posts/generate             -> 201, draft stored
+    POST /api/posts/{id}/publish         -> 200, variant status=posted
+"""
+from __future__ import annotations
+
+from datetime import UTC
+from unittest.mock import patch
+
+import pytest
+
+from app.ai.content import GeneratedPost
+from app.db.models import PostStatus, PostType
+from app.platforms.base import PublishResult
+
+
+@pytest.fixture()
+def fake_generate_post(monkeypatch):
+    """Replace Claude call with a canned reply — no API key needed."""
+
+    def fake(**kwargs):
+        return GeneratedPost(
+            text="Hey, we just shipped a thing. Check it out.",
+            system_prompt="stub",
+            user_prompt="stub",
+            model="stub-model",
+            input_tokens=100,
+            output_tokens=50,
+            cost_usd=0.001,
+            scrubbed=False,
+        )
+
+    monkeypatch.setattr("app.api.posts.generate_post", fake, raising=True)
+
+
+@pytest.fixture()
+def fake_spintax(monkeypatch):
+    monkeypatch.setattr(
+        "app.api.posts.generate_spintax_variant",
+        lambda text, profile: text + " (variant)",
+        raising=True,
+    )
+
+
+def test_healthz(client):
+    resp = client.get("/healthz")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert "version" in body
+
+
+def test_profile_404_when_missing(client):
+    r = client.get("/api/business-profile")
+    assert r.status_code == 404
+
+
+def test_profile_upsert(client):
+    payload = {
+        "name": "Acme",
+        "description": "We make things.",
+        "tone": "casual",
+        "length": "medium",
+        "emoji_density": "light",
+    }
+    r = client.put("/api/business-profile", json=payload)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["id"] == 1
+    assert body["name"] == "Acme"
+
+    # Second upsert updates the same row
+    payload["name"] = "Acme Inc."
+    r2 = client.put("/api/business-profile", json=payload)
+    assert r2.status_code == 200
+    assert r2.json()["id"] == 1
+    assert r2.json()["name"] == "Acme Inc."
+
+
+def test_target_crud(client):
+    payload = {
+        "platform_id": "facebook",
+        "external_id": "https://www.facebook.com/groups/123",
+        "name": "Test Group",
+        "tags": ["test"],
+    }
+    r = client.post("/api/targets", json=payload)
+    assert r.status_code == 201, r.text
+    tid = r.json()["id"]
+
+    # Duplicate external_id rejected
+    r_dup = client.post("/api/targets", json=payload)
+    assert r_dup.status_code == 409
+
+    r_list = client.get("/api/targets")
+    assert len(r_list.json()) == 1
+
+    r_get = client.get(f"/api/targets/{tid}")
+    assert r_get.status_code == 200
+
+    r_patch = client.patch(f"/api/targets/{tid}", json={"active": False})
+    assert r_patch.json()["active"] is False
+
+    r_del = client.delete(f"/api/targets/{tid}")
+    assert r_del.status_code == 204
+    assert client.get(f"/api/targets/{tid}").status_code == 404
+
+
+def test_generate_requires_profile(client, fake_generate_post):
+    r = client.post(
+        "/api/posts/generate",
+        json={"post_type": "informative", "generate_image": False},
+    )
+    assert r.status_code == 400
+
+
+def test_full_publish_flow(client, fake_generate_post, fake_spintax):
+    # 1. Profile
+    r = client.put(
+        "/api/business-profile",
+        json={"name": "Acme", "description": "We make things."},
+    )
+    assert r.status_code == 200
+
+    # 2. Target
+    r = client.post(
+        "/api/targets",
+        json={
+            "platform_id": "facebook",
+            "external_id": "https://www.facebook.com/groups/abc",
+            "name": "Group A",
+        },
+    )
+    assert r.status_code == 201, r.text
+    target_id = r.json()["id"]
+
+    # 3. Generate draft
+    r = client.post(
+        "/api/posts/generate",
+        json={
+            "post_type": "informative",
+            "generate_image": False,
+            "use_few_shot": False,
+        },
+    )
+    assert r.status_code == 201, r.text
+    post = r.json()
+    assert post["status"] == PostStatus.DRAFT.value
+    assert post["text"].startswith("Hey")
+    post_id = post["id"]
+
+    # 4. Publish now — patch FacebookPlatform.publish to avoid touching the bridge.
+    async def fake_publish(self, post, target):
+        return PublishResult(
+            ok=True,
+            external_post_id=f"https://www.facebook.com/groups/{target.id}/posts/fake",
+        )
+
+    with patch(
+        "app.api.posts.FacebookPlatform.publish",
+        new=fake_publish,
+    ):
+        r = client.post(
+            f"/api/posts/{post_id}/publish",
+            json={"target_ids": [target_id], "generate_spintax": False},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == PostStatus.POSTED.value
+    assert len(body["variants"]) == 1
+    assert body["variants"][0]["status"] == PostStatus.POSTED.value
+    assert body["variants"][0]["external_post_id"]
+
+
+def test_schedule_flow(client, fake_generate_post):
+    # Setup
+    client.put(
+        "/api/business-profile",
+        json={"name": "Acme", "description": "We make things."},
+    )
+    t = client.post(
+        "/api/targets",
+        json={
+            "platform_id": "facebook",
+            "external_id": "https://www.facebook.com/groups/xyz",
+            "name": "Group X",
+        },
+    ).json()
+
+    # Create a draft directly (no AI call)
+    draft = client.post(
+        "/api/posts",
+        json={
+            "post_type": PostType.STORY.value,
+            "text": "Scheduled ahead.",
+        },
+    ).json()
+
+    # Schedule it 1h from now
+    from datetime import datetime, timedelta
+
+    sched_at = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+    r = client.post(
+        f"/api/posts/{draft['id']}/schedule",
+        json={
+            "target_ids": [t["id"]],
+            "scheduled_for": sched_at,
+            "generate_spintax": False,
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == PostStatus.SCHEDULED.value
+    assert len(body["variants"]) == 1
+    assert body["variants"][0]["status"] == PostStatus.SCHEDULED.value
+
+
+def test_feedback(client):
+    # Need a post to attach feedback to
+    p = client.post(
+        "/api/posts",
+        json={"post_type": "engagement", "text": "What do you think?"},
+    ).json()
+
+    r = client.post(
+        "/api/feedback",
+        json={"post_id": p["id"], "rating": "up", "comment": "nice"},
+    )
+    assert r.status_code == 201, r.text
+
+    r_list = client.get(f"/api/feedback/by-post/{p['id']}")
+    assert r_list.status_code == 200
+    assert len(r_list.json()) == 1
+    assert r_list.json()[0]["rating"] == "up"
+
+
+def test_media_upload_rejects_bad_mime(client):
+    resp = client.post(
+        "/api/media/upload",
+        files={"file": ("x.txt", b"hello", "text/plain")},
+    )
+    assert resp.status_code == 400
+
+
+def test_media_upload_accepts_png(client, tmp_path, monkeypatch):
+    # Redirect the uploads dir to tmp to not pollute the repo during tests
+    import app.api.media as media_mod
+
+    test_dir = tmp_path / "uploads"
+    monkeypatch.setattr(media_mod, "UPLOADS_DIR", test_dir, raising=True)
+    test_dir.mkdir(parents=True, exist_ok=True)
+
+    png_bytes = (
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"
+        b"\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89"
+        b"\x00\x00\x00\rIDATx\x9cc\xf8\xcf\xc0\x00\x00\x00\x03\x00\x01\x5b\xb7\xc0*"
+        b"\x00\x00\x00\x00IEND\xaeB`\x82"
+    )
+    resp = client.post(
+        "/api/media/upload",
+        files={"file": ("a.png", png_bytes, "image/png")},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["mime"] == "image/png"
+    assert body["url"].startswith("/static/images/uploads/")
+
+
+def test_status_endpoint(client):
+    r = client.get("/api/status")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is True
+    # Scheduler is stubbed to no-op start() so it reports not running
+    assert "scheduler_running" in body
+    assert "extension_connected" in body

--- a/backend/tests/test_humanizer.py
+++ b/backend/tests/test_humanizer.py
@@ -1,0 +1,198 @@
+"""M4 Humanizer tests.
+
+Covers:
+- classify_failure: checkpoint / shadow-ban / unknown
+- apply_schedule_jitter: result falls in [-j, +j] minutes
+- on_failure + on_success counters and smart-pause activation
+- in_blackout: today vs other day
+- API endpoints for profile, pause, blackouts, session-health
+"""
+from __future__ import annotations
+
+import random
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.db.models import (
+    BlackoutDate,
+    HumanizerProfile,
+    SessionHealth,
+    SessionHealthStatus,
+)
+from app.services import humanizer as hz
+
+
+def _make_profile(db, **overrides):
+    p = HumanizerProfile(**overrides)
+    db.add(p)
+    db.commit()
+    db.refresh(p)
+    return p
+
+
+# ---------- Classifier ----------
+
+
+@pytest.mark.parametrize(
+    "reason,expected",
+    [
+        ("checkpoint_detected: please re-enter your password", "checkpoint"),
+        ("captcha required", "checkpoint"),
+        ("Please re-enter your password", "checkpoint"),
+        ("Your account is temporarily blocked for violation", "shadow_ban"),
+        ("unavailable: try again later", "shadow_ban"),
+        ("post_button_not_found_or_disabled", "unknown"),
+        ("", "unknown"),
+        (None, "unknown"),
+    ],
+)
+def test_classify_failure(reason, expected):
+    assert hz.classify_failure(reason).kind == expected
+
+
+# ---------- Jitter ----------
+
+
+def test_jitter_within_bounds(db):
+    profile = _make_profile(db, schedule_jitter_minutes=5)
+    base = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    random.seed(42)
+    for _ in range(200):
+        out = hz.apply_schedule_jitter(base, profile)
+        delta = abs((out - base).total_seconds())
+        assert delta <= 5 * 60 + 1
+
+
+def test_jitter_zero_is_noop(db):
+    profile = _make_profile(db, schedule_jitter_minutes=0)
+    base = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    assert hz.apply_schedule_jitter(base, profile) == base
+
+
+# ---------- Smart pause ----------
+
+
+def test_pause_not_activated_below_threshold(db):
+    _make_profile(db, consecutive_failures_threshold=3, smart_pause_minutes=60)
+    health, _ = hz.on_failure(db, "facebook", "composer_editor_did_not_open")
+    assert health.consecutive_failures == 1
+    assert health.status == SessionHealthStatus.WARNING
+    assert hz.check_pause(db) is None
+
+
+def test_pause_activated_at_threshold(db):
+    _make_profile(db, consecutive_failures_threshold=3, smart_pause_minutes=45)
+    for _ in range(3):
+        hz.on_failure(db, "facebook", "composer_editor_did_not_open")
+    health = db.query(SessionHealth).first()
+    assert health.consecutive_failures == 3
+    until = hz.check_pause(db)
+    assert until is not None
+    delta_min = (until - datetime.now(UTC)).total_seconds() / 60
+    assert 40 <= delta_min <= 46
+
+
+def test_checkpoint_triggers_pause_immediately(db):
+    _make_profile(db, consecutive_failures_threshold=10, smart_pause_minutes=30)
+    hz.on_failure(db, "facebook", "checkpoint_detected: re-enter your password")
+    until = hz.check_pause(db)
+    assert until is not None
+
+
+def test_on_success_resets_counter(db):
+    _make_profile(db, consecutive_failures_threshold=3)
+    hz.on_failure(db, "facebook", "x")
+    hz.on_failure(db, "facebook", "y")
+    hz.on_success(db, "facebook")
+    health = db.query(SessionHealth).filter_by(platform_id="facebook").first()
+    assert health.consecutive_failures == 0
+    assert health.status == SessionHealthStatus.HEALTHY
+
+
+def test_check_pause_auto_clears_when_expired(db):
+    profile = _make_profile(db, smart_pause_minutes=30)
+    profile.smart_pause_until = datetime.now(UTC) - timedelta(minutes=1)
+    profile.smart_pause_reason = "old"
+    db.commit()
+    assert hz.check_pause(db) is None
+    db.refresh(profile)
+    assert profile.smart_pause_until is None
+    assert profile.smart_pause_reason is None
+
+
+# ---------- Blackout ----------
+
+
+def test_blackout_matches_same_day(db):
+    today = datetime.now(UTC).replace(hour=5, minute=0)
+    db.add(BlackoutDate(date=today.replace(hour=0, minute=0), reason="holiday"))
+    db.commit()
+    assert hz.in_blackout(db, today) is not None
+
+
+def test_blackout_does_not_match_other_day(db):
+    today = datetime.now(UTC)
+    other = today + timedelta(days=2)
+    db.add(BlackoutDate(date=other, reason="future"))
+    db.commit()
+    assert hz.in_blackout(db, today) is None
+
+
+# ---------- API ----------
+
+
+def test_profile_get_creates_singleton(client):
+    r = client.get("/api/humanizer/profile")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["typing_wpm_min"] == 35
+    assert body["schedule_jitter_minutes"] == 7
+
+
+def test_profile_patch_persists(client):
+    client.get("/api/humanizer/profile")
+    r = client.patch(
+        "/api/humanizer/profile",
+        json={"typing_wpm_min": 50, "mistake_rate": 0.05},
+    )
+    assert r.status_code == 200
+    assert r.json()["typing_wpm_min"] == 50
+    assert r.json()["mistake_rate"] == 0.05
+
+
+def test_pause_endpoints_roundtrip(client):
+    r = client.post("/api/humanizer/pause")
+    assert r.status_code == 200
+    assert r.json()["paused"] is True
+    r = client.get("/api/humanizer/pause")
+    assert r.json()["paused"] is True
+    r = client.post("/api/humanizer/resume")
+    assert r.json()["paused"] is False
+    assert client.get("/api/humanizer/pause").json()["paused"] is False
+
+
+def test_blackout_crud(client):
+    r = client.post(
+        "/api/humanizer/blackout-dates",
+        json={"date": "2026-12-25T00:00:00Z", "reason": "Christmas"},
+    )
+    assert r.status_code == 201
+    bid = r.json()["id"]
+    assert r.json()["reason"] == "Christmas"
+
+    listing = client.get("/api/humanizer/blackout-dates").json()
+    assert len(listing) == 1
+
+    r = client.delete(f"/api/humanizer/blackout-dates/{bid}")
+    assert r.status_code == 204
+    assert client.get("/api/humanizer/blackout-dates").json() == []
+
+
+def test_session_health_listing(client, db):
+    # Poke the service once so a row is created.
+    hz.on_failure(db, "facebook", "x")
+    r = client.get("/api/humanizer/session-health")
+    assert r.status_code == 200
+    rows = r.json()
+    assert any(row["platform_id"] == "facebook" for row in rows)

--- a/backend/tests/test_media.py
+++ b/backend/tests/test_media.py
@@ -1,0 +1,242 @@
+"""M2 Media Library tests.
+
+We stub `tag_image` (Claude Vision) so tests don't hit the API.
+Real file I/O is kept — Pillow reads PNG dimensions, disk writes go to tmp_path.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.ai.vision import TagResult, media_relevance_score
+from app.db.models import PostType  # noqa: E402
+
+PNG_BYTES = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"
+    b"\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89"
+    b"\x00\x00\x00\rIDATx\x9cc\xf8\xcf\xc0\x00\x00\x00\x03\x00\x01\x5b\xb7\xc0*"
+    b"\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+
+@pytest.fixture()
+def redirect_uploads(tmp_path, monkeypatch):
+    import app.api.media as media_mod
+
+    test_dir = tmp_path / "uploads"
+    test_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(media_mod, "UPLOADS_DIR", test_dir, raising=True)
+    # `data/...` prefix is still used for local_path; make the `data/` root a tmp too.
+    # Ensure delete/tag endpoints can find files via Path("data")/local_path:
+    monkeypatch.chdir(tmp_path)
+    # Re-create the structure so local_path "images/uploads/..." resolves under data/.
+    (tmp_path / "data" / "images").mkdir(parents=True, exist_ok=True)
+    real_uploads = tmp_path / "data" / "images" / "uploads"
+    real_uploads.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(media_mod, "UPLOADS_DIR", real_uploads, raising=True)
+    return real_uploads
+
+
+@pytest.fixture()
+def fake_tag(monkeypatch):
+    """Avoid touching Anthropic API."""
+
+    def fake(path, mime=None):
+        return TagResult(
+            caption="A close-up of basil leaves on a wooden table.",
+            tags=["basil", "herbs", "kitchen", "food"],
+            cost_usd=0.0015,
+        )
+
+    monkeypatch.setattr("app.api.media.tag_image", fake, raising=True)
+
+
+# ---------- unit tests ----------
+
+
+def test_relevance_score_basic_overlap():
+    s = media_relevance_score(
+        slot_post_type="informative",
+        slot_topic_hint="how to spot overwatered basil quickly",
+        asset_tags=["basil", "kitchen"],
+        asset_caption="Pot of basil on a windowsill",
+    )
+    assert s > 0
+
+
+def test_relevance_score_no_overlap():
+    s = media_relevance_score(
+        slot_post_type="story",
+        slot_topic_hint="customer won a marathon",
+        asset_tags=["keyboard", "laptop"],
+        asset_caption="A workspace with monitors",
+    )
+    assert s == 0.0
+
+
+def test_relevance_score_handles_empty():
+    assert (
+        media_relevance_score(
+            slot_post_type="engagement",
+            slot_topic_hint=None,
+            asset_tags=[],
+            asset_caption=None,
+        )
+        == 0.0
+    )
+
+
+# ---------- API tests ----------
+
+
+def test_upload_persists_and_lists(client, redirect_uploads):
+    resp = client.post(
+        "/api/media/upload",
+        files={"file": ("pic.png", PNG_BYTES, "image/png")},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["id"] > 0
+    assert body["width"] == 1 and body["height"] == 1
+    assert body["url"].startswith("/static/images/uploads/")
+
+    listing = client.get("/api/media").json()
+    assert len(listing) == 1
+    assert listing[0]["id"] == body["id"]
+    assert listing[0]["ai_tags"] == []
+
+
+def test_get_and_patch_tags(client, redirect_uploads):
+    aid = client.post(
+        "/api/media/upload",
+        files={"file": ("a.png", PNG_BYTES, "image/png")},
+    ).json()["id"]
+
+    r = client.patch(f"/api/media/{aid}", json={"tags_user": ["seasonal", "launch"]})
+    assert r.status_code == 200
+    assert r.json()["tags_user"] == ["seasonal", "launch"]
+
+
+def test_delete_removes_file_and_row(client, redirect_uploads):
+    upload = client.post(
+        "/api/media/upload",
+        files={"file": ("a.png", PNG_BYTES, "image/png")},
+    ).json()
+    aid = upload["id"]
+    listing_before = client.get("/api/media").json()
+    file_path = redirect_uploads / upload["filename"]
+    assert file_path.exists()
+
+    r = client.delete(f"/api/media/{aid}")
+    assert r.status_code == 204
+    assert client.get(f"/api/media/{aid}").status_code == 404
+    assert len(client.get("/api/media").json()) == len(listing_before) - 1
+
+
+def test_tag_endpoint_stores_caption_and_tags(client, redirect_uploads, fake_tag):
+    aid = client.post(
+        "/api/media/upload",
+        files={"file": ("basil.png", PNG_BYTES, "image/png")},
+    ).json()["id"]
+
+    r = client.post(f"/api/media/{aid}/tag")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "basil" in body["tags"]
+    assert body["caption"]
+
+    asset = client.get(f"/api/media/{aid}").json()
+    assert "basil" in asset["ai_tags"]
+    assert asset["tagged_at"] is not None
+
+
+def _make_plan_with_slot(client, topic_hint: str, post_type: PostType):
+    client.put(
+        "/api/business-profile",
+        json={"name": "Acme", "description": "We make things."},
+    )
+    start = datetime.now(UTC).replace(microsecond=0)
+    end = start + timedelta(days=3)
+    plan = client.post(
+        "/api/plans",
+        json={
+            "name": "Pilot",
+            "start_date": start.isoformat(),
+            "end_date": end.isoformat(),
+        },
+    ).json()
+    slot = client.post(
+        f"/api/plans/{plan['id']}/slots",
+        json={
+            "scheduled_for": (start + timedelta(hours=3)).isoformat(),
+            "post_type": post_type.value,
+            "topic_hint": topic_hint,
+        },
+    ).json()
+    return plan, slot
+
+
+def test_attach_to_slot(client, redirect_uploads, fake_tag):
+    aid = client.post(
+        "/api/media/upload",
+        files={"file": ("a.png", PNG_BYTES, "image/png")},
+    ).json()["id"]
+    _, slot = _make_plan_with_slot(client, "basil care", PostType.INFORMATIVE)
+
+    r = client.post(f"/api/media/{aid}/attach-to-slot/{slot['id']}")
+    assert r.status_code == 200
+
+    # Slot should now reference the asset
+    # (slots live under /api/plans/slots/... — patch lets us read via another fetch)
+    # Easiest check: suggest endpoint won't dedupe an already-attached asset,
+    # but here we verify by re-reading the plan.
+    # Fetch plan detail via /api/plans/{id}
+    # Use the plan id from slot
+    # Instead just check the relational state via media_asset_id property on slot
+    # — we can see it via the plan's slots list.
+    plan_id = slot["plan_id"]
+    plan_after = client.get(f"/api/plans/{plan_id}").json()
+    assert plan_after["slots"][0]["media_asset_id"] == aid
+
+
+def test_suggest_for_slot_ranks_by_tag_overlap(client, redirect_uploads, fake_tag):
+    # Two assets, different tag sets
+    aid1 = client.post(
+        "/api/media/upload",
+        files={"file": ("a.png", PNG_BYTES, "image/png")},
+    ).json()["id"]
+    # Asset 2: upload a second one with no tags — should score 0
+    client.post(
+        "/api/media/upload",
+        files={"file": ("b.png", PNG_BYTES, "image/png")},
+    )
+    # Tag asset 1 (fake returns basil/herbs/kitchen tags)
+    client.post(f"/api/media/{aid1}/tag")
+
+    _, slot = _make_plan_with_slot(client, "basil care tips for kitchen", PostType.INFORMATIVE)
+
+    r = client.get(f"/api/media/suggest-for-slot/{slot['id']}")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body) == 1  # only asset 1 has any overlap
+    assert body[0]["asset"]["id"] == aid1
+    assert body[0]["score"] > 0
+
+
+def test_suggest_empty_when_no_tags(client, redirect_uploads):
+    # Upload but never tag
+    client.post(
+        "/api/media/upload",
+        files={"file": ("a.png", PNG_BYTES, "image/png")},
+    )
+    _, slot = _make_plan_with_slot(client, "anything", PostType.STORY)
+    assert client.get(f"/api/media/suggest-for-slot/{slot['id']}").json() == []
+
+
+def test_upload_still_rejects_bad_mime(client, redirect_uploads):
+    r = client.post(
+        "/api/media/upload",
+        files={"file": ("x.txt", b"hi", "text/plain")},
+    )
+    assert r.status_code == 400

--- a/backend/tests/test_meta_platforms.py
+++ b/backend/tests/test_meta_platforms.py
@@ -1,0 +1,354 @@
+"""M7 — Instagram + Threads via Meta Graph API.
+
+Mocks all HTTP calls to `app.platforms.meta_graph` so tests stay hermetic.
+Verifies:
+- adapt_content truncation + hashtag cap (IG) / length-aware trim (Threads)
+- InstagramPlatform.publish dispatches create→publish→returns external_id
+- ThreadsPlatform.publish handles text-only + text+image
+- Credential CRUD endpoints (list/delete) + manual POST
+- OAuth URL endpoint refuses without app_id
+- _platform_for registry returns the right subclass
+- Metrics round-trip for IG/Threads via `fetch_metrics`
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from app.db.models import (
+    Post,
+    PostStatus,
+    PostType,
+    PlatformCredential,
+    Target,
+)
+from app.platforms.instagram import (
+    IG_CAPTION_MAX,
+    IG_HASHTAG_MAX,
+    InstagramPlatform,
+    _trim_hashtags,
+)
+from app.platforms.registry import PLATFORMS, get_platform
+from app.platforms.threads import THREADS_MAX, ThreadsPlatform
+
+
+# ---------- adapt_content ----------
+
+
+def test_instagram_adapt_truncates_to_2200_chars():
+    ig = InstagramPlatform()
+    long_text = "a" * (IG_CAPTION_MAX + 500)
+    adapted = ig.adapt_content(long_text)
+    assert len(adapted) == IG_CAPTION_MAX
+    assert adapted.endswith("\u2026")
+
+
+def test_instagram_adapt_caps_hashtags_at_30():
+    tags = " ".join(f"#tag{i}" for i in range(45))
+    text = f"Hello world! {tags}"
+    adapted = InstagramPlatform().adapt_content(text)
+    assert adapted.count("#") == IG_HASHTAG_MAX
+
+
+def test_trim_hashtags_preserves_first_n():
+    text = "hi #one #two #three #four"
+    out = _trim_hashtags(text, max_tags=2)
+    # Only first two survive.
+    assert "#one" in out
+    assert "#two" in out
+    assert "#three" not in out
+    assert "#four" not in out
+
+
+def test_threads_adapt_truncates_to_500_chars_on_word_boundary():
+    # 600 chars of "foo bar" — ensure we chop near a space.
+    text = ("foo bar " * 100).strip()
+    out = ThreadsPlatform().adapt_content(text)
+    assert len(out) <= THREADS_MAX
+    assert out.endswith("\u2026")
+    assert "  " not in out  # no double-space garbage
+
+
+def test_threads_adapt_leaves_hashtags_alone():
+    text = "news drop " + " ".join(f"#tag{i}" for i in range(10))
+    out = ThreadsPlatform().adapt_content(text)
+    assert out.count("#") == 10
+
+
+# ---------- Registry ----------
+
+
+def test_registry_has_three_platforms():
+    assert set(PLATFORMS.keys()) == {"facebook", "instagram", "threads"}
+
+
+def test_get_platform_returns_correct_subclass():
+    assert get_platform("instagram").__class__.__name__ == "InstagramPlatform"
+    assert get_platform("threads").__class__.__name__ == "ThreadsPlatform"
+    assert get_platform("facebook").__class__.__name__ == "FacebookPlatform"
+    assert get_platform("nope") is None
+
+
+# ---------- Publishing (mocked) ----------
+
+
+def _make_cred(db, platform_id: str, account_id: str, token: str = "tkn_XYZ"):
+    row = PlatformCredential(
+        platform_id=platform_id,
+        account_id=account_id,
+        username=f"{platform_id}_user",
+        access_token=token,
+        extra={},
+    )
+    db.add(row)
+    db.commit()
+    return row
+
+
+def _make_target(db, platform_id: str, external_id: str):
+    t = Target(platform_id=platform_id, external_id=external_id, name=f"{platform_id} target")
+    db.add(t)
+    db.commit()
+    return t
+
+
+@pytest.mark.asyncio
+async def test_instagram_publish_dispatches_create_and_publish(db):
+    _make_cred(db, "instagram", "IG123")
+    target = _make_target(db, "instagram", "IG123")
+    post = Post(
+        post_type=PostType.INFORMATIVE,
+        status=PostStatus.DRAFT,
+        text="Hello from tests",
+        image_url="https://cdn.example.com/img.jpg",
+    )
+
+    with patch("app.platforms.instagram.meta_graph.ig_create_container") as create_mock, patch(
+        "app.platforms.instagram.meta_graph.ig_publish_container"
+    ) as publish_mock:
+        create_mock.return_value = "CRE123"
+        publish_mock.return_value = "MEDIA999"
+        platform = InstagramPlatform(db=db)
+        result = await platform.publish(post, target)
+
+    assert result.ok
+    assert result.external_post_id == "MEDIA999"
+    create_mock.assert_called_once()
+    kwargs = create_mock.call_args.kwargs
+    assert kwargs["ig_user_id"] == "IG123"
+    assert kwargs["access_token"] == "tkn_XYZ"
+    assert kwargs["image_url"] == "https://cdn.example.com/img.jpg"
+
+
+@pytest.mark.asyncio
+async def test_instagram_publish_requires_public_image_url(db):
+    _make_cred(db, "instagram", "IG123")
+    target = _make_target(db, "instagram", "IG123")
+    post = Post(
+        post_type=PostType.INFORMATIVE,
+        status=PostStatus.DRAFT,
+        text="No image",
+        image_url=None,
+    )
+    platform = InstagramPlatform(db=db)
+    result = await platform.publish(post, target)
+    assert not result.ok
+    assert "publicly-reachable" in result.error
+
+
+@pytest.mark.asyncio
+async def test_instagram_publish_fails_without_credential(db):
+    target = _make_target(db, "instagram", "IG999")
+    post = Post(
+        post_type=PostType.INFORMATIVE,
+        status=PostStatus.DRAFT,
+        text="hi",
+        image_url="https://cdn.example.com/i.jpg",
+    )
+    platform = InstagramPlatform(db=db)
+    result = await platform.publish(post, target)
+    assert not result.ok
+    assert "credential" in result.error.lower()
+
+
+@pytest.mark.asyncio
+async def test_threads_publish_text_only(db):
+    _make_cred(db, "threads", "TH123")
+    target = _make_target(db, "threads", "TH123")
+    post = Post(
+        post_type=PostType.INFORMATIVE,
+        status=PostStatus.DRAFT,
+        text="Short thought",
+        image_url=None,
+    )
+    with patch("app.platforms.threads.meta_graph.threads_create_container") as create_mock, patch(
+        "app.platforms.threads.meta_graph.threads_publish_container"
+    ) as publish_mock:
+        create_mock.return_value = "TCRE"
+        publish_mock.return_value = "TMEDIA"
+        result = await ThreadsPlatform(db=db).publish(post, target)
+
+    assert result.ok
+    assert result.external_post_id == "TMEDIA"
+    # image_url should be None (text-only)
+    assert create_mock.call_args.kwargs["image_url"] is None
+
+
+@pytest.mark.asyncio
+async def test_threads_publish_with_image(db):
+    _make_cred(db, "threads", "TH123")
+    target = _make_target(db, "threads", "TH123")
+    post = Post(
+        post_type=PostType.INFORMATIVE,
+        status=PostStatus.DRAFT,
+        text="Image post",
+        image_url="https://cdn.example.com/pic.jpg",
+    )
+    with patch("app.platforms.threads.meta_graph.threads_create_container") as create_mock, patch(
+        "app.platforms.threads.meta_graph.threads_publish_container"
+    ) as publish_mock:
+        create_mock.return_value = "TCRE"
+        publish_mock.return_value = "TMEDIA"
+        result = await ThreadsPlatform(db=db).publish(post, target)
+
+    assert result.ok
+    assert create_mock.call_args.kwargs["image_url"] == "https://cdn.example.com/pic.jpg"
+
+
+@pytest.mark.asyncio
+async def test_threads_drops_non_public_image(db):
+    _make_cred(db, "threads", "TH123")
+    target = _make_target(db, "threads", "TH123")
+    post = Post(
+        post_type=PostType.INFORMATIVE,
+        status=PostStatus.DRAFT,
+        text="With local path",
+        image_url="/static/images/uploads/foo.jpg",
+    )
+    with patch("app.platforms.threads.meta_graph.threads_create_container") as create_mock, patch(
+        "app.platforms.threads.meta_graph.threads_publish_container"
+    ) as publish_mock:
+        create_mock.return_value = "TCRE"
+        publish_mock.return_value = "TMEDIA"
+        result = await ThreadsPlatform(db=db).publish(post, target)
+
+    assert result.ok
+    # Local path gets silently dropped → image_url kwarg is None.
+    assert create_mock.call_args.kwargs["image_url"] is None
+
+
+# ---------- Metrics ----------
+
+
+@pytest.mark.asyncio
+async def test_instagram_fetch_metrics_maps_keys(db):
+    _make_cred(db, "instagram", "IG555")
+    with patch("app.platforms.instagram.meta_graph.ig_insights") as mock:
+        mock.return_value = {"likes": 10, "comments": 3, "reach": 200}
+        out = await InstagramPlatform(db=db).fetch_metrics("MEDIA_X")
+    assert out == {"likes": 10, "comments": 3, "reach": 200}
+
+
+@pytest.mark.asyncio
+async def test_threads_fetch_metrics_maps_replies_and_reposts(db):
+    _make_cred(db, "threads", "TH555")
+    with patch("app.platforms.threads.meta_graph.threads_insights") as mock:
+        mock.return_value = {"likes": 4, "comments": 1, "shares": 2, "reach": 500}
+        out = await ThreadsPlatform(db=db).fetch_metrics("MEDIA_X")
+    assert out["likes"] == 4
+    assert out["comments"] == 1
+    assert out["shares"] == 2
+    assert out["reach"] == 500
+
+
+# ---------- API: OAuth URL + credentials CRUD ----------
+
+
+def test_oauth_url_requires_app_id(client, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "meta_app_id", "", raising=False)
+    r = client.get("/api/meta/oauth/url")
+    assert r.status_code == 400
+
+
+def test_oauth_url_with_app_id_returns_login_url(client, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "meta_app_id", "123456", raising=False)
+    r = client.get("/api/meta/oauth/url")
+    assert r.status_code == 200
+    body = r.json()
+    assert "facebook.com" in body["url"]
+    assert "client_id=123456" in body["url"]
+    assert "state=" in body["url"]
+    assert len(body["state"]) > 16
+
+
+def test_manual_credential_upsert_and_list(client):
+    payload = {
+        "platform_id": "instagram",
+        "account_id": "IG777",
+        "username": "testbiz",
+        "access_token": "LONG_TOKEN_1",
+    }
+    r = client.post("/api/meta/credentials", json=payload)
+    assert r.status_code == 200
+    cred = r.json()
+    assert cred["platform_id"] == "instagram"
+    assert cred["account_id"] == "IG777"
+    # Token is never returned.
+    assert "access_token" not in cred
+
+    # Upsert = same (platform, account) just updates, no new row.
+    payload["access_token"] = "LONG_TOKEN_2"
+    r2 = client.post("/api/meta/credentials", json=payload)
+    assert r2.status_code == 200
+    assert r2.json()["id"] == cred["id"]
+
+    listing = client.get("/api/platform-credentials").json()
+    assert len(listing) == 1
+
+
+def test_manual_credential_rejects_unknown_platform(client):
+    r = client.post(
+        "/api/meta/credentials",
+        json={
+            "platform_id": "vkontakte",
+            "account_id": "X",
+            "access_token": "t",
+        },
+    )
+    assert r.status_code == 400
+
+
+def test_delete_credential(client):
+    r = client.post(
+        "/api/meta/credentials",
+        json={
+            "platform_id": "threads",
+            "account_id": "TH_DEL",
+            "access_token": "t",
+        },
+    )
+    cid = r.json()["id"]
+    assert client.delete(f"/api/platform-credentials/{cid}").status_code == 204
+    assert client.delete(f"/api/platform-credentials/{cid}").status_code == 404
+
+
+# ---------- list_targets ----------
+
+
+@pytest.mark.asyncio
+async def test_instagram_list_targets_returns_credential_account(db):
+    _make_cred(db, "instagram", "IG_LT", token="tok")
+    out = await InstagramPlatform(db=db).list_targets()
+    assert len(out) == 1
+    assert out[0]["external_id"] == "IG_LT"
+
+
+@pytest.mark.asyncio
+async def test_threads_list_targets_empty_without_credential(db):
+    out = await ThreadsPlatform(db=db).list_targets()
+    assert out == []

--- a/backend/tests/test_planner.py
+++ b/backend/tests/test_planner.py
@@ -1,0 +1,344 @@
+"""Tests for Content Planner Agent + /api/plans endpoints.
+
+Stubs:
+- `propose_plan` → canned list of 3 SlotProposals.
+- `refine_plan` → canned RefinementResult.
+- `generate_post` → canned GeneratedPost (same fixture as test_api_smoke).
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.agents.planner import (
+    PlanProposal,
+    RefinementResult,
+    SlotProposal,
+    _extract_json,
+    _parse_slots,
+)
+from app.ai.content import GeneratedPost
+from app.db.models import PlanStatus, PostType, SlotStatus
+
+
+@pytest.fixture()
+def profile(client):
+    """Ensure a business profile exists for planner endpoints."""
+    r = client.put(
+        "/api/business-profile",
+        json={
+            "name": "Acme",
+            "description": "We make things.",
+            "posts_per_day": 2,
+            "post_type_ratios": {"informative": 0.5, "engagement": 0.5},
+        },
+    )
+    assert r.status_code == 200
+    return r.json()
+
+
+@pytest.fixture()
+def fake_propose(monkeypatch):
+    """Stub the Claude-calling planner with 3 canned slots."""
+
+    def fake(business_profile, start_date, end_date, goal=None):
+        base = start_date.replace(hour=10, minute=0, second=0, microsecond=0)
+        return PlanProposal(
+            slots=[
+                SlotProposal(
+                    scheduled_for=base,
+                    post_type=PostType.INFORMATIVE,
+                    topic_hint="How to spot overwatered basil in 10 seconds",
+                    rationale="Value-first opener",
+                ),
+                SlotProposal(
+                    scheduled_for=base + timedelta(days=1, hours=3),
+                    post_type=PostType.ENGAGEMENT,
+                    topic_hint="Ask what herb they most struggle with",
+                    rationale="Drive comments",
+                ),
+                SlotProposal(
+                    scheduled_for=base + timedelta(days=2),
+                    post_type=PostType.STORY,
+                    topic_hint="Time a customer asked us about rosemary in winter",
+                    rationale="Humanize the brand",
+                ),
+            ],
+            summary="Value-first week with one engagement and one story.",
+            input_tokens=200,
+            output_tokens=400,
+            cost_usd=0.007,
+        )
+
+    monkeypatch.setattr("app.api.plans.propose_plan", fake, raising=True)
+
+
+@pytest.fixture()
+def fake_refine(monkeypatch):
+    def fake(business_profile, start_date, end_date, current_slots, chat_history, user_message):
+        # Respond as if we moved everything to evenings; return 2 new slots.
+        base = start_date.replace(hour=18, minute=0, second=0, microsecond=0)
+        return RefinementResult(
+            slots=[
+                SlotProposal(
+                    scheduled_for=base,
+                    post_type=PostType.ENGAGEMENT,
+                    topic_hint="Evening question post",
+                    rationale="Audience active after work",
+                ),
+                SlotProposal(
+                    scheduled_for=base + timedelta(days=1),
+                    post_type=PostType.INFORMATIVE,
+                    topic_hint="Quick evening tip",
+                    rationale="Pairs with engagement slot",
+                ),
+            ],
+            summary="Shifted to evening slots.",
+            input_tokens=50,
+            output_tokens=100,
+            cost_usd=0.0015,
+            reply="Moved everything to evenings as requested.",
+            assistant_history_entry={
+                "role": "assistant",
+                "content": "Moved everything to evenings as requested.",
+            },
+        )
+
+    monkeypatch.setattr("app.api.plans.refine_plan", fake, raising=True)
+
+
+@pytest.fixture()
+def fake_generate_post(monkeypatch):
+    def fake(**kwargs):
+        return GeneratedPost(
+            text="Basil looks sad? Dump the saucer water.",
+            system_prompt="stub",
+            user_prompt="stub",
+            model="stub-model",
+            input_tokens=50,
+            output_tokens=30,
+            cost_usd=0.0006,
+            scrubbed=False,
+        )
+
+    monkeypatch.setattr("app.api.plans.generate_post", fake, raising=True)
+
+
+# ---------- unit tests on the agent helpers ----------
+
+
+def test_extract_json_handles_fences():
+    raw = "```json\n{\"slots\": [], \"summary\": \"\"}\n```"
+    assert _extract_json(raw) == {"slots": [], "summary": ""}
+
+
+def test_extract_json_plain():
+    assert _extract_json(' {"slots": [], "summary": "x"} ') == {
+        "slots": [],
+        "summary": "x",
+    }
+
+
+def test_parse_slots_rejects_bad_post_type():
+    with pytest.raises(ValueError, match="invalid post_type"):
+        _parse_slots(
+            {
+                "slots": [
+                    {
+                        "scheduled_for": "2025-07-12T10:00:00Z",
+                        "post_type": "not_a_real_type",
+                    }
+                ]
+            }
+        )
+
+
+def test_parse_slots_utc_normalization():
+    out = _parse_slots(
+        {
+            "slots": [
+                {
+                    "scheduled_for": "2025-07-12T10:00:00Z",
+                    "post_type": "informative",
+                    "topic_hint": "hi",
+                    "rationale": "r",
+                }
+            ]
+        }
+    )
+    assert len(out) == 1
+    assert out[0].scheduled_for.tzinfo is UTC
+    assert out[0].post_type == PostType.INFORMATIVE
+
+
+# ---------- API tests ----------
+
+
+def test_generate_plan_requires_profile(client, fake_propose):
+    start = datetime.now(UTC).replace(microsecond=0)
+    end = start + timedelta(days=7)
+    r = client.post(
+        "/api/plans/generate",
+        json={
+            "name": "Week 1",
+            "goal": "Steady engagement",
+            "start_date": start.isoformat(),
+            "end_date": end.isoformat(),
+        },
+    )
+    assert r.status_code == 400
+
+
+def test_generate_plan_happy_path(client, profile, fake_propose):
+    start = datetime.now(UTC).replace(microsecond=0)
+    end = start + timedelta(days=7)
+    r = client.post(
+        "/api/plans/generate",
+        json={
+            "name": "Week 1",
+            "goal": "Steady engagement",
+            "start_date": start.isoformat(),
+            "end_date": end.isoformat(),
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["name"] == "Week 1"
+    assert body["status"] == PlanStatus.DRAFT.value
+    assert len(body["slots"]) == 3
+    # Slots come back ordered by scheduled_for asc
+    sched_dates = [s["scheduled_for"] for s in body["slots"]]
+    assert sched_dates == sorted(sched_dates)
+    assert body["slots"][0]["post_type"] == PostType.INFORMATIVE.value
+    assert body["slots"][0]["status"] == SlotStatus.PLANNED.value
+    assert body["generation_cost_usd"] > 0
+
+
+def test_plan_list_and_get(client, profile, fake_propose):
+    start = datetime.now(UTC).replace(microsecond=0)
+    end = start + timedelta(days=5)
+    r = client.post(
+        "/api/plans/generate",
+        json={
+            "name": "P1",
+            "start_date": start.isoformat(),
+            "end_date": end.isoformat(),
+        },
+    )
+    plan_id = r.json()["id"]
+
+    all_plans = client.get("/api/plans").json()
+    assert len(all_plans) == 1
+    assert all_plans[0]["id"] == plan_id
+
+    single = client.get(f"/api/plans/{plan_id}")
+    assert single.status_code == 200
+    assert len(single.json()["slots"]) == 3
+
+
+def test_plan_patch(client, profile, fake_propose):
+    start = datetime.now(UTC).replace(microsecond=0)
+    end = start + timedelta(days=3)
+    plan_id = client.post(
+        "/api/plans/generate",
+        json={"name": "Temp", "start_date": start.isoformat(), "end_date": end.isoformat()},
+    ).json()["id"]
+
+    r = client.patch(
+        f"/api/plans/{plan_id}",
+        json={"name": "Renamed", "status": PlanStatus.ACTIVE.value},
+    )
+    assert r.status_code == 200
+    assert r.json()["name"] == "Renamed"
+    assert r.json()["status"] == PlanStatus.ACTIVE.value
+
+
+def test_plan_delete(client, profile, fake_propose):
+    start = datetime.now(UTC).replace(microsecond=0)
+    end = start + timedelta(days=3)
+    plan_id = client.post(
+        "/api/plans/generate",
+        json={"name": "DelMe", "start_date": start.isoformat(), "end_date": end.isoformat()},
+    ).json()["id"]
+
+    r = client.delete(f"/api/plans/{plan_id}")
+    assert r.status_code == 204
+    assert client.get(f"/api/plans/{plan_id}").status_code == 404
+
+
+def test_slot_crud(client, profile, fake_propose):
+    start = datetime.now(UTC).replace(microsecond=0)
+    end = start + timedelta(days=3)
+    plan = client.post(
+        "/api/plans/generate",
+        json={"name": "X", "start_date": start.isoformat(), "end_date": end.isoformat()},
+    ).json()
+
+    # Manually add a slot
+    new_slot_at = (start + timedelta(days=1, hours=2)).isoformat()
+    r = client.post(
+        f"/api/plans/{plan['id']}/slots",
+        json={
+            "scheduled_for": new_slot_at,
+            "post_type": PostType.HOT_TAKE.value,
+            "topic_hint": "Unpopular opinion about overwatering",
+        },
+    )
+    assert r.status_code == 201, r.text
+    new_slot = r.json()
+    assert new_slot["post_type"] == PostType.HOT_TAKE.value
+
+    # Patch — drag-n-drop to a new time
+    moved_to = (start + timedelta(days=2, hours=5)).isoformat()
+    r = client.patch(
+        f"/api/plans/slots/{new_slot['id']}",
+        json={"scheduled_for": moved_to, "notes": "moved in drag-n-drop"},
+    )
+    assert r.status_code == 200
+    assert r.json()["scheduled_for"].startswith(moved_to[:19])
+    assert r.json()["notes"] == "moved in drag-n-drop"
+
+    # Delete
+    assert client.delete(f"/api/plans/slots/{new_slot['id']}").status_code == 204
+
+
+def test_plan_chat_updates_slots(client, profile, fake_propose, fake_refine):
+    start = datetime.now(UTC).replace(microsecond=0)
+    end = start + timedelta(days=5)
+    plan = client.post(
+        "/api/plans/generate",
+        json={"name": "ChatPlan", "start_date": start.isoformat(), "end_date": end.isoformat()},
+    ).json()
+
+    r = client.post(
+        f"/api/plans/{plan['id']}/chat",
+        json={"message": "Move everything to evenings"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["updated"] is True
+    assert "evenings" in body["reply"]
+    assert len(body["plan"]["slots"]) == 2  # fake_refine returned 2 slots
+    assert len(body["plan"]["chat_history"]) >= 3  # initial assistant + user + assistant
+
+
+def test_generate_post_from_slot(client, profile, fake_propose, fake_generate_post):
+    start = datetime.now(UTC).replace(microsecond=0)
+    end = start + timedelta(days=3)
+    plan = client.post(
+        "/api/plans/generate",
+        json={"name": "GenPlan", "start_date": start.isoformat(), "end_date": end.isoformat()},
+    ).json()
+    slot_id = plan["slots"][0]["id"]
+
+    r = client.post(f"/api/plans/slots/{slot_id}/generate-post")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["slot"]["status"] == SlotStatus.GENERATED.value
+    assert body["slot"]["post_id"] == body["post"]["id"]
+    assert body["post"]["text"].startswith("Basil")
+
+    # Regenerate is blocked until slot's post is deleted
+    r2 = client.post(f"/api/plans/slots/{slot_id}/generate-post")
+    assert r2.status_code == 409

--- a/backend/tests/test_review_flow.py
+++ b/backend/tests/test_review_flow.py
@@ -1,0 +1,227 @@
+"""M5 — Review & Approval flow.
+
+Covers:
+- generate() routes new posts to PENDING_REVIEW when profile.review_before_posting.
+- auto_approve_types short-circuits review (status=DRAFT).
+- /approve transitions PENDING_REVIEW → DRAFT (no schedule) or SCHEDULED (+variants).
+- /reject → SKIPPED; reason appended to generation_prompt.
+- /regenerate replaces text + keeps status at PENDING_REVIEW.
+- /approve-all mass-approves filtered by post_type.
+- Thumbs up/down feedback on a PENDING_REVIEW post works.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.ai.content import GeneratedPost
+from app.db.models import PostStatus
+
+
+@pytest.fixture()
+def fake_generate_post(monkeypatch):
+    counter = {"n": 0}
+
+    def fake(**kwargs):
+        counter["n"] += 1
+        return GeneratedPost(
+            text=f"Generated draft #{counter['n']} — topic hint: "
+            f"{kwargs.get('topic_hint') or '(none)'}",
+            system_prompt="stub",
+            user_prompt="stub-user",
+            model="stub-model",
+            input_tokens=100,
+            output_tokens=50,
+            cost_usd=0.001,
+            scrubbed=False,
+        )
+
+    monkeypatch.setattr("app.api.posts.generate_post", fake, raising=True)
+    return counter
+
+
+def _put_profile(client, **overrides):
+    payload = {
+        "name": "Acme",
+        "description": "We make things.",
+        "review_before_posting": True,
+    }
+    payload.update(overrides)
+    r = client.put("/api/business-profile", json=payload)
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def _generate(client, post_type="informative", topic_hint=None):
+    r = client.post(
+        "/api/posts/generate",
+        json={
+            "post_type": post_type,
+            "topic_hint": topic_hint,
+            "generate_image": False,
+            "use_few_shot": False,
+        },
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def test_generate_goes_to_pending_review_when_enabled(client, fake_generate_post):
+    _put_profile(client, review_before_posting=True)
+    post = _generate(client)
+    assert post["status"] == PostStatus.PENDING_REVIEW.value
+
+
+def test_generate_goes_to_draft_when_review_off(client, fake_generate_post):
+    _put_profile(client, review_before_posting=False)
+    post = _generate(client)
+    assert post["status"] == PostStatus.DRAFT.value
+
+
+def test_auto_approve_type_skips_review(client, fake_generate_post):
+    _put_profile(
+        client,
+        review_before_posting=True,
+        auto_approve_types=["informative"],
+    )
+    # informative is on allow-list → DRAFT
+    post_info = _generate(client, post_type="informative")
+    assert post_info["status"] == PostStatus.DRAFT.value
+    # hard_sell is not → PENDING_REVIEW
+    post_hs = _generate(client, post_type="hard_sell")
+    assert post_hs["status"] == PostStatus.PENDING_REVIEW.value
+
+
+def test_pending_review_list_filter(client, fake_generate_post):
+    _put_profile(client, review_before_posting=True)
+    p1 = _generate(client)
+    _generate(client)
+    # plus one DRAFT to make sure it's excluded
+    r = client.post(
+        "/api/posts",
+        json={"post_type": "engagement", "text": "already a draft"},
+    )
+    assert r.status_code == 201
+
+    r_list = client.get("/api/posts/review/pending")
+    assert r_list.status_code == 200
+    body = r_list.json()
+    assert len(body) == 2
+    assert all(p["status"] == PostStatus.PENDING_REVIEW.value for p in body)
+    assert p1["id"] in [p["id"] for p in body]
+
+
+def test_approve_to_draft(client, fake_generate_post):
+    _put_profile(client, review_before_posting=True)
+    post = _generate(client)
+    r = client.post(
+        f"/api/posts/{post['id']}/approve",
+        json={"target_ids": [], "scheduled_for": None},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["status"] == PostStatus.DRAFT.value
+
+
+def test_approve_with_schedule_creates_variants(client, fake_generate_post):
+    _put_profile(client, review_before_posting=True)
+    target = client.post(
+        "/api/targets",
+        json={
+            "platform_id": "facebook",
+            "external_id": "https://www.facebook.com/groups/x",
+            "name": "X",
+        },
+    ).json()
+    post = _generate(client)
+    sched = (datetime.now(UTC) + timedelta(hours=2)).isoformat()
+    r = client.post(
+        f"/api/posts/{post['id']}/approve",
+        json={"target_ids": [target["id"]], "scheduled_for": sched},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == PostStatus.SCHEDULED.value
+    assert len(body["variants"]) == 1
+    assert body["variants"][0]["target_id"] == target["id"]
+
+
+def test_approve_rejects_non_pending(client, fake_generate_post):
+    _put_profile(client, review_before_posting=False)
+    post = _generate(client)  # status=DRAFT
+    r = client.post(
+        f"/api/posts/{post['id']}/approve",
+        json={"target_ids": [], "scheduled_for": None},
+    )
+    assert r.status_code == 409
+
+
+def test_reject_transitions_to_skipped(client, fake_generate_post):
+    _put_profile(client, review_before_posting=True)
+    post = _generate(client)
+    r = client.post(
+        f"/api/posts/{post['id']}/reject",
+        json={"reason": "too salesy"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == PostStatus.SKIPPED.value
+
+
+def test_regenerate_replaces_text(client, fake_generate_post):
+    _put_profile(client, review_before_posting=True)
+    post = _generate(client)
+    original_text = post["text"]
+    r = client.post(
+        f"/api/posts/{post['id']}/regenerate",
+        json={"topic_hint": "new angle", "generate_image": False},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["text"] != original_text
+    assert "new angle" in body["text"]
+    # Still in PENDING_REVIEW — regeneration doesn't auto-approve.
+    assert body["status"] == PostStatus.PENDING_REVIEW.value
+
+
+def test_approve_all_filters_by_post_type(client, fake_generate_post):
+    _put_profile(client, review_before_posting=True)
+    info = _generate(client, post_type="informative")
+    sell = _generate(client, post_type="hard_sell")
+
+    r = client.post(
+        "/api/posts/review/approve-all",
+        json={"post_type": "informative", "scheduled_for": None},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body) == 1
+    assert body[0]["id"] == info["id"]
+    assert body[0]["status"] == PostStatus.DRAFT.value
+
+    # sell is still pending
+    r_sell = client.get(f"/api/posts/{sell['id']}")
+    assert r_sell.json()["status"] == PostStatus.PENDING_REVIEW.value
+
+
+def test_approve_all_without_filter(client, fake_generate_post):
+    _put_profile(client, review_before_posting=True)
+    _generate(client, post_type="informative")
+    _generate(client, post_type="hard_sell")
+
+    r = client.post(
+        "/api/posts/review/approve-all",
+        json={"post_type": None, "scheduled_for": None},
+    )
+    assert r.status_code == 200
+    assert len(r.json()) == 2
+
+
+def test_thumbs_feedback_on_pending_post(client, fake_generate_post):
+    _put_profile(client, review_before_posting=True)
+    post = _generate(client)
+    r = client.post(
+        "/api/feedback",
+        json={"post_id": post["id"], "rating": "up"},
+    )
+    assert r.status_code == 201

--- a/backend/tests/test_security_and_ops.py
+++ b/backend/tests/test_security_and_ops.py
@@ -1,0 +1,217 @@
+"""M8 — Production polish: PIN auth, Fernet encryption, backups, observability.
+
+- Fernet round-trip + backwards-compat with legacy plaintext.
+- PlatformCredential.access_token transparently encrypts at rest.
+- Dashboard PIN middleware blocks /api/*, allows /healthz + /api/auth/*.
+- Successful login sets a session cookie that unlocks /api/*.
+- /metrics returns Prometheus exposition text with request counters.
+- Backup creates a zip with app.db inside.
+"""
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from app.db.models import PlatformCredential
+from app.security import (
+    _FERNET_PREFIX,
+    decrypt_str,
+    encrypt_str,
+)
+
+
+# ---------- Fernet ----------
+
+
+def test_fernet_roundtrip():
+    token = encrypt_str("hello-world")
+    assert token.startswith(_FERNET_PREFIX)
+    assert decrypt_str(token) == "hello-world"
+
+
+def test_fernet_passthrough_on_legacy_plaintext():
+    # Values without the fernet: prefix are returned unchanged.
+    assert decrypt_str("plain-old-token") == "plain-old-token"
+
+
+def test_fernet_encrypts_only_once():
+    encrypted = encrypt_str("s3cret")
+    re_encrypted = encrypt_str(encrypted)
+    # Second call is a no-op — still decrypts to the original.
+    assert decrypt_str(re_encrypted) == "s3cret"
+
+
+def test_fernet_empty_string_is_passthrough():
+    assert encrypt_str("") == ""
+
+
+# ---------- PlatformCredential encryption ----------
+
+
+def test_credential_access_token_encrypted_at_rest(db):
+    c = PlatformCredential(
+        platform_id="instagram",
+        account_id="IG_ENC",
+        access_token="SUPER_SECRET_TOKEN",
+    )
+    db.add(c)
+    db.commit()
+    db.refresh(c)
+
+    # Raw column stores the ciphertext prefix.
+    assert c.access_token_encrypted.startswith(_FERNET_PREFIX)
+    # Property returns the plaintext.
+    assert c.access_token == "SUPER_SECRET_TOKEN"
+
+
+def test_credential_reads_legacy_plaintext(db):
+    """A row that was written before M8 still reads OK."""
+    c = PlatformCredential(
+        platform_id="threads",
+        account_id="TH_OLD",
+        access_token="LEGACY_PLAIN",
+    )
+    db.add(c)
+    db.commit()
+    # Simulate old plaintext by overwriting the raw column.
+    c.access_token_encrypted = "LEGACY_PLAIN"
+    db.commit()
+    db.refresh(c)
+    assert c.access_token == "LEGACY_PLAIN"
+
+
+# ---------- PIN auth ----------
+
+
+def test_auth_disabled_when_pin_empty(client, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "dashboard_pin", "", raising=False)
+    r = client.get("/api/auth/status")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["auth_required"] is False
+    assert body["authenticated"] is True
+
+
+def test_auth_blocks_without_pin(client, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "dashboard_pin", "1234", raising=False)
+    r = client.get("/api/posts")
+    assert r.status_code == 401
+
+
+def test_auth_allows_with_header(client, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "dashboard_pin", "1234", raising=False)
+    r = client.get("/api/posts", headers={"X-Dashboard-Pin": "1234"})
+    assert r.status_code == 200
+
+
+def test_auth_allows_with_cookie_after_login(client, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "dashboard_pin", "1234", raising=False)
+    r = client.post("/api/auth/login", json={"pin": "1234"})
+    assert r.status_code == 200
+    # Cookie is set by TestClient automatically.
+    r2 = client.get("/api/posts")
+    assert r2.status_code == 200
+
+
+def test_auth_rejects_wrong_pin(client, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "dashboard_pin", "1234", raising=False)
+    r = client.post("/api/auth/login", json={"pin": "wrong"})
+    assert r.status_code == 401
+
+
+def test_healthz_bypasses_auth(client, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "dashboard_pin", "1234", raising=False)
+    assert client.get("/healthz").status_code == 200
+
+
+# ---------- Observability ----------
+
+
+def test_metrics_endpoint_returns_exposition_format(client):
+    # Fire a couple of requests to populate counters.
+    client.get("/healthz")
+    client.get("/api/status")
+    r = client.get("/metrics")
+    assert r.status_code == 200
+    body = r.text
+    assert "# TYPE http_requests_total counter" in body
+    assert "http_requests_total{" in body
+
+
+def test_request_id_header_added(client):
+    r = client.get("/healthz")
+    assert "x-request-id" in {k.lower() for k in r.headers.keys()}
+    assert len(r.headers["X-Request-ID"]) >= 8
+
+
+def test_request_id_echoes_client_supplied(client):
+    r = client.get("/healthz", headers={"X-Request-ID": "my-trace-123"})
+    assert r.headers["X-Request-ID"] == "my-trace-123"
+
+
+# ---------- Backups ----------
+
+
+def test_backup_run_creates_zip_with_app_db(tmp_path, monkeypatch):
+    # Point db_url + backup_dir at the tmp filesystem.
+    from app.config import settings
+    from app.services import backups
+
+    db_file = tmp_path / "app.db"
+    # Make a small sqlite file to snapshot.
+    import sqlite3
+
+    con = sqlite3.connect(str(db_file))
+    con.execute("CREATE TABLE t (id INTEGER)")
+    con.execute("INSERT INTO t VALUES (1)")
+    con.commit()
+    con.close()
+
+    backup_dir = tmp_path / "backups"
+    monkeypatch.setattr(settings, "db_url", f"sqlite:///{db_file}", raising=False)
+    monkeypatch.setattr(settings, "backup_dir", str(backup_dir), raising=False)
+
+    out = backups.run_backup()
+    assert out.exists()
+    with zipfile.ZipFile(out) as zf:
+        names = zf.namelist()
+        assert "app.db" in names
+
+
+def test_backup_prune_removes_old_archives(tmp_path, monkeypatch):
+    import os
+    import time
+
+    from app.config import settings
+    from app.services import backups
+
+    backup_dir = tmp_path / "backups"
+    backup_dir.mkdir()
+    monkeypatch.setattr(settings, "backup_dir", str(backup_dir), raising=False)
+    monkeypatch.setattr(settings, "backup_keep_days", 1, raising=False)
+
+    # An old file (2 days) and a fresh file.
+    old = backup_dir / "autoposter-2020-01-01T00-00-00Z.zip"
+    old.write_bytes(b"PK\x05\x06" + b"\x00" * 18)
+    os.utime(old, (time.time() - 2 * 24 * 3600, time.time() - 2 * 24 * 3600))
+    fresh = backup_dir / "autoposter-2099-01-01T00-00-00Z.zip"
+    fresh.write_bytes(b"PK\x05\x06" + b"\x00" * 18)
+
+    pruned = backups.prune_old_backups(backup_dir)
+    assert pruned == 1
+    assert not old.exists()
+    assert fresh.exists()

--- a/backend/tests/test_targets_agent.py
+++ b/backend/tests/test_targets_agent.py
@@ -1,0 +1,362 @@
+"""M3 Targets Agent + API tests.
+
+We stub Claude (`score_targets`, `cluster_targets`) and the extension bridge so
+nothing hits the network. Real SQLite + real FastAPI routing.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.agents.targets import ClusterAssignment, ClusterResult, ScoreResult, TargetScore
+
+
+@pytest.fixture()
+def profile_ready(client):
+    """Seed a BusinessProfile so /score and /cluster don't 400."""
+    r = client.put(
+        "/api/business-profile",
+        json={
+            "name": "Garden Nook",
+            "description": "Indoor gardening supplies for apartment dwellers.",
+            "target_audience": "Urban renters who grow herbs on windowsills.",
+        },
+    )
+    assert r.status_code == 200, r.text
+
+
+@pytest.fixture()
+def fake_agent(monkeypatch):
+    """Return a (score_spy, cluster_spy) pair — tests inject scripted behaviour."""
+
+    class Spy:
+        calls: list
+        script: object
+
+        def __init__(self) -> None:
+            self.calls = []
+            self.script = None
+
+    score_spy = Spy()
+    cluster_spy = Spy()
+
+    def fake_score(profile, targets):
+        score_spy.calls.append([t.id for t in targets])
+        if callable(score_spy.script):
+            return score_spy.script(profile, targets)
+        return ScoreResult(
+            scores=[
+                TargetScore(target_id=t.id, score=70 if "garden" in t.name.lower() else 20,
+                            reasoning=f"auto-{t.name}")
+                for t in targets
+            ],
+            input_tokens=500,
+            output_tokens=200,
+            cost_usd=0.005,
+        )
+
+    def fake_cluster(profile, targets):
+        cluster_spy.calls.append([t.id for t in targets])
+        if callable(cluster_spy.script):
+            return cluster_spy.script(profile, targets)
+        # Naive split: first half -> list A, second half -> list B.
+        half = len(targets) // 2 or 1
+        return ClusterResult(
+            lists=[
+                ClusterAssignment(
+                    list_name="Urban gardeners",
+                    target_ids=[t.id for t in targets[:half]],
+                ),
+                ClusterAssignment(
+                    list_name="General cooks",
+                    target_ids=[t.id for t in targets[half:]],
+                ),
+            ],
+            cost_usd=0.004,
+        )
+
+    monkeypatch.setattr("app.api.targets.score_targets", fake_score, raising=True)
+    monkeypatch.setattr("app.api.targets.cluster_targets", fake_cluster, raising=True)
+    return score_spy, cluster_spy
+
+
+# ---------- agent unit-ish tests (no API) ----------
+
+
+def test_score_result_clamps_and_filters_unknown_ids(monkeypatch):
+    """If Claude returns an out-of-range score or unknown id, we clamp/drop it."""
+    from app.agents import targets as agent_mod
+
+    def stub_call(system, user):
+        return (
+            '{"scores":['
+            '{"id": 1, "score": 150, "reasoning": "over"},'
+            '{"id": 2, "score": -20, "reasoning": "under"},'
+            '{"id": 999, "score": 50, "reasoning": "unknown"}'
+            "]}",
+            10,
+            5,
+        )
+
+    monkeypatch.setattr(agent_mod, "_call_claude", stub_call, raising=True)
+
+    class FakeTarget:
+        def __init__(self, tid):
+            self.id = tid
+            self.name = f"t{tid}"
+            self.platform_id = "facebook"
+            self.category = None
+            self.description_snippet = None
+            self.member_count = None
+
+    class FakeProfile:
+        name = "X"
+        description = "Y"
+        products = None
+        target_audience = None
+        language = "en"
+
+    result = agent_mod.score_targets(FakeProfile(), [FakeTarget(1), FakeTarget(2)])
+    # id=999 should be dropped; 150→100; -20→0.
+    by_id = {s.target_id: s.score for s in result.scores}
+    assert by_id == {1: 100, 2: 0}
+
+
+def test_cluster_leftover_goes_to_other(monkeypatch):
+    from app.agents import targets as agent_mod
+
+    def stub_call(system, user):
+        return (
+            '{"lists":[{"name":"A","target_ids":[1]}]}',
+            10,
+            5,
+        )
+
+    monkeypatch.setattr(agent_mod, "_call_claude", stub_call, raising=True)
+
+    class FakeTarget:
+        def __init__(self, tid):
+            self.id = tid
+            self.name = f"t{tid}"
+            self.platform_id = "facebook"
+            self.category = None
+            self.description_snippet = None
+            self.member_count = None
+
+    class FakeProfile:
+        name = "X"
+        description = "Y"
+        products = None
+        target_audience = None
+        language = "en"
+
+    result = agent_mod.cluster_targets(
+        FakeProfile(), [FakeTarget(1), FakeTarget(2), FakeTarget(3)]
+    )
+    # id=1 is in A; 2 and 3 go to "Other".
+    names = [lg.list_name for lg in result.lists]
+    assert "Other" in names
+    other = next(lg for lg in result.lists if lg.list_name == "Other")
+    assert sorted(other.target_ids) == [2, 3]
+
+
+def test_cluster_single_target_shortcircuits(monkeypatch):
+    """With ≤1 target, cluster should skip Claude entirely."""
+    from app.agents import targets as agent_mod
+
+    called = {"n": 0}
+
+    def stub_call(system, user):
+        called["n"] += 1
+        raise AssertionError("should not be called")
+
+    monkeypatch.setattr(agent_mod, "_call_claude", stub_call, raising=True)
+
+    class FakeTarget:
+        id = 1
+        name = "x"
+        platform_id = "facebook"
+        category = None
+        description_snippet = None
+        member_count = None
+
+    class FakeProfile:
+        name = "X"
+        description = "Y"
+        products = None
+        target_audience = None
+        language = "en"
+
+    result = agent_mod.cluster_targets(FakeProfile(), [FakeTarget()])
+    assert called["n"] == 0
+    assert len(result.lists) == 1
+    assert result.lists[0].list_name == "All targets"
+
+
+# ---------- API tests ----------
+
+
+def _mk_target(client, external_id: str, name: str, source: str = "scraped_suggested"):
+    return client.post(
+        "/api/targets",
+        json={
+            "platform_id": "facebook",
+            "external_id": external_id,
+            "name": name,
+            "source": source,
+        },
+    ).json()
+
+
+def test_manual_create_auto_approves(client):
+    t = _mk_target(client, "https://www.facebook.com/groups/1", "Manual Group", source="manual")
+    assert t["review_status"] == "approved"
+
+
+def test_scraped_create_is_pending(client):
+    t = _mk_target(
+        client, "https://www.facebook.com/groups/2", "Scraped Group",
+        source="scraped_suggested",
+    )
+    assert t["review_status"] == "pending"
+
+
+def test_score_endpoint_populates_relevance(client, profile_ready, fake_agent):
+    t1 = _mk_target(client, "https://fb/groups/a", "Herb garden lovers")
+    t2 = _mk_target(client, "https://fb/groups/b", "Random car club")
+    r = client.post("/api/targets/score", json={"target_ids": []})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert {s["target_id"] for s in body["scored"]} == {t1["id"], t2["id"]}
+    # Now the rows should have scores + reasoning.
+    reloaded = client.get("/api/targets").json()
+    by_name = {t["name"]: t for t in reloaded}
+    assert by_name["Herb garden lovers"]["relevance_score"] == 70
+    assert by_name["Random car club"]["relevance_score"] == 20
+
+
+def test_score_endpoint_respects_explicit_ids(client, profile_ready, fake_agent):
+    t1 = _mk_target(client, "https://fb/groups/a", "Herb garden lovers")
+    _mk_target(client, "https://fb/groups/b", "Random car club")
+    spy, _cluster = fake_agent
+    r = client.post("/api/targets/score", json={"target_ids": [t1["id"]]})
+    assert r.status_code == 200
+    assert spy.calls[-1] == [t1["id"]]
+
+
+def test_score_requires_profile(client, fake_agent):
+    """Without a BusinessProfile, /score should 400."""
+    _mk_target(client, "https://fb/groups/a", "G")
+    r = client.post("/api/targets/score", json={"target_ids": []})
+    assert r.status_code == 400
+
+
+def test_bulk_review_approve_and_reject(client):
+    t1 = _mk_target(client, "https://fb/groups/a", "A")
+    t2 = _mk_target(client, "https://fb/groups/b", "B")
+    r = client.post(
+        "/api/targets/bulk-review",
+        json={"target_ids": [t1["id"], t2["id"]], "review_status": "approved"},
+    )
+    assert r.status_code == 200
+    for row in r.json():
+        assert row["review_status"] == "approved"
+
+    r = client.post(
+        "/api/targets/bulk-review",
+        json={"target_ids": [t2["id"]], "review_status": "rejected"},
+    )
+    assert r.status_code == 200
+    assert r.json()[0]["review_status"] == "rejected"
+
+
+def test_cluster_writes_list_name_on_approved(client, profile_ready, fake_agent):
+    t1 = _mk_target(client, "https://fb/groups/a", "A")
+    t2 = _mk_target(client, "https://fb/groups/b", "B")
+    t3 = _mk_target(client, "https://fb/groups/c", "C")
+    t4 = _mk_target(client, "https://fb/groups/d", "D")
+    client.post(
+        "/api/targets/bulk-review",
+        json={
+            "target_ids": [t1["id"], t2["id"], t3["id"], t4["id"]],
+            "review_status": "approved",
+        },
+    )
+    r = client.post("/api/targets/cluster", json={"target_ids": []})
+    assert r.status_code == 200, r.text
+    lists = r.json()["lists"]
+    assert len(lists) == 2
+    # All four targets should now have a list_name.
+    reloaded = client.get("/api/targets").json()
+    assert all(t["list_name"] in {"Urban gardeners", "General cooks"} for t in reloaded)
+
+
+def test_list_filters_by_review_status(client):
+    t1 = _mk_target(client, "https://fb/groups/a", "A", source="scraped_suggested")
+    _mk_target(client, "https://fb/groups/b", "B", source="manual")  # auto-approved
+    r = client.get("/api/targets?review_status=pending").json()
+    assert [t["id"] for t in r] == [t1["id"]]
+    r = client.get("/api/targets?review_status=approved").json()
+    assert t1["id"] not in [t["id"] for t in r]
+
+
+def test_discover_endpoint_calls_bridge(client, monkeypatch):
+    """/discover should call the extension bridge and upsert pending targets."""
+    async def fake_request(payload, timeout=60):
+        assert payload["type"] == "list_suggested_groups"
+        return {
+            "ok": True,
+            "groups": [
+                {
+                    "url": "https://fb/groups/new1",
+                    "external_id": "https://fb/groups/new1",
+                    "name": "Urban gardeners club",
+                    "member_count": 15000,
+                    "description": "For apartment gardeners",
+                },
+                {
+                    "external_id": "https://fb/groups/new2",
+                    "name": "Pest control tips",
+                    "member_count": 8000,
+                },
+            ],
+        }
+
+    from app.ws import extension_bridge as br
+    monkeypatch.setattr(br.bridge, "request", fake_request, raising=True)
+    r = client.post("/api/targets/discover")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["created"] == 2
+    assert body["updated"] == 0
+    # Both should be pending.
+    rows = client.get("/api/targets?review_status=pending").json()
+    assert len(rows) == 2
+    assert rows[0]["description_snippet"] == "For apartment gardeners" or \
+        rows[1]["description_snippet"] == "For apartment gardeners"
+
+
+def test_discover_second_call_updates(client, monkeypatch):
+    """Re-running discover on the same url should update, not duplicate."""
+    async def fake_request(payload, timeout=60):
+        return {
+            "ok": True,
+            "groups": [
+                {
+                    "external_id": "https://fb/groups/same",
+                    "name": "Updated name",
+                    "member_count": 42,
+                }
+            ],
+        }
+
+    from app.ws import extension_bridge as br
+    monkeypatch.setattr(br.bridge, "request", fake_request, raising=True)
+
+    r1 = client.post("/api/targets/discover").json()
+    r2 = client.post("/api/targets/discover").json()
+    assert r1["created"] == 1 and r1["updated"] == 0
+    assert r2["created"] == 0 and r2["updated"] == 1
+    rows = client.get("/api/targets").json()
+    assert len(rows) == 1
+    assert rows[0]["name"] == "Updated name"
+    assert rows[0]["member_count"] == 42

--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+.next/
+out/
+*.log
+.env*.local
+.DS_Store
+next-env.d.ts

--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -5,3 +5,4 @@ out/
 .env*.local
 .DS_Store
 next-env.d.ts
+tsconfig.tsbuildinfo

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,0 +1,23 @@
+# autoposter-AI dashboard
+
+Next.js 15 + Tailwind + shadcn-style UI. Localhost-only, no auth in v1.
+
+## Run
+
+```bash
+npm install
+npm run dev      # http://localhost:3000
+```
+
+Set `NEXT_PUBLIC_API_URL` if the backend isn't at `http://localhost:8787`.
+
+## Pages
+
+| Path | Purpose |
+|------|---------|
+| `/profile` | Business profile (singleton). Tone / length / emoji / posting window. |
+| `/targets` | Add / remove / sync targets (FB group URLs). |
+| `/compose` | Generate via Claude, attach image, publish now or schedule. |
+| `/queue` | All posts with per-variant status, thumbs up/down, delete. |
+
+The yellow banner on `/profile` is the Facebook ToS warning — do not remove.

--- a/dashboard/app/analytics/page.tsx
+++ b/dashboard/app/analytics/page.tsx
@@ -1,0 +1,362 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  applyProposal,
+  collectMetricsNow,
+  generateAnalystReport,
+  getAnalyticsSummary,
+  getTopPerformers,
+  listAnalystReports,
+  listProposals,
+  refreshFewShotStore,
+  rejectProposal,
+  type AnalystReport,
+  type AnalyticsSummary,
+  type OptimizerProposal,
+  type TopPerformer,
+} from "@/lib/api";
+import { formatDate } from "@/lib/utils";
+import {
+  BarChart3,
+  CheckCircle2,
+  RefreshCw,
+  Sparkles,
+  TrendingDown,
+  TrendingUp,
+  XCircle,
+} from "lucide-react";
+
+export default function AnalyticsPage() {
+  const [summary, setSummary] = useState<AnalyticsSummary | null>(null);
+  const [top, setTop] = useState<TopPerformer[]>([]);
+  const [bottom, setBottom] = useState<TopPerformer[]>([]);
+  const [reports, setReports] = useState<AnalystReport[]>([]);
+  const [proposals, setProposals] = useState<OptimizerProposal[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [working, setWorking] = useState<string | null>(null);
+  const [msg, setMsg] = useState<string | null>(null);
+
+  const refresh = async () => {
+    setLoading(true);
+    try {
+      const [s, t, b, r, p] = await Promise.all([
+        getAnalyticsSummary(7),
+        getTopPerformers(7, 5, false),
+        getTopPerformers(7, 5, true),
+        listAnalystReports(),
+        listProposals(),
+      ]);
+      setSummary(s);
+      setTop(t);
+      setBottom(b);
+      setReports(r);
+      setProposals(p);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const collect = async () => {
+    setWorking("collect");
+    setMsg(null);
+    try {
+      const r = await collectMetricsNow();
+      setMsg(
+        `Collected: touched ${r.variants_touched} variants, ${r.rows_created} new rows.`,
+      );
+      await refresh();
+    } catch (e) {
+      setMsg(e instanceof Error ? e.message : String(e));
+    } finally {
+      setWorking(null);
+    }
+  };
+
+  const runReport = async () => {
+    setWorking("report");
+    setMsg(null);
+    try {
+      const r = await generateAnalystReport({ days: 7 });
+      setMsg(`New report #${r.id} — cost $${r.cost_usd.toFixed(4)}.`);
+      await refresh();
+    } catch (e) {
+      setMsg(e instanceof Error ? e.message : String(e));
+    } finally {
+      setWorking(null);
+    }
+  };
+
+  const refreshFewShot = async () => {
+    setWorking("fewshot");
+    setMsg(null);
+    try {
+      const r = await refreshFewShotStore();
+      setMsg(`Few-shot store: ${r.inserted} examples.`);
+    } catch (e) {
+      setMsg(e instanceof Error ? e.message : String(e));
+    } finally {
+      setWorking(null);
+    }
+  };
+
+  const onApply = async (id: number) => {
+    await applyProposal(id);
+    await refresh();
+  };
+
+  const onReject = async (id: number) => {
+    await rejectProposal(id);
+    await refresh();
+  };
+
+  if (loading) return <div>Loading…</div>;
+
+  return (
+    <div className="space-y-6 max-w-6xl">
+      <Card>
+        <CardHeader>
+          <div className="flex items-start justify-between gap-4 flex-wrap">
+            <div>
+              <CardTitle className="flex items-center gap-2">
+                <BarChart3 className="h-5 w-5" />
+                Analytics — Last 7 days
+              </CardTitle>
+              <CardDescription>
+                KPIs + AI-driven insights. Analyst runs weekly (Sunday 21:00
+                UTC). You can trigger it manually here.
+              </CardDescription>
+            </div>
+            <div className="flex gap-2">
+              <Button size="sm" variant="outline" onClick={collect} disabled={!!working}>
+                <RefreshCw className="h-4 w-4 mr-1" />
+                Collect metrics
+              </Button>
+              <Button size="sm" variant="outline" onClick={refreshFewShot} disabled={!!working}>
+                Refresh few-shot
+              </Button>
+              <Button size="sm" onClick={runReport} disabled={!!working}>
+                <Sparkles className="h-4 w-4 mr-1" />
+                Run Analyst
+              </Button>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {msg && (
+            <div className="text-sm mb-3 rounded bg-muted px-3 py-2">{msg}</div>
+          )}
+          <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
+            <Kpi label="Posts" value={summary?.posts ?? 0} />
+            <Kpi label="Likes" value={summary?.likes ?? 0} />
+            <Kpi label="Comments" value={summary?.comments ?? 0} />
+            <Kpi label="Shares" value={summary?.shares ?? 0} />
+            <Kpi
+              label="Avg score"
+              value={(summary?.avg_engagement_score ?? 0).toFixed(1)}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <TrendingUp className="h-5 w-5" /> Top performers
+            </CardTitle>
+            <CardDescription>Highest engagement_score in window.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <PerformersList items={top} empty="No posts with metrics yet." />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <TrendingDown className="h-5 w-5" /> Bottom performers
+            </CardTitle>
+            <CardDescription>Post types / angles to reconsider.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <PerformersList items={bottom} empty="Nothing collected yet." />
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Optimizer proposals</CardTitle>
+          <CardDescription>
+            Small safe changes (posting window, ratios) may auto-apply when
+            confidence ≥ 0.75. Others wait for you.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {proposals.length === 0 ? (
+            <div className="text-sm text-muted-foreground">No proposals.</div>
+          ) : (
+            <div className="space-y-2">
+              {proposals.map((p) => (
+                <div
+                  key={p.id}
+                  className="rounded border p-3 flex items-start justify-between gap-3 flex-wrap"
+                >
+                  <div className="flex-1 min-w-0 space-y-1">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <Badge
+                        variant={
+                          p.status === "applied"
+                            ? "success"
+                            : p.status === "rejected"
+                              ? "outline"
+                              : "warning"
+                        }
+                      >
+                        {p.status}
+                      </Badge>
+                      {p.auto_applied && (
+                        <Badge variant="secondary">auto</Badge>
+                      )}
+                      <span className="font-medium">{p.field}</span>
+                      <span className="text-xs text-muted-foreground">
+                        confidence {(p.confidence * 100).toFixed(0)}%
+                      </span>
+                    </div>
+                    <div className="text-sm text-muted-foreground">
+                      {p.reasoning}
+                    </div>
+                    <div className="text-xs">
+                      <code className="bg-muted px-1 rounded">
+                        {JSON.stringify(p.current_value)}
+                      </code>
+                      {" → "}
+                      <code className="bg-muted px-1 rounded">
+                        {JSON.stringify(p.proposed_value)}
+                      </code>
+                    </div>
+                  </div>
+                  {p.status === "pending" && (
+                    <div className="flex gap-1">
+                      <Button
+                        size="sm"
+                        onClick={() => onApply(p.id)}
+                        disabled={!!working}
+                      >
+                        <CheckCircle2 className="h-4 w-4 mr-1" />
+                        Apply
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => onReject(p.id)}
+                        disabled={!!working}
+                      >
+                        <XCircle className="h-4 w-4 mr-1" />
+                        Reject
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Recent Analyst reports</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {reports.length === 0 ? (
+            <div className="text-sm text-muted-foreground">
+              No reports yet. Click "Run Analyst" to generate one.
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {reports.map((r) => (
+                <div key={r.id} className="rounded border p-3 space-y-2">
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground flex-wrap">
+                    <span>#{r.id}</span>
+                    <span>
+                      {formatDate(r.period_start)} → {formatDate(r.period_end)}
+                    </span>
+                    <span>${r.cost_usd.toFixed(4)}</span>
+                    <span>{r.model}</span>
+                  </div>
+                  <div className="text-sm whitespace-pre-wrap">{r.summary}</div>
+                  {r.body.patterns && r.body.patterns.length > 0 && (
+                    <details className="text-xs">
+                      <summary className="cursor-pointer">
+                        {r.body.patterns.length} patterns
+                      </summary>
+                      <ul className="list-disc pl-5 pt-1 space-y-0.5">
+                        {r.body.patterns.map((line, i) => (
+                          <li key={i}>{line}</li>
+                        ))}
+                      </ul>
+                    </details>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function Kpi({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="rounded border p-3 bg-card">
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <div className="text-2xl font-semibold">{value}</div>
+    </div>
+  );
+}
+
+function PerformersList({
+  items,
+  empty,
+}: {
+  items: TopPerformer[];
+  empty: string;
+}) {
+  if (items.length === 0)
+    return <div className="text-sm text-muted-foreground">{empty}</div>;
+  return (
+    <div className="space-y-2">
+      {items.map((p) => (
+        <div key={p.post_id} className="rounded border p-2 bg-card">
+          <div className="flex items-center gap-2 text-xs">
+            <Badge variant="outline">{p.post_type}</Badge>
+            <span className="font-medium">
+              score {p.engagement_score.toFixed(1)}
+            </span>
+            {p.posted_at && (
+              <span className="text-muted-foreground">
+                {formatDate(p.posted_at)}
+              </span>
+            )}
+          </div>
+          <div className="text-sm mt-1 line-clamp-2">{p.text_preview}</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/dashboard/app/compose/page.tsx
+++ b/dashboard/app/compose/page.tsx
@@ -1,0 +1,388 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Select } from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import {
+  createPost,
+  generatePost,
+  listTargets,
+  publishPost,
+  schedulePost,
+  uploadMedia,
+  type Post,
+  type PostType,
+  type Target,
+} from "@/lib/api";
+
+const POST_TYPES: PostType[] = [
+  "informative",
+  "soft_sell",
+  "hard_sell",
+  "engagement",
+  "story",
+  "motivational",
+  "testimonial",
+  "hot_take",
+  "seasonal",
+];
+
+export default function ComposePage() {
+  const [targets, setTargets] = useState<Target[]>([]);
+  const [selectedTargetIds, setSelectedTargetIds] = useState<Set<number>>(
+    new Set(),
+  );
+  const [draft, setDraft] = useState<Post | null>(null);
+  const [text, setText] = useState("");
+  const [firstComment, setFirstComment] = useState("");
+  const [ctaUrl, setCtaUrl] = useState("");
+  const [postType, setPostType] = useState<PostType>("informative");
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [topicHint, setTopicHint] = useState("");
+  const [scheduledFor, setScheduledFor] = useState("");
+  const [busy, setBusy] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    listTargets({ active_only: true }).then(setTargets).catch(() => {});
+  }, []);
+
+  const toggleTarget = (id: number) => {
+    setSelectedTargetIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const onUpload = async (file: File) => {
+    setBusy("Uploading image…");
+    try {
+      const res = await uploadMedia(file);
+      setImageUrl(res.url);
+      setMessage(`Uploaded ${res.filename} (${(res.size_bytes / 1024).toFixed(0)} KB).`);
+    } catch (e) {
+      setMessage(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const onGenerate = async (withImage: boolean) => {
+    setBusy(withImage ? "Generating text + image…" : "Generating text…");
+    setMessage(null);
+    try {
+      const d = await generatePost({
+        post_type: postType,
+        topic_hint: topicHint || undefined,
+        generate_image: withImage,
+        use_few_shot: true,
+      });
+      setDraft(d);
+      setText(d.text);
+      setImageUrl(d.image_url);
+    } catch (e) {
+      setMessage(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const ensureDraft = async (): Promise<Post> => {
+    if (draft) {
+      return draft;
+    }
+    const d = await createPost({
+      post_type: postType,
+      text,
+      image_url: imageUrl,
+      first_comment: firstComment || null,
+      cta_url: ctaUrl || null,
+    });
+    setDraft(d);
+    return d;
+  };
+
+  const onPublishNow = async () => {
+    if (!text.trim()) {
+      setMessage("Text is empty.");
+      return;
+    }
+    if (selectedTargetIds.size === 0) {
+      setMessage("Select at least one target.");
+      return;
+    }
+    setBusy("Publishing…");
+    setMessage(null);
+    try {
+      const d = await ensureDraft();
+      const result = await publishPost(d.id, {
+        target_ids: [...selectedTargetIds],
+        generate_spintax: selectedTargetIds.size > 1,
+      });
+      const ok = result.variants.filter((v) => v.status === "posted").length;
+      const failed = result.variants.filter((v) => v.status === "failed");
+      setMessage(
+        `Publish result: ${ok}/${result.variants.length} posted.` +
+          (failed.length
+            ? ` Failures: ${failed.map((f) => f.error).join("; ")}`
+            : ""),
+      );
+    } catch (e) {
+      setMessage(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const onSchedule = async () => {
+    if (!scheduledFor) {
+      setMessage("Pick a date/time.");
+      return;
+    }
+    if (selectedTargetIds.size === 0) {
+      setMessage("Select at least one target.");
+      return;
+    }
+    setBusy("Scheduling…");
+    setMessage(null);
+    try {
+      const d = await ensureDraft();
+      await schedulePost(d.id, {
+        target_ids: [...selectedTargetIds],
+        scheduled_for: new Date(scheduledFor).toISOString(),
+        generate_spintax: selectedTargetIds.size > 1,
+      });
+      setMessage(`Scheduled for ${new Date(scheduledFor).toLocaleString()}.`);
+    } catch (e) {
+      setMessage(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const resetDraft = () => {
+    setDraft(null);
+    setText("");
+    setFirstComment("");
+    setCtaUrl("");
+    setImageUrl(null);
+    setMessage(null);
+  };
+
+  return (
+    <div className="space-y-4 max-w-4xl">
+      <Card>
+        <CardHeader>
+          <CardTitle>Compose a post</CardTitle>
+          <CardDescription>
+            Generate a draft with Claude, edit it, attach an image, pick
+            targets, then publish now or schedule.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div className="space-y-1.5">
+              <Label>Post type</Label>
+              <Select
+                value={postType}
+                onChange={(e) => setPostType(e.target.value as PostType)}
+              >
+                {POST_TYPES.map((t) => (
+                  <option key={t} value={t}>
+                    {t}
+                  </option>
+                ))}
+              </Select>
+            </div>
+            <div className="space-y-1.5 md:col-span-2">
+              <Label>Topic hint (optional)</Label>
+              <Input
+                value={topicHint}
+                onChange={(e) => setTopicHint(e.target.value)}
+                placeholder="e.g. launch of our new pricing tier"
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              disabled={!!busy}
+              onClick={() => onGenerate(false)}
+            >
+              Generate text (Claude)
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={!!busy}
+              onClick={() => onGenerate(true)}
+            >
+              Generate text + image (Gemini)
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              disabled={!!busy}
+              onClick={resetDraft}
+            >
+              New draft
+            </Button>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>Post text</Label>
+            <Textarea
+              rows={8}
+              value={text}
+              onChange={(e) => {
+                setText(e.target.value);
+                if (draft) setDraft(null); // text edited → force re-create on publish
+              }}
+            />
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-1.5">
+              <Label>First comment (optional)</Label>
+              <Textarea
+                rows={2}
+                value={firstComment}
+                onChange={(e) => setFirstComment(e.target.value)}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label>CTA URL (optional)</Label>
+              <Input
+                type="url"
+                value={ctaUrl}
+                onChange={(e) => setCtaUrl(e.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>Image</Label>
+            <div className="flex items-center gap-3">
+              <Input
+                type="file"
+                accept="image/*"
+                onChange={(e) => {
+                  const f = e.target.files?.[0];
+                  if (f) onUpload(f);
+                }}
+              />
+              {imageUrl && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => setImageUrl(null)}
+                >
+                  Remove
+                </Button>
+              )}
+            </div>
+            {imageUrl && (
+              <div className="mt-2 rounded-md border p-2 inline-block">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={imageUrl}
+                  alt="preview"
+                  className="max-h-48 rounded"
+                />
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Targets</CardTitle>
+          <CardDescription>
+            Select one or more. Multi-target posts get auto-spintaxed to
+            avoid identical text across groups.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {targets.length === 0 ? (
+            <div className="text-sm text-muted-foreground">
+              No active targets. Add some on the Targets page.
+            </div>
+          ) : (
+            <div className="flex flex-wrap gap-2">
+              {targets.map((t) => {
+                const on = selectedTargetIds.has(t.id);
+                return (
+                  <button
+                    key={t.id}
+                    type="button"
+                    onClick={() => toggleTarget(t.id)}
+                    className={
+                      "rounded-md border px-3 py-1.5 text-sm transition-colors " +
+                      (on
+                        ? "bg-primary text-primary-foreground border-primary"
+                        : "hover:bg-accent")
+                    }
+                  >
+                    {t.name}
+                    <Badge variant="outline" className="ml-2">
+                      {t.platform_id}
+                    </Badge>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Publish</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex flex-wrap items-end gap-3">
+            <Button disabled={!!busy} onClick={onPublishNow}>
+              {busy ?? "Publish now"}
+            </Button>
+            <div className="space-y-1.5">
+              <Label>Schedule for</Label>
+              <Input
+                type="datetime-local"
+                value={scheduledFor}
+                onChange={(e) => setScheduledFor(e.target.value)}
+              />
+            </div>
+            <Button
+              variant="outline"
+              disabled={!!busy || !scheduledFor}
+              onClick={onSchedule}
+            >
+              Schedule
+            </Button>
+          </div>
+          {message && (
+            <div className="text-sm rounded-md border bg-muted/40 p-3 whitespace-pre-wrap">
+              {message}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/dashboard/app/globals.css
+++ b/dashboard/app/globals.css
@@ -1,0 +1,54 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 240 10% 3.9%;
+    --card: 0 0% 100%;
+    --card-foreground: 240 10% 3.9%;
+    --primary: 240 5.9% 10%;
+    --primary-foreground: 0 0% 98%;
+    --secondary: 240 4.8% 95.9%;
+    --secondary-foreground: 240 5.9% 10%;
+    --muted: 240 4.8% 95.9%;
+    --muted-foreground: 240 3.8% 46.1%;
+    --accent: 240 4.8% 95.9%;
+    --accent-foreground: 240 5.9% 10%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 240 5.9% 90%;
+    --input: 240 5.9% 90%;
+    --ring: 240 5.9% 10%;
+    --radius: 0.5rem;
+  }
+
+  .dark {
+    --background: 240 10% 3.9%;
+    --foreground: 0 0% 98%;
+    --card: 240 10% 3.9%;
+    --card-foreground: 0 0% 98%;
+    --primary: 0 0% 98%;
+    --primary-foreground: 240 5.9% 10%;
+    --secondary: 240 3.7% 15.9%;
+    --secondary-foreground: 0 0% 98%;
+    --muted: 240 3.7% 15.9%;
+    --muted-foreground: 240 5% 64.9%;
+    --accent: 240 3.7% 15.9%;
+    --accent-foreground: 0 0% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 240 3.7% 15.9%;
+    --input: 240 3.7% 15.9%;
+    --ring: 240 4.9% 83.9%;
+  }
+
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground;
+    font-feature-settings: "rlig" 1, "calt" 1;
+  }
+}

--- a/dashboard/app/humanizer/page.tsx
+++ b/dashboard/app/humanizer/page.tsx
@@ -1,0 +1,424 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import {
+  activatePause,
+  addBlackout,
+  deleteBlackout,
+  getHumanizer,
+  getPauseStatus,
+  HumanizerProfile,
+  listBlackouts,
+  listSessionHealth,
+  patchHumanizer,
+  resumeFromPause,
+  SessionHealth,
+  type BlackoutDate,
+  type SmartPauseInfo,
+} from "@/lib/api";
+import { formatDate } from "@/lib/utils";
+import { Loader2, Pause, Play, ShieldCheck, Trash2 } from "lucide-react";
+
+const STATUS_COLORS = {
+  healthy: "border-green-300 text-green-800",
+  warning: "border-amber-300 text-amber-800",
+  checkpoint: "border-red-400 text-red-800",
+  shadow_ban_suspected: "border-red-400 text-red-800",
+  paused: "border-muted-foreground text-muted-foreground",
+} as const;
+
+export default function HumanizerPage() {
+  const [profile, setProfile] = useState<HumanizerProfile | null>(null);
+  const [health, setHealth] = useState<SessionHealth[]>([]);
+  const [pause, setPause] = useState<SmartPauseInfo | null>(null);
+  const [blackouts, setBlackouts] = useState<BlackoutDate[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [newBlackout, setNewBlackout] = useState({ date: "", reason: "" });
+
+  const refresh = async () => {
+    const [p, h, ps, bs] = await Promise.all([
+      getHumanizer(),
+      listSessionHealth(),
+      getPauseStatus(),
+      listBlackouts(),
+    ]);
+    setProfile(p);
+    setHealth(h);
+    setPause(ps);
+    setBlackouts(bs);
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const update = (patch: Partial<HumanizerProfile>) => {
+    if (!profile) return;
+    setProfile({ ...profile, ...patch });
+  };
+
+  const save = async () => {
+    if (!profile) return;
+    setSaving(true);
+    try {
+      const next = await patchHumanizer({
+        typing_wpm_min: profile.typing_wpm_min,
+        typing_wpm_max: profile.typing_wpm_max,
+        mistake_rate: profile.mistake_rate,
+        pause_between_sentences_ms_min: profile.pause_between_sentences_ms_min,
+        pause_between_sentences_ms_max: profile.pause_between_sentences_ms_max,
+        mouse_path_curvature: profile.mouse_path_curvature,
+        idle_scroll_before_post_sec_min: profile.idle_scroll_before_post_sec_min,
+        idle_scroll_before_post_sec_max: profile.idle_scroll_before_post_sec_max,
+        schedule_jitter_minutes: profile.schedule_jitter_minutes,
+        consecutive_failures_threshold: profile.consecutive_failures_threshold,
+        smart_pause_minutes: profile.smart_pause_minutes,
+      });
+      setProfile(next);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const onPause = async () => {
+    const p = await activatePause();
+    setPause(p);
+  };
+
+  const onResume = async () => {
+    const p = await resumeFromPause();
+    setPause(p);
+  };
+
+  const addBo = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newBlackout.date) return;
+    const iso = new Date(newBlackout.date).toISOString();
+    await addBlackout({ date: iso, reason: newBlackout.reason || null });
+    setNewBlackout({ date: "", reason: "" });
+    setBlackouts(await listBlackouts());
+  };
+
+  if (!profile) {
+    return (
+      <div className="p-6 flex items-center gap-2 text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" /> Loading…
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 max-w-4xl">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <ShieldCheck className="h-5 w-5" /> Humanizer & Safety
+          </CardTitle>
+          <CardDescription>
+            Controls how "human" the browser interaction feels. Typing speed,
+            mouse paths, scheduling jitter, and the automatic cool-down when
+            something goes wrong.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <section className="grid md:grid-cols-2 gap-4">
+            <Field label="Typing WPM min">
+              <Input
+                type="number"
+                value={profile.typing_wpm_min}
+                onChange={(e) => update({ typing_wpm_min: +e.target.value })}
+              />
+            </Field>
+            <Field label="Typing WPM max">
+              <Input
+                type="number"
+                value={profile.typing_wpm_max}
+                onChange={(e) => update({ typing_wpm_max: +e.target.value })}
+              />
+            </Field>
+            <Field label="Mistake rate (0–1)">
+              <Input
+                type="number"
+                step="0.005"
+                value={profile.mistake_rate}
+                onChange={(e) => update({ mistake_rate: +e.target.value })}
+              />
+            </Field>
+            <Field label="Mouse path curvature (0–1)">
+              <Input
+                type="number"
+                step="0.05"
+                value={profile.mouse_path_curvature}
+                onChange={(e) =>
+                  update({ mouse_path_curvature: +e.target.value })
+                }
+              />
+            </Field>
+            <Field label="Sentence pause min (ms)">
+              <Input
+                type="number"
+                value={profile.pause_between_sentences_ms_min}
+                onChange={(e) =>
+                  update({ pause_between_sentences_ms_min: +e.target.value })
+                }
+              />
+            </Field>
+            <Field label="Sentence pause max (ms)">
+              <Input
+                type="number"
+                value={profile.pause_between_sentences_ms_max}
+                onChange={(e) =>
+                  update({ pause_between_sentences_ms_max: +e.target.value })
+                }
+              />
+            </Field>
+            <Field label="Idle scroll before post (sec, min)">
+              <Input
+                type="number"
+                value={profile.idle_scroll_before_post_sec_min}
+                onChange={(e) =>
+                  update({ idle_scroll_before_post_sec_min: +e.target.value })
+                }
+              />
+            </Field>
+            <Field label="Idle scroll before post (sec, max)">
+              <Input
+                type="number"
+                value={profile.idle_scroll_before_post_sec_max}
+                onChange={(e) =>
+                  update({ idle_scroll_before_post_sec_max: +e.target.value })
+                }
+              />
+            </Field>
+            <Field label="Schedule jitter (± minutes)">
+              <Input
+                type="number"
+                value={profile.schedule_jitter_minutes}
+                onChange={(e) =>
+                  update({ schedule_jitter_minutes: +e.target.value })
+                }
+              />
+            </Field>
+            <Field label="Failure threshold for auto-pause">
+              <Input
+                type="number"
+                value={profile.consecutive_failures_threshold}
+                onChange={(e) =>
+                  update({ consecutive_failures_threshold: +e.target.value })
+                }
+              />
+            </Field>
+            <Field label="Auto-pause duration (minutes)">
+              <Input
+                type="number"
+                value={profile.smart_pause_minutes}
+                onChange={(e) =>
+                  update({ smart_pause_minutes: +e.target.value })
+                }
+              />
+            </Field>
+          </section>
+          <Button onClick={save} disabled={saving}>
+            {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+            Save
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Smart pause</CardTitle>
+          <CardDescription>
+            When active the scheduler sits idle — no posting happens until it
+            expires or you resume.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {pause?.paused ? (
+            <div className="flex items-center gap-3">
+              <Badge variant="outline" className="border-red-400 text-red-700">
+                Paused
+              </Badge>
+              <span className="text-sm text-muted-foreground">
+                until {pause.until ? formatDate(pause.until) : "?"}
+                {pause.reason && ` — ${pause.reason}`}
+              </span>
+              <Button size="sm" variant="outline" onClick={onResume}>
+                <Play className="h-3 w-3" />
+                Resume now
+              </Button>
+            </div>
+          ) : (
+            <div className="flex items-center gap-3">
+              <Badge
+                variant="outline"
+                className="border-green-400 text-green-800"
+              >
+                Active
+              </Badge>
+              <Button size="sm" variant="outline" onClick={onPause}>
+                <Pause className="h-3 w-3" />
+                Pause posting
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Session health</CardTitle>
+          <CardDescription>
+            Per-platform running tally of failures / successes. Non-healthy
+            platforms are skipped until the counter resets with a new success.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {health.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No activity yet.
+            </p>
+          ) : (
+            <table className="w-full text-sm">
+              <thead className="border-b bg-muted/50">
+                <tr className="text-left">
+                  <th className="py-2 px-3">Platform</th>
+                  <th className="py-2 px-3">Status</th>
+                  <th className="py-2 px-3">Fail streak</th>
+                  <th className="py-2 px-3">Last fail</th>
+                  <th className="py-2 px-3">Last success</th>
+                </tr>
+              </thead>
+              <tbody>
+                {health.map((h) => (
+                  <tr key={h.platform_id} className="border-b last:border-0">
+                    <td className="py-2 px-3 font-medium">{h.platform_id}</td>
+                    <td className="py-2 px-3">
+                      <Badge
+                        variant="outline"
+                        className={STATUS_COLORS[h.status]}
+                      >
+                        {h.status}
+                      </Badge>
+                    </td>
+                    <td className="py-2 px-3">{h.consecutive_failures}</td>
+                    <td
+                      className="py-2 px-3 text-xs text-muted-foreground"
+                      title={h.last_failure_reason ?? ""}
+                    >
+                      {h.last_failure_at ? formatDate(h.last_failure_at) : "—"}
+                    </td>
+                    <td className="py-2 px-3 text-xs text-muted-foreground">
+                      {h.last_success_at ? formatDate(h.last_success_at) : "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Blackout dates</CardTitle>
+          <CardDescription>
+            Days where the scheduler stays quiet (vacations, holidays, known
+            brand-risky days).
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <form
+            onSubmit={addBo}
+            className="grid grid-cols-1 md:grid-cols-3 gap-3 items-end"
+          >
+            <Field label="Date">
+              <Input
+                type="date"
+                value={newBlackout.date}
+                onChange={(e) =>
+                  setNewBlackout({ ...newBlackout, date: e.target.value })
+                }
+              />
+            </Field>
+            <Field label="Reason (optional)">
+              <Input
+                value={newBlackout.reason}
+                onChange={(e) =>
+                  setNewBlackout({ ...newBlackout, reason: e.target.value })
+                }
+                placeholder="vacation, holiday, …"
+              />
+            </Field>
+            <Button type="submit">Add</Button>
+          </form>
+          <div className="rounded-md border">
+            <table className="w-full text-sm">
+              <thead className="border-b bg-muted/50">
+                <tr className="text-left">
+                  <th className="py-2 px-3">Date</th>
+                  <th className="py-2 px-3">Reason</th>
+                  <th className="py-2 px-3 w-12"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {blackouts.length === 0 ? (
+                  <tr>
+                    <td colSpan={3} className="p-4 text-muted-foreground">
+                      No blackout dates.
+                    </td>
+                  </tr>
+                ) : (
+                  blackouts.map((b) => (
+                    <tr key={b.id} className="border-b last:border-0">
+                      <td className="py-2 px-3">{formatDate(b.date)}</td>
+                      <td className="py-2 px-3">{b.reason ?? "—"}</td>
+                      <td className="py-2 px-3">
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          onClick={async () => {
+                            await deleteBlackout(b.id);
+                            setBlackouts(await listBlackouts());
+                          }}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-xs">{label}</Label>
+      {children}
+    </div>
+  );
+}

--- a/dashboard/app/layout.tsx
+++ b/dashboard/app/layout.tsx
@@ -1,0 +1,29 @@
+import type { Metadata } from "next";
+import { Sidebar } from "@/components/layout/sidebar";
+import { StatusBar } from "@/components/layout/status-bar";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "autoposter-AI",
+  description: "Local self-hosted AI social poster",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-background font-sans antialiased">
+        <div className="flex min-h-screen">
+          <Sidebar />
+          <main className="flex-1 p-6 space-y-4">
+            <StatusBar />
+            {children}
+          </main>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/dashboard/app/layout.tsx
+++ b/dashboard/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { AuthGate } from "@/components/auth-gate";
 import { Sidebar } from "@/components/layout/sidebar";
 import { StatusBar } from "@/components/layout/status-bar";
 import "./globals.css";
@@ -16,13 +17,15 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="min-h-screen bg-background font-sans antialiased">
-        <div className="flex min-h-screen">
-          <Sidebar />
-          <main className="flex-1 p-6 space-y-4">
-            <StatusBar />
-            {children}
-          </main>
-        </div>
+        <AuthGate>
+          <div className="flex min-h-screen">
+            <Sidebar />
+            <main className="flex-1 p-6 space-y-4">
+              <StatusBar />
+              {children}
+            </main>
+          </div>
+        </AuthGate>
       </body>
     </html>
   );

--- a/dashboard/app/library/page.tsx
+++ b/dashboard/app/library/page.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  ApiError,
+  MediaAsset,
+  deleteMedia,
+  listMedia,
+  patchMedia,
+  tagMedia,
+  uploadMedia,
+} from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  ImageIcon,
+  Loader2,
+  Sparkles,
+  Trash2,
+  Upload,
+  X,
+} from "lucide-react";
+
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, "") ?? "http://localhost:8787";
+
+export default function LibraryPage() {
+  const [assets, setAssets] = useState<MediaAsset[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [uploading, setUploading] = useState(false);
+  const [taggingIds, setTaggingIds] = useState<Set<number>>(new Set());
+  const [selected, setSelected] = useState<MediaAsset | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const refresh = async () => {
+    setLoading(true);
+    try {
+      const list = await listMedia();
+      setAssets(list);
+      if (selected) {
+        const updated = list.find((a) => a.id === selected.id) ?? null;
+        setSelected(updated);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Load failed");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleFiles = async (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    setError(null);
+    setUploading(true);
+    try {
+      for (const file of Array.from(files)) {
+        await uploadMedia(file);
+      }
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Upload failed");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleTag = async (assetId: number) => {
+    setError(null);
+    setTaggingIds((prev) => new Set(prev).add(assetId));
+    try {
+      await tagMedia(assetId);
+      await refresh();
+    } catch (e) {
+      setError(
+        e instanceof ApiError
+          ? `${e.status}: ${e.message}`
+          : e instanceof Error
+            ? e.message
+            : "Tag failed",
+      );
+    } finally {
+      setTaggingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(assetId);
+        return next;
+      });
+    }
+  };
+
+  const handleDelete = async (assetId: number) => {
+    if (!confirm("Delete this asset? The file will be removed from disk.")) return;
+    await deleteMedia(assetId);
+    setSelected(null);
+    refresh();
+  };
+
+  const onDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    handleFiles(e.dataTransfer.files);
+  };
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold flex items-center gap-2">
+          <ImageIcon className="h-6 w-6" />
+          Media Library
+        </h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Drop images here. Tag with Claude Vision to get auto-suggestions for
+          content slots.
+        </p>
+      </div>
+
+      {error && (
+        <div className="rounded-md bg-destructive/10 text-destructive text-sm p-3">
+          {error}
+        </div>
+      )}
+
+      <Card
+        onDragOver={(e) => e.preventDefault()}
+        onDrop={onDrop}
+        className="border-dashed border-2 p-8 flex flex-col items-center justify-center text-center cursor-pointer hover:bg-accent/20 transition"
+        onClick={() => inputRef.current?.click()}
+      >
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/jpeg,image/png,image/webp,image/gif"
+          multiple
+          hidden
+          onChange={(e) => handleFiles(e.target.files)}
+        />
+        {uploading ? (
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        ) : (
+          <Upload className="h-6 w-6 text-muted-foreground" />
+        )}
+        <div className="mt-2 font-medium">
+          {uploading ? "Uploading…" : "Drop images or click to upload"}
+        </div>
+        <div className="text-xs text-muted-foreground mt-1">
+          JPEG / PNG / WebP / GIF, max 10 MB each
+        </div>
+      </Card>
+
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+        {loading ? (
+          <p className="text-sm text-muted-foreground col-span-full">
+            Loading…
+          </p>
+        ) : assets.length === 0 ? (
+          <p className="text-sm text-muted-foreground col-span-full">
+            No assets yet. Upload your first image above.
+          </p>
+        ) : (
+          assets.map((a) => (
+            <Card
+              key={a.id}
+              className={`overflow-hidden cursor-pointer hover:ring-2 hover:ring-primary/50 transition ${
+                selected?.id === a.id ? "ring-2 ring-primary" : ""
+              }`}
+              onClick={() => setSelected(a)}
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={`${API_BASE}/static/${a.local_path}`}
+                alt={a.ai_caption ?? a.filename}
+                className="w-full aspect-square object-cover"
+              />
+              <CardContent className="p-2 space-y-1">
+                <div className="text-xs text-muted-foreground line-clamp-2 min-h-[2.5em]">
+                  {a.ai_caption ?? "Not tagged yet"}
+                </div>
+                <div className="flex flex-wrap gap-1">
+                  {(a.ai_tags ?? []).slice(0, 3).map((t) => (
+                    <Badge key={t} variant="secondary" className="text-[10px]">
+                      {t}
+                    </Badge>
+                  ))}
+                  {(a.ai_tags ?? []).length === 0 && (
+                    <Badge variant="outline" className="text-[10px]">
+                      untagged
+                    </Badge>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          ))
+        )}
+      </div>
+
+      {selected && (
+        <Card className="sticky bottom-6 bg-card/95 backdrop-blur">
+          <CardContent className="p-4 flex items-center gap-4">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={`${API_BASE}/static/${selected.local_path}`}
+              alt=""
+              className="w-24 h-24 object-cover rounded-md"
+            />
+            <div className="flex-1 min-w-0">
+              <div className="font-medium truncate">{selected.filename}</div>
+              <div className="text-xs text-muted-foreground">
+                {selected.width}×{selected.height} ·{" "}
+                {(selected.size_bytes / 1024).toFixed(0)} KB
+              </div>
+              <div className="text-sm mt-1 line-clamp-2">
+                {selected.ai_caption ?? "Run AI tag to get a caption."}
+              </div>
+              <div className="flex flex-wrap gap-1 mt-1">
+                {(selected.ai_tags ?? []).map((t) => (
+                  <Badge key={t} variant="secondary" className="text-[10px]">
+                    {t}
+                  </Badge>
+                ))}
+              </div>
+              <UserTagsEditor
+                asset={selected}
+                onSaved={(next) => {
+                  setSelected(next);
+                  refresh();
+                }}
+              />
+            </div>
+            <div className="flex flex-col gap-2">
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() => handleTag(selected.id)}
+                disabled={taggingIds.has(selected.id)}
+              >
+                {taggingIds.has(selected.id) ? (
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                ) : (
+                  <Sparkles className="h-3 w-3" />
+                )}
+                Tag with AI
+              </Button>
+              <Button
+                size="sm"
+                variant="destructive"
+                onClick={() => handleDelete(selected.id)}
+              >
+                <Trash2 className="h-3 w-3" />
+                Delete
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => setSelected(null)}
+              >
+                <X className="h-3 w-3" />
+                Close
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function UserTagsEditor({
+  asset,
+  onSaved,
+}: {
+  asset: MediaAsset;
+  onSaved: (a: MediaAsset) => void;
+}) {
+  const [val, setVal] = useState((asset.tags_user ?? []).join(", "));
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    setVal((asset.tags_user ?? []).join(", "));
+  }, [asset.id]);
+
+  const save = async () => {
+    setBusy(true);
+    try {
+      const next = await patchMedia(asset.id, {
+        tags_user: val
+          .split(",")
+          .map((t) => t.trim())
+          .filter(Boolean),
+      });
+      onSaved(next);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="mt-2 flex gap-2 items-end">
+      <div className="flex-1">
+        <Label className="text-[10px]">Your tags (comma-separated)</Label>
+        <Input
+          value={val}
+          onChange={(e) => setVal(e.target.value)}
+          placeholder="launch, hero-image"
+          className="h-7 text-xs"
+        />
+      </div>
+      <Button size="sm" variant="outline" onClick={save} disabled={busy}>
+        Save
+      </Button>
+    </div>
+  );
+}

--- a/dashboard/app/page.tsx
+++ b/dashboard/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function Home() {
+  redirect("/profile");
+}

--- a/dashboard/app/plans/[id]/page.tsx
+++ b/dashboard/app/plans/[id]/page.tsx
@@ -5,15 +5,21 @@ import Link from "next/link";
 import {
   ApiError,
   ContentPlan,
+  MediaAsset,
   PlanSlot,
   PostType,
+  attachMediaToSlot,
   chatPlan,
   createSlot,
   deleteSlot,
   generatePostFromSlot,
   getPlan,
   patchSlot,
+  suggestMediaForSlot,
 } from "@/lib/api";
+
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, "") ?? "http://localhost:8787";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -355,6 +361,7 @@ export default function PlanDetailPage({
               onPatch={(p) => handleSlotPatch(selectedSlot.id, p)}
               onDelete={() => handleSlotDelete(selectedSlot.id)}
               onGenerate={() => handleGeneratePost(selectedSlot.id)}
+              onAttached={() => refresh()}
             />
           ) : (
             <p className="text-sm text-muted-foreground">
@@ -431,24 +438,40 @@ function SlotEditor({
   onPatch,
   onDelete,
   onGenerate,
+  onAttached,
 }: {
   slot: PlanSlot;
   onPatch: (p: Parameters<typeof patchSlot>[1]) => void;
   onDelete: () => void;
   onGenerate: () => void;
+  onAttached: () => void;
 }) {
   const [when, setWhen] = useState(toLocalDateTimeInput(slot.scheduled_for));
   const [postType, setPostType] = useState(slot.post_type);
   const [topicHint, setTopicHint] = useState(slot.topic_hint ?? "");
   const [notes, setNotes] = useState(slot.notes ?? "");
   const [busy, setBusy] = useState(false);
+  const [suggestions, setSuggestions] = useState<
+    { asset: MediaAsset; score: number }[]
+  >([]);
+  const [loadingSuggestions, setLoadingSuggestions] = useState(false);
 
   useEffect(() => {
     setWhen(toLocalDateTimeInput(slot.scheduled_for));
     setPostType(slot.post_type);
     setTopicHint(slot.topic_hint ?? "");
     setNotes(slot.notes ?? "");
-  }, [slot]);
+    setLoadingSuggestions(true);
+    suggestMediaForSlot(slot.id, 3)
+      .then(setSuggestions)
+      .catch(() => setSuggestions([]))
+      .finally(() => setLoadingSuggestions(false));
+  }, [slot.id]);
+
+  const handleAttach = async (assetId: number) => {
+    await attachMediaToSlot(assetId, slot.id);
+    onAttached();
+  };
 
   const save = async () => {
     setBusy(true);
@@ -516,6 +539,39 @@ function SlotEditor({
           </Link>
         </div>
       )}
+      <div className="border-t pt-3 mt-3">
+        <Label className="text-xs">Suggested media</Label>
+        {loadingSuggestions ? (
+          <p className="text-xs text-muted-foreground">Checking…</p>
+        ) : suggestions.length === 0 ? (
+          <p className="text-xs text-muted-foreground">
+            {slot.media_asset_id
+              ? "Image already attached."
+              : "No matches. Tag assets in the Library first."}
+          </p>
+        ) : (
+          <div className="grid grid-cols-3 gap-2 mt-1">
+            {suggestions.map(({ asset, score }) => (
+              <button
+                key={asset.id}
+                type="button"
+                onClick={() => handleAttach(asset.id)}
+                className={`rounded overflow-hidden border hover:ring-2 hover:ring-primary transition ${
+                  slot.media_asset_id === asset.id ? "ring-2 ring-primary" : ""
+                }`}
+                title={`${asset.ai_caption ?? asset.filename} — score ${score}`}
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={`${API_BASE}/static/${asset.local_path}`}
+                  alt=""
+                  className="w-full aspect-square object-cover"
+                />
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
       <div className="flex gap-2 flex-wrap">
         <Button onClick={save} disabled={busy} size="sm">
           Save

--- a/dashboard/app/plans/[id]/page.tsx
+++ b/dashboard/app/plans/[id]/page.tsx
@@ -1,0 +1,616 @@
+"use client";
+
+import { use, useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import {
+  ApiError,
+  ContentPlan,
+  PlanSlot,
+  PostType,
+  chatPlan,
+  createSlot,
+  deleteSlot,
+  generatePostFromSlot,
+  getPlan,
+  patchSlot,
+} from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Select } from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import {
+  ArrowLeft,
+  Loader2,
+  Plus,
+  Send,
+  Sparkles,
+  Trash2,
+  Wand2,
+} from "lucide-react";
+
+const POST_TYPES: { value: PostType; label: string }[] = [
+  { value: "informative", label: "Informative" },
+  { value: "soft_sell", label: "Soft sell" },
+  { value: "hard_sell", label: "Hard sell" },
+  { value: "engagement", label: "Engagement" },
+  { value: "story", label: "Story" },
+  { value: "motivational", label: "Motivational" },
+  { value: "testimonial", label: "Testimonial" },
+  { value: "hot_take", label: "Hot take" },
+  { value: "seasonal", label: "Seasonal" },
+];
+
+const TYPE_COLORS: Record<PostType, string> = {
+  informative: "bg-blue-500/20 border-blue-500/40 text-blue-700 dark:text-blue-300",
+  soft_sell: "bg-emerald-500/20 border-emerald-500/40 text-emerald-700 dark:text-emerald-300",
+  hard_sell: "bg-red-500/20 border-red-500/40 text-red-700 dark:text-red-300",
+  engagement: "bg-purple-500/20 border-purple-500/40 text-purple-700 dark:text-purple-300",
+  story: "bg-amber-500/20 border-amber-500/40 text-amber-700 dark:text-amber-300",
+  motivational: "bg-orange-500/20 border-orange-500/40 text-orange-700 dark:text-orange-300",
+  testimonial: "bg-teal-500/20 border-teal-500/40 text-teal-700 dark:text-teal-300",
+  hot_take: "bg-pink-500/20 border-pink-500/40 text-pink-700 dark:text-pink-300",
+  seasonal: "bg-cyan-500/20 border-cyan-500/40 text-cyan-700 dark:text-cyan-300",
+};
+
+function dayKey(iso: string): string {
+  return new Date(iso).toISOString().slice(0, 10);
+}
+
+function buildDayBuckets(plan: ContentPlan): { date: Date; slots: PlanSlot[] }[] {
+  const start = new Date(plan.start_date);
+  const end = new Date(plan.end_date);
+  start.setHours(0, 0, 0, 0);
+  end.setHours(0, 0, 0, 0);
+  const days: { date: Date; slots: PlanSlot[] }[] = [];
+  for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+    const day = new Date(d);
+    days.push({ date: day, slots: [] });
+  }
+  for (const slot of plan.slots) {
+    const key = dayKey(slot.scheduled_for);
+    const bucket = days.find(
+      (b) => b.date.toISOString().slice(0, 10) === key,
+    );
+    if (bucket) bucket.slots.push(slot);
+    else days.push({ date: new Date(slot.scheduled_for), slots: [slot] });
+  }
+  return days;
+}
+
+function toLocalDateTimeInput(iso: string): string {
+  const d = new Date(iso);
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(
+    d.getHours(),
+  )}:${pad(d.getMinutes())}`;
+}
+
+export default function PlanDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = use(params);
+  const planId = Number(id);
+
+  const [plan, setPlan] = useState<ContentPlan | null>(null);
+  const [selectedSlot, setSelectedSlot] = useState<PlanSlot | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [chatMessage, setChatMessage] = useState("");
+  const [chatBusy, setChatBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [addingAt, setAddingAt] = useState<Date | null>(null);
+  const chatEndRef = useRef<HTMLDivElement>(null);
+
+  const refresh = async () => {
+    try {
+      const p = await getPlan(planId);
+      setPlan(p);
+      if (selectedSlot) {
+        const still = p.slots.find((s) => s.id === selectedSlot.id) ?? null;
+        setSelectedSlot(still);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Load failed");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [planId]);
+
+  useEffect(() => {
+    chatEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [plan?.chat_history.length]);
+
+  const days = useMemo(() => (plan ? buildDayBuckets(plan) : []), [plan]);
+
+  const handleChatSend = async () => {
+    if (!chatMessage.trim() || !plan) return;
+    setChatBusy(true);
+    setError(null);
+    const msg = chatMessage;
+    setChatMessage("");
+    try {
+      const res = await chatPlan(plan.id, msg);
+      setPlan(res.plan);
+    } catch (e) {
+      setError(
+        e instanceof ApiError
+          ? `${e.status}: ${e.message}`
+          : e instanceof Error
+            ? e.message
+            : "Chat failed",
+      );
+      setChatMessage(msg);
+    } finally {
+      setChatBusy(false);
+    }
+  };
+
+  const handleSlotPatch = async (
+    slotId: number,
+    patch: Parameters<typeof patchSlot>[1],
+  ) => {
+    try {
+      await patchSlot(slotId, patch);
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Patch failed");
+    }
+  };
+
+  const handleSlotDelete = async (slotId: number) => {
+    if (!confirm("Delete this slot?")) return;
+    await deleteSlot(slotId);
+    setSelectedSlot(null);
+    refresh();
+  };
+
+  const handleSlotAdd = async (data: {
+    scheduled_for: string;
+    post_type: PostType;
+    topic_hint: string;
+  }) => {
+    if (!plan) return;
+    await createSlot(plan.id, {
+      scheduled_for: new Date(data.scheduled_for).toISOString(),
+      post_type: data.post_type,
+      topic_hint: data.topic_hint || null,
+    });
+    setAddingAt(null);
+    refresh();
+  };
+
+  const handleGeneratePost = async (slotId: number) => {
+    setError(null);
+    try {
+      const res = await generatePostFromSlot(slotId);
+      setSelectedSlot(res.slot);
+      await refresh();
+    } catch (e) {
+      setError(
+        e instanceof ApiError
+          ? `${e.status}: ${e.message}`
+          : e instanceof Error
+            ? e.message
+            : "Generation failed",
+      );
+    }
+  };
+
+  const handleDragStart = (e: React.DragEvent, slotId: number) => {
+    e.dataTransfer.setData("slot-id", String(slotId));
+  };
+
+  const handleDrop = async (e: React.DragEvent, day: Date) => {
+    e.preventDefault();
+    const slotId = Number(e.dataTransfer.getData("slot-id"));
+    if (!slotId || !plan) return;
+    const slot = plan.slots.find((s) => s.id === slotId);
+    if (!slot) return;
+    // Keep hour/min, change date
+    const existing = new Date(slot.scheduled_for);
+    const next = new Date(day);
+    next.setHours(existing.getHours(), existing.getMinutes(), 0, 0);
+    await handleSlotPatch(slotId, { scheduled_for: next.toISOString() });
+  };
+
+  if (loading && !plan) {
+    return <div className="p-6">Loading plan…</div>;
+  }
+  if (!plan) {
+    return (
+      <div className="p-6">
+        <p>Plan not found.</p>
+        <Link href="/plans" className="text-primary underline">
+          Back to plans
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-[calc(100vh-3rem)]">
+      {/* Left: calendar */}
+      <div className="flex-1 p-6 overflow-y-auto">
+        <div className="mb-4 flex items-center justify-between">
+          <div>
+            <Link
+              href="/plans"
+              className="text-sm text-muted-foreground hover:text-foreground flex items-center gap-1 mb-1"
+            >
+              <ArrowLeft className="h-3 w-3" />
+              Back
+            </Link>
+            <h1 className="text-xl font-bold">{plan.name}</h1>
+            <div className="text-xs text-muted-foreground mt-1">
+              {new Date(plan.start_date).toLocaleDateString()} –{" "}
+              {new Date(plan.end_date).toLocaleDateString()} ·{" "}
+              {plan.slots.length} slots · cost $
+              {plan.generation_cost_usd.toFixed(4)}
+            </div>
+          </div>
+          <Badge variant="outline">{plan.status}</Badge>
+        </div>
+
+        {error && (
+          <div className="mb-4 rounded-md bg-destructive/10 text-destructive text-sm p-3">
+            {error}
+          </div>
+        )}
+
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
+          {days.map(({ date, slots }) => (
+            <Card
+              key={date.toISOString()}
+              className="min-h-[140px]"
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={(e) => handleDrop(e, date)}
+            >
+              <CardHeader className="p-3 pb-1 flex flex-row items-center justify-between">
+                <div className="text-sm font-medium">
+                  {date.toLocaleDateString(undefined, {
+                    weekday: "short",
+                    month: "short",
+                    day: "numeric",
+                  })}
+                </div>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6"
+                  onClick={() => {
+                    const at = new Date(date);
+                    at.setHours(10, 0, 0, 0);
+                    setAddingAt(at);
+                  }}
+                >
+                  <Plus className="h-3 w-3" />
+                </Button>
+              </CardHeader>
+              <CardContent className="p-3 pt-1 space-y-1">
+                {slots.length === 0 && (
+                  <div className="text-xs text-muted-foreground italic">
+                    Drop a slot here or + to add
+                  </div>
+                )}
+                {slots.map((slot) => (
+                  <button
+                    key={slot.id}
+                    draggable
+                    onDragStart={(e) => handleDragStart(e, slot.id)}
+                    onClick={() => setSelectedSlot(slot)}
+                    className={`w-full text-left text-xs rounded border px-2 py-1.5 cursor-grab hover:shadow-sm transition ${TYPE_COLORS[slot.post_type]}`}
+                  >
+                    <div className="font-medium">
+                      {new Date(slot.scheduled_for).toLocaleTimeString([], {
+                        hour: "2-digit",
+                        minute: "2-digit",
+                      })}
+                      {" · "}
+                      {POST_TYPES.find((t) => t.value === slot.post_type)
+                        ?.label ?? slot.post_type}
+                    </div>
+                    {slot.topic_hint && (
+                      <div className="text-[11px] opacity-80 line-clamp-2 mt-0.5">
+                        {slot.topic_hint}
+                      </div>
+                    )}
+                    {slot.status !== "planned" && (
+                      <Badge variant="secondary" className="mt-1 text-[10px]">
+                        {slot.status}
+                      </Badge>
+                    )}
+                  </button>
+                ))}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+
+      {/* Right: inspector + chat */}
+      <div className="w-[420px] border-l flex flex-col bg-card/40">
+        {/* Inspector */}
+        <div className="border-b p-4 max-h-[50%] overflow-y-auto">
+          <div className="text-xs uppercase tracking-wide text-muted-foreground mb-2">
+            Slot inspector
+          </div>
+          {addingAt ? (
+            <AddSlotForm
+              date={addingAt}
+              onCancel={() => setAddingAt(null)}
+              onSave={handleSlotAdd}
+            />
+          ) : selectedSlot ? (
+            <SlotEditor
+              slot={selectedSlot}
+              onPatch={(p) => handleSlotPatch(selectedSlot.id, p)}
+              onDelete={() => handleSlotDelete(selectedSlot.id)}
+              onGenerate={() => handleGeneratePost(selectedSlot.id)}
+            />
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Click a slot to edit, or drag across days to reschedule.
+            </p>
+          )}
+        </div>
+
+        {/* Chat with Planner */}
+        <div className="flex-1 flex flex-col">
+          <div className="px-4 py-2 border-b text-xs uppercase tracking-wide text-muted-foreground flex items-center gap-2">
+            <Wand2 className="h-3 w-3" />
+            Chat with Planner
+          </div>
+          <div className="flex-1 overflow-y-auto p-4 space-y-2 text-sm">
+            {plan.chat_history.length === 0 && (
+              <p className="text-muted-foreground text-xs italic">
+                Ask the Planner to adjust the mix, move times, or add slots.
+              </p>
+            )}
+            {plan.chat_history.map((t, i) => (
+              <div
+                key={i}
+                className={
+                  t.role === "user"
+                    ? "ml-8 rounded-md bg-primary/10 px-3 py-2"
+                    : "mr-8 rounded-md bg-muted px-3 py-2"
+                }
+              >
+                <div className="text-[10px] uppercase tracking-wide opacity-60 mb-0.5">
+                  {t.role}
+                </div>
+                <div className="whitespace-pre-wrap">{t.content}</div>
+              </div>
+            ))}
+            <div ref={chatEndRef} />
+          </div>
+          <div className="border-t p-3">
+            <div className="flex gap-2">
+              <Textarea
+                rows={2}
+                placeholder='e.g. "Move Thursday to Friday evening"'
+                value={chatMessage}
+                onChange={(e) => setChatMessage(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    handleChatSend();
+                  }
+                }}
+                disabled={chatBusy}
+              />
+              <Button
+                onClick={handleChatSend}
+                disabled={chatBusy || !chatMessage.trim()}
+                size="icon"
+              >
+                {chatBusy ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Send className="h-4 w-4" />
+                )}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SlotEditor({
+  slot,
+  onPatch,
+  onDelete,
+  onGenerate,
+}: {
+  slot: PlanSlot;
+  onPatch: (p: Parameters<typeof patchSlot>[1]) => void;
+  onDelete: () => void;
+  onGenerate: () => void;
+}) {
+  const [when, setWhen] = useState(toLocalDateTimeInput(slot.scheduled_for));
+  const [postType, setPostType] = useState(slot.post_type);
+  const [topicHint, setTopicHint] = useState(slot.topic_hint ?? "");
+  const [notes, setNotes] = useState(slot.notes ?? "");
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    setWhen(toLocalDateTimeInput(slot.scheduled_for));
+    setPostType(slot.post_type);
+    setTopicHint(slot.topic_hint ?? "");
+    setNotes(slot.notes ?? "");
+  }, [slot]);
+
+  const save = async () => {
+    setBusy(true);
+    try {
+      await onPatch({
+        scheduled_for: new Date(when).toISOString(),
+        post_type: postType,
+        topic_hint: topicHint || null,
+        notes: notes || null,
+      });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <Label>When</Label>
+        <Input
+          type="datetime-local"
+          value={when}
+          onChange={(e) => setWhen(e.target.value)}
+        />
+      </div>
+      <div>
+        <Label>Post type</Label>
+        <Select
+          value={postType}
+          onChange={(e) => setPostType(e.target.value as PostType)}
+        >
+          {POST_TYPES.map((t) => (
+            <option key={t.value} value={t.value}>
+              {t.label}
+            </option>
+          ))}
+        </Select>
+      </div>
+      <div>
+        <Label>Topic hint</Label>
+        <Textarea
+          rows={3}
+          value={topicHint}
+          onChange={(e) => setTopicHint(e.target.value)}
+        />
+      </div>
+      <div>
+        <Label>Notes</Label>
+        <Textarea
+          rows={2}
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+        />
+      </div>
+      {slot.rationale && (
+        <div className="text-xs text-muted-foreground italic">
+          Planner rationale: {slot.rationale}
+        </div>
+      )}
+      {slot.post_id && (
+        <div className="text-xs">
+          Post drafted:{" "}
+          <Link href="/queue" className="text-primary underline">
+            view in queue
+          </Link>
+        </div>
+      )}
+      <div className="flex gap-2 flex-wrap">
+        <Button onClick={save} disabled={busy} size="sm">
+          Save
+        </Button>
+        <Button
+          onClick={onGenerate}
+          disabled={busy || !!slot.post_id}
+          size="sm"
+          variant="secondary"
+        >
+          <Sparkles className="h-3 w-3" />
+          {slot.post_id ? "Generated" : "Generate post"}
+        </Button>
+        <Button
+          onClick={onDelete}
+          disabled={busy}
+          size="sm"
+          variant="destructive"
+        >
+          <Trash2 className="h-3 w-3" />
+          Delete
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function AddSlotForm({
+  date,
+  onCancel,
+  onSave,
+}: {
+  date: Date;
+  onCancel: () => void;
+  onSave: (data: {
+    scheduled_for: string;
+    post_type: PostType;
+    topic_hint: string;
+  }) => Promise<void>;
+}) {
+  const [when, setWhen] = useState(toLocalDateTimeInput(date.toISOString()));
+  const [postType, setPostType] = useState<PostType>("informative");
+  const [topicHint, setTopicHint] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const submit = async () => {
+    setBusy(true);
+    try {
+      await onSave({ scheduled_for: when, post_type: postType, topic_hint: topicHint });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="text-sm font-medium">New slot</div>
+      <div>
+        <Label>When</Label>
+        <Input
+          type="datetime-local"
+          value={when}
+          onChange={(e) => setWhen(e.target.value)}
+        />
+      </div>
+      <div>
+        <Label>Post type</Label>
+        <Select
+          value={postType}
+          onChange={(e) => setPostType(e.target.value as PostType)}
+        >
+          {POST_TYPES.map((t) => (
+            <option key={t.value} value={t.value}>
+              {t.label}
+            </option>
+          ))}
+        </Select>
+      </div>
+      <div>
+        <Label>Topic hint</Label>
+        <Textarea
+          rows={3}
+          placeholder="What angle should the writer take?"
+          value={topicHint}
+          onChange={(e) => setTopicHint(e.target.value)}
+        />
+      </div>
+      <div className="flex gap-2">
+        <Button onClick={submit} disabled={busy} size="sm">
+          Add
+        </Button>
+        <Button onClick={onCancel} size="sm" variant="outline">
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/app/plans/page.tsx
+++ b/dashboard/app/plans/page.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+import {
+  ApiError,
+  ContentPlan,
+  createEmptyPlan,
+  deletePlan,
+  generatePlan,
+  listPlans,
+} from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { CalendarDays, Loader2, Sparkles, Trash2 } from "lucide-react";
+
+function todayISO(offsetDays = 0): string {
+  const d = new Date();
+  d.setDate(d.getDate() + offsetDays);
+  d.setHours(0, 0, 0, 0);
+  return d.toISOString().slice(0, 10);
+}
+
+export default function PlansListPage() {
+  const router = useRouter();
+  const [plans, setPlans] = useState<ContentPlan[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [name, setName] = useState("");
+  const [goal, setGoal] = useState("");
+  const [startDate, setStartDate] = useState(todayISO());
+  const [endDate, setEndDate] = useState(todayISO(14));
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = async () => {
+    setLoading(true);
+    try {
+      setPlans(await listPlans());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load plans");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const handleGenerate = async (useAI: boolean) => {
+    setError(null);
+    if (!name.trim()) {
+      setError("Give the plan a name.");
+      return;
+    }
+    setCreating(true);
+    try {
+      const payload = {
+        name: name.trim(),
+        goal: goal.trim() || null,
+        start_date: new Date(startDate + "T00:00:00Z").toISOString(),
+        end_date: new Date(endDate + "T23:59:59Z").toISOString(),
+      };
+      const plan = useAI
+        ? await generatePlan(payload)
+        : await createEmptyPlan(payload);
+      router.push(`/plans/${plan.id}`);
+    } catch (e) {
+      setError(
+        e instanceof ApiError
+          ? `${e.status}: ${e.message}`
+          : e instanceof Error
+            ? e.message
+            : "Unknown error",
+      );
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    if (!confirm("Delete plan? All slots will be removed.")) return;
+    await deletePlan(id);
+    refresh();
+  };
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold flex items-center gap-2">
+          <CalendarDays className="h-6 w-6" />
+          Content Plans
+        </h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Let the Planner agent propose a calendar, then edit it in the calendar
+          view.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>New plan</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <Label htmlFor="name">Name</Label>
+            <Input
+              id="name"
+              placeholder="e.g. July growth"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </div>
+          <div>
+            <Label htmlFor="goal">Goal (optional)</Label>
+            <Textarea
+              id="goal"
+              rows={2}
+              placeholder="Drive sign-ups for the new product launch."
+              value={goal}
+              onChange={(e) => setGoal(e.target.value)}
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <Label htmlFor="start">Start</Label>
+              <Input
+                id="start"
+                type="date"
+                value={startDate}
+                onChange={(e) => setStartDate(e.target.value)}
+              />
+            </div>
+            <div>
+              <Label htmlFor="end">End</Label>
+              <Input
+                id="end"
+                type="date"
+                value={endDate}
+                onChange={(e) => setEndDate(e.target.value)}
+              />
+            </div>
+          </div>
+          {error && (
+            <div className="rounded-md bg-destructive/10 text-destructive text-sm p-3">
+              {error}
+            </div>
+          )}
+          <div className="flex gap-2">
+            <Button
+              onClick={() => handleGenerate(true)}
+              disabled={creating}
+            >
+              {creating ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Sparkles className="h-4 w-4" />
+              )}
+              Generate with AI
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => handleGenerate(false)}
+              disabled={creating}
+            >
+              Create empty
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div>
+        <h2 className="text-lg font-semibold mb-3">Existing plans</h2>
+        {loading ? (
+          <p className="text-sm text-muted-foreground">Loading…</p>
+        ) : plans.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No plans yet. Create one above.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {plans.map((p) => (
+              <Card key={p.id} className="hover:bg-accent/40 transition-colors">
+                <div className="flex items-center p-4">
+                  <Link href={`/plans/${p.id}`} className="flex-1">
+                    <div className="flex items-center gap-3">
+                      <span className="font-medium">{p.name}</span>
+                      <Badge variant="outline">{p.status}</Badge>
+                      <Badge variant="secondary">
+                        {p.slots.length} slot{p.slots.length === 1 ? "" : "s"}
+                      </Badge>
+                    </div>
+                    <div className="text-xs text-muted-foreground mt-1">
+                      {new Date(p.start_date).toLocaleDateString()} –{" "}
+                      {new Date(p.end_date).toLocaleDateString()}
+                    </div>
+                    {p.goal && (
+                      <div className="text-sm text-muted-foreground mt-1 line-clamp-1">
+                        {p.goal}
+                      </div>
+                    )}
+                  </Link>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleDelete(p.id);
+                    }}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/app/platforms/page.tsx
+++ b/dashboard/app/platforms/page.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import {
+  addManualCredential,
+  deletePlatformCredential,
+  getMetaOAuthUrl,
+  listPlatformCredentials,
+  type PlatformCredential,
+} from "@/lib/api";
+import { formatDate } from "@/lib/utils";
+import { Link2, Plus, Trash2 } from "lucide-react";
+
+export default function PlatformsPage() {
+  const [creds, setCreds] = useState<PlatformCredential[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [manualOpen, setManualOpen] = useState(false);
+  const [form, setForm] = useState<{
+    platform_id: "instagram" | "threads";
+    account_id: string;
+    username: string;
+    access_token: string;
+  }>({
+    platform_id: "instagram",
+    account_id: "",
+    username: "",
+    access_token: "",
+  });
+
+  const refresh = async () => {
+    setLoading(true);
+    try {
+      const rows = await listPlatformCredentials();
+      setCreds(rows);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load credentials");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const startOAuth = async () => {
+    try {
+      const { url } = await getMetaOAuthUrl();
+      window.location.href = url;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "OAuth URL failed");
+    }
+  };
+
+  const saveManual = async () => {
+    try {
+      await addManualCredential({
+        platform_id: form.platform_id,
+        account_id: form.account_id.trim(),
+        username: form.username.trim() || undefined,
+        access_token: form.access_token.trim(),
+      });
+      setForm({
+        platform_id: "instagram",
+        account_id: "",
+        username: "",
+        access_token: "",
+      });
+      setManualOpen(false);
+      refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Save failed");
+    }
+  };
+
+  const remove = async (id: number) => {
+    if (!confirm("Disconnect this account?")) return;
+    await deletePlatformCredential(id);
+    refresh();
+  };
+
+  return (
+    <div className="space-y-6 p-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Platforms</h1>
+        <p className="text-muted-foreground">
+          Connect Instagram and Threads via Meta OAuth. Facebook Groups live in
+          the extension settings.
+        </p>
+      </div>
+
+      {error && (
+        <Card className="border-destructive">
+          <CardContent className="pt-6 text-sm text-destructive">
+            {error}
+          </CardContent>
+        </Card>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Connect Meta</CardTitle>
+          <CardDescription>
+            Logs into Facebook, lists your Pages, and stores a long-lived token
+            for the first Instagram Business account it finds.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex gap-2">
+          <Button onClick={startOAuth}>
+            <Link2 className="mr-2 h-4 w-4" /> Connect via OAuth
+          </Button>
+          <Button variant="outline" onClick={() => setManualOpen((v) => !v)}>
+            <Plus className="mr-2 h-4 w-4" />
+            {manualOpen ? "Cancel manual" : "Paste token manually"}
+          </Button>
+        </CardContent>
+      </Card>
+
+      {manualOpen && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Manual credential</CardTitle>
+            <CardDescription>
+              For CLI users who already obtained a long-lived token elsewhere
+              (Graph API Explorer, Postman, etc).
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-3 md:grid-cols-2">
+            <div>
+              <Label>Platform</Label>
+              <select
+                className="w-full rounded-md border bg-background p-2 text-sm"
+                value={form.platform_id}
+                onChange={(e) =>
+                  setForm((f) => ({
+                    ...f,
+                    platform_id: e.target.value as "instagram" | "threads",
+                  }))
+                }
+              >
+                <option value="instagram">Instagram</option>
+                <option value="threads">Threads</option>
+              </select>
+            </div>
+            <div>
+              <Label>Account ID (numeric)</Label>
+              <Input
+                value={form.account_id}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, account_id: e.target.value }))
+                }
+                placeholder="17841400000000000"
+              />
+            </div>
+            <div>
+              <Label>Username (optional)</Label>
+              <Input
+                value={form.username}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, username: e.target.value }))
+                }
+              />
+            </div>
+            <div className="md:col-span-2">
+              <Label>Long-lived access token</Label>
+              <Input
+                value={form.access_token}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, access_token: e.target.value }))
+                }
+                placeholder="EAAG..."
+              />
+            </div>
+            <div className="md:col-span-2">
+              <Button
+                onClick={saveManual}
+                disabled={!form.account_id || !form.access_token}
+              >
+                Save
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Connected accounts</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <p className="text-sm text-muted-foreground">Loading…</p>
+          ) : creds.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No connected accounts yet.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {creds.map((c) => (
+                <div
+                  key={c.id}
+                  className="flex items-center justify-between rounded-lg border p-3 text-sm"
+                >
+                  <div className="flex flex-col">
+                    <div className="flex items-center gap-2">
+                      <Badge variant="outline">{c.platform_id}</Badge>
+                      <span className="font-medium">
+                        {c.username || c.account_id}
+                      </span>
+                    </div>
+                    <span className="text-xs text-muted-foreground">
+                      id {c.account_id} · updated {formatDate(c.updated_at)}
+                    </span>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => remove(c.id)}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/dashboard/app/profile/page.tsx
+++ b/dashboard/app/profile/page.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Select } from "@/components/ui/select";
+import { WarningBanner } from "@/components/warning-banner";
+import {
+  getBusinessProfile,
+  upsertBusinessProfile,
+  type BusinessProfile,
+  type EmojiDensity,
+  type Length,
+  type Tone,
+} from "@/lib/api";
+
+const EMPTY: Partial<BusinessProfile> = {
+  name: "",
+  description: "",
+  website_url: "",
+  products: "",
+  target_audience: "",
+  call_to_action_url: "",
+  tone: "casual",
+  length: "medium",
+  emoji_density: "light",
+  language: "en",
+  posting_window_start_hour: 9,
+  posting_window_end_hour: 20,
+  timezone: "UTC",
+  posts_per_day: 3,
+  review_before_posting: true,
+};
+
+export default function ProfilePage() {
+  const [form, setForm] = useState<Partial<BusinessProfile>>(EMPTY);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const existing = await getBusinessProfile();
+      if (existing) setForm(existing);
+      setLoading(false);
+    })();
+  }, []);
+
+  const update = <K extends keyof BusinessProfile>(
+    key: K,
+    value: BusinessProfile[K],
+  ) => setForm((f) => ({ ...f, [key]: value }));
+
+  const save = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    setMessage(null);
+    try {
+      const saved = await upsertBusinessProfile(form);
+      setForm(saved);
+      setMessage("Saved.");
+    } catch (e) {
+      setMessage(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) return <div>Loading…</div>;
+
+  return (
+    <div className="space-y-4 max-w-3xl">
+      <WarningBanner />
+      <Card>
+        <CardHeader>
+          <CardTitle>Business Profile</CardTitle>
+          <CardDescription>
+            Context the AI uses when writing. One profile per install (v1).
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={save} className="space-y-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="space-y-1.5">
+                <Label>Business name</Label>
+                <Input
+                  value={form.name ?? ""}
+                  onChange={(e) => update("name", e.target.value)}
+                  required
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label>Website</Label>
+                <Input
+                  type="url"
+                  value={form.website_url ?? ""}
+                  onChange={(e) => update("website_url", e.target.value)}
+                  placeholder="https://example.com"
+                />
+              </div>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label>Description</Label>
+              <Textarea
+                rows={3}
+                required
+                value={form.description ?? ""}
+                onChange={(e) => update("description", e.target.value)}
+              />
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="space-y-1.5">
+                <Label>Products / services</Label>
+                <Textarea
+                  rows={2}
+                  value={form.products ?? ""}
+                  onChange={(e) => update("products", e.target.value)}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label>Target audience</Label>
+                <Textarea
+                  rows={2}
+                  value={form.target_audience ?? ""}
+                  onChange={(e) =>
+                    update("target_audience", e.target.value)
+                  }
+                />
+              </div>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label>Default call-to-action URL</Label>
+              <Input
+                type="url"
+                value={form.call_to_action_url ?? ""}
+                onChange={(e) =>
+                  update("call_to_action_url", e.target.value)
+                }
+                placeholder="https://example.com/pricing"
+              />
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              <div className="space-y-1.5">
+                <Label>Tone</Label>
+                <Select
+                  value={form.tone ?? "casual"}
+                  onChange={(e) => update("tone", e.target.value as Tone)}
+                >
+                  <option value="professional">Professional</option>
+                  <option value="casual">Casual</option>
+                  <option value="fun">Fun</option>
+                </Select>
+              </div>
+              <div className="space-y-1.5">
+                <Label>Length</Label>
+                <Select
+                  value={form.length ?? "medium"}
+                  onChange={(e) =>
+                    update("length", e.target.value as Length)
+                  }
+                >
+                  <option value="short">Short</option>
+                  <option value="medium">Medium</option>
+                  <option value="long">Long</option>
+                </Select>
+              </div>
+              <div className="space-y-1.5">
+                <Label>Emoji</Label>
+                <Select
+                  value={form.emoji_density ?? "light"}
+                  onChange={(e) =>
+                    update(
+                      "emoji_density",
+                      e.target.value as EmojiDensity,
+                    )
+                  }
+                >
+                  <option value="none">None</option>
+                  <option value="light">Light</option>
+                  <option value="medium">Medium</option>
+                  <option value="heavy">Heavy</option>
+                </Select>
+              </div>
+              <div className="space-y-1.5">
+                <Label>Language</Label>
+                <Input
+                  value={form.language ?? "en"}
+                  onChange={(e) => update("language", e.target.value)}
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              <div className="space-y-1.5">
+                <Label>Window start hour</Label>
+                <Input
+                  type="number"
+                  min={0}
+                  max={23}
+                  value={form.posting_window_start_hour ?? 9}
+                  onChange={(e) =>
+                    update(
+                      "posting_window_start_hour",
+                      parseInt(e.target.value, 10),
+                    )
+                  }
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label>Window end hour</Label>
+                <Input
+                  type="number"
+                  min={0}
+                  max={23}
+                  value={form.posting_window_end_hour ?? 20}
+                  onChange={(e) =>
+                    update(
+                      "posting_window_end_hour",
+                      parseInt(e.target.value, 10),
+                    )
+                  }
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label>Timezone</Label>
+                <Input
+                  value={form.timezone ?? "UTC"}
+                  onChange={(e) => update("timezone", e.target.value)}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label>Posts per day</Label>
+                <Input
+                  type="number"
+                  min={1}
+                  max={50}
+                  value={form.posts_per_day ?? 3}
+                  onChange={(e) =>
+                    update("posts_per_day", parseInt(e.target.value, 10))
+                  }
+                />
+              </div>
+            </div>
+
+            <div className="flex items-center gap-2 text-sm">
+              <input
+                id="rbp"
+                type="checkbox"
+                checked={form.review_before_posting ?? true}
+                onChange={(e) =>
+                  update("review_before_posting", e.target.checked)
+                }
+              />
+              <Label htmlFor="rbp">Require review before posting</Label>
+            </div>
+
+            <div className="flex items-center gap-3">
+              <Button type="submit" disabled={saving}>
+                {saving ? "Saving…" : "Save"}
+              </Button>
+              {message && (
+                <span className="text-sm text-muted-foreground">
+                  {message}
+                </span>
+              )}
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/dashboard/app/profile/page.tsx
+++ b/dashboard/app/profile/page.tsx
@@ -267,6 +267,26 @@ export default function ProfilePage() {
               <Label htmlFor="rbp">Require review before posting</Label>
             </div>
 
+            <div className="space-y-1.5">
+              <Label>
+                Auto-approve post types (comma-separated — skip review queue for
+                trusted types)
+              </Label>
+              <Input
+                placeholder="e.g. informative, motivational"
+                value={(form.auto_approve_types ?? []).join(", ")}
+                onChange={(e) =>
+                  update(
+                    "auto_approve_types",
+                    e.target.value
+                      .split(",")
+                      .map((s) => s.trim())
+                      .filter(Boolean),
+                  )
+                }
+              />
+            </div>
+
             <div className="flex items-center gap-3">
               <Button type="submit" disabled={saving}>
                 {saving ? "Saving…" : "Save"}

--- a/dashboard/app/queue/page.tsx
+++ b/dashboard/app/queue/page.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge, type BadgeProps } from "@/components/ui/badge";
+import {
+  deletePost,
+  listPosts,
+  sendFeedback,
+  type Post,
+  type PostStatus,
+} from "@/lib/api";
+import { formatDate } from "@/lib/utils";
+import { ThumbsDown, ThumbsUp, Trash2 } from "lucide-react";
+
+const STATUS_VARIANT: Record<PostStatus, BadgeProps["variant"]> = {
+  draft: "outline",
+  pending_review: "warning",
+  scheduled: "secondary",
+  posting: "warning",
+  posted: "success",
+  failed: "destructive",
+  skipped: "outline",
+};
+
+export default function QueuePage() {
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState<PostStatus | "all">("all");
+
+  const refresh = async () => {
+    setLoading(true);
+    try {
+      const data = await listPosts(filter === "all" ? undefined : filter);
+      setPosts(data);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+    const id = setInterval(refresh, 15_000);
+    return () => clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filter]);
+
+  const onDelete = async (id: number) => {
+    if (!confirm("Delete this post and its variants?")) return;
+    await deletePost(id);
+    await refresh();
+  };
+
+  const onFeedback = async (id: number, rating: "up" | "down") => {
+    await sendFeedback({ post_id: id, rating });
+    await refresh();
+  };
+
+  return (
+    <div className="space-y-4 max-w-6xl">
+      <Card>
+        <CardHeader>
+          <div className="flex items-start justify-between gap-4 flex-wrap">
+            <div>
+              <CardTitle>Queue</CardTitle>
+              <CardDescription>
+                All posts — drafts, scheduled, posted, failed.
+              </CardDescription>
+            </div>
+            <div className="flex gap-1 text-sm">
+              {(
+                [
+                  "all",
+                  "draft",
+                  "scheduled",
+                  "posting",
+                  "posted",
+                  "failed",
+                ] as const
+              ).map((f) => (
+                <Button
+                  key={f}
+                  size="sm"
+                  variant={filter === f ? "default" : "outline"}
+                  onClick={() => setFilter(f)}
+                >
+                  {f}
+                </Button>
+              ))}
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="text-sm text-muted-foreground">Loading…</div>
+          ) : posts.length === 0 ? (
+            <div className="text-sm text-muted-foreground">
+              Nothing here. Generate a post on the Compose page.
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {posts.map((p) => (
+                <div
+                  key={p.id}
+                  className="rounded-md border p-3 space-y-2 bg-card"
+                >
+                  <div className="flex items-start justify-between gap-3 flex-wrap">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <Badge variant={STATUS_VARIANT[p.status]}>
+                        {p.status}
+                      </Badge>
+                      <Badge variant="outline">{p.post_type}</Badge>
+                      <span className="text-xs text-muted-foreground">
+                        #{p.id} · {formatDate(p.created_at)}
+                      </span>
+                      {p.scheduled_for && (
+                        <span className="text-xs text-muted-foreground">
+                          scheduled: {formatDate(p.scheduled_for)}
+                        </span>
+                      )}
+                      {p.posted_at && (
+                        <span className="text-xs text-muted-foreground">
+                          posted: {formatDate(p.posted_at)}
+                        </span>
+                      )}
+                    </div>
+                    <div className="flex gap-1">
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={() => onFeedback(p.id, "up")}
+                        title="Thumbs up"
+                      >
+                        <ThumbsUp className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={() => onFeedback(p.id, "down")}
+                        title="Thumbs down"
+                      >
+                        <ThumbsDown className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={() => onDelete(p.id)}
+                        title="Delete"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+                  <div className="text-sm whitespace-pre-wrap">{p.text}</div>
+                  {p.image_url && (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={p.image_url}
+                      alt=""
+                      className="max-h-40 rounded border"
+                    />
+                  )}
+                  {p.variants.length > 0 && (
+                    <div className="text-xs space-y-1">
+                      <div className="text-muted-foreground">
+                        Variants ({p.variants.length}):
+                      </div>
+                      {p.variants.map((v) => (
+                        <div
+                          key={v.id}
+                          className="flex items-center gap-2 flex-wrap"
+                        >
+                          <Badge variant={STATUS_VARIANT[v.status]}>
+                            {v.status}
+                          </Badge>
+                          <span className="text-muted-foreground">
+                            target #{v.target_id}
+                          </span>
+                          {v.external_post_id && (
+                            <a
+                              href={v.external_post_id}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="underline text-blue-600 break-all"
+                            >
+                              open
+                            </a>
+                          )}
+                          {v.error && (
+                            <span className="text-destructive">
+                              {v.error}
+                            </span>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/dashboard/app/review/page.tsx
+++ b/dashboard/app/review/page.tsx
@@ -1,0 +1,377 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import {
+  approvePost,
+  approveAllPending,
+  deletePost,
+  listPendingReview,
+  listTargets,
+  patchPost,
+  regeneratePost,
+  rejectPost,
+  sendFeedback,
+  type Post,
+  type Target,
+} from "@/lib/api";
+import { formatDate } from "@/lib/utils";
+import {
+  CheckCircle2,
+  RefreshCw,
+  Send,
+  ThumbsDown,
+  ThumbsUp,
+  XCircle,
+} from "lucide-react";
+
+export default function ReviewPage() {
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [targets, setTargets] = useState<Target[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState<number | null>(null);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [drafts, setDrafts] = useState<Record<number, string>>({});
+  const [targetSel, setTargetSel] = useState<Record<number, Set<number>>>({});
+
+  const refresh = async () => {
+    setLoading(true);
+    try {
+      const [p, t] = await Promise.all([
+        listPendingReview(),
+        listTargets({ active_only: true }),
+      ]);
+      setPosts(p);
+      setTargets(t);
+      setDrafts((prev) => {
+        // Seed empty drafts so "dirty" detection doesn't fire on every keystroke.
+        const next = { ...prev };
+        for (const post of p) {
+          if (next[post.id] === undefined) next[post.id] = post.text;
+        }
+        return next;
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const approvedTargets = useMemo(
+    () => targets.filter((t) => t.review_status === "approved" || t.active),
+    [targets],
+  );
+
+  const toggleSelected = (id: number) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const toggleTarget = (postId: number, targetId: number) => {
+    setTargetSel((prev) => {
+      const cur = new Set(prev[postId] ?? []);
+      if (cur.has(targetId)) cur.delete(targetId);
+      else cur.add(targetId);
+      return { ...prev, [postId]: cur };
+    });
+  };
+
+  const saveEdit = async (post: Post) => {
+    const draft = drafts[post.id];
+    if (draft === undefined || draft === post.text) return;
+    setBusy(post.id);
+    try {
+      await patchPost(post.id, { text: draft });
+      await refresh();
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const onApprove = async (post: Post, schedule = false) => {
+    const draft = drafts[post.id];
+    const targetIds = Array.from(targetSel[post.id] ?? []);
+    setBusy(post.id);
+    try {
+      if (draft !== undefined && draft !== post.text) {
+        await patchPost(post.id, { text: draft });
+      }
+      const scheduled_for = schedule
+        ? new Date(Date.now() + 5 * 60 * 1000).toISOString()
+        : null;
+      await approvePost(post.id, { target_ids: targetIds, scheduled_for });
+      await refresh();
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const onReject = async (post: Post) => {
+    const reason =
+      prompt("Why are you rejecting this post? (optional)") ?? undefined;
+    setBusy(post.id);
+    try {
+      await rejectPost(post.id, reason);
+      await refresh();
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const onRegenerate = async (post: Post) => {
+    const hint = prompt("Topic hint for regeneration (leave blank = same):");
+    setBusy(post.id);
+    try {
+      await regeneratePost(post.id, { topic_hint: hint || null });
+      setDrafts((prev) => {
+        const next = { ...prev };
+        delete next[post.id];
+        return next;
+      });
+      await refresh();
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const onFeedback = async (post: Post, rating: "up" | "down") => {
+    await sendFeedback({ post_id: post.id, rating });
+  };
+
+  const onBulkApprove = async () => {
+    if (selected.size === 0) {
+      if (!confirm(`Approve ALL ${posts.length} pending posts?`)) return;
+      await approveAllPending({});
+    } else {
+      for (const id of selected) {
+        const post = posts.find((p) => p.id === id);
+        if (!post) continue;
+        await onApprove(post, false);
+      }
+    }
+    setSelected(new Set());
+    await refresh();
+  };
+
+  const onDelete = async (post: Post) => {
+    if (!confirm("Delete this draft?")) return;
+    await deletePost(post.id);
+    await refresh();
+  };
+
+  return (
+    <div className="space-y-4 max-w-6xl">
+      <Card>
+        <CardHeader>
+          <div className="flex items-start justify-between gap-4 flex-wrap">
+            <div>
+              <CardTitle>Review Queue</CardTitle>
+              <CardDescription>
+                Posts waiting for your approval before they can be scheduled or
+                published. Edit inline, regenerate, or bulk-approve.
+              </CardDescription>
+            </div>
+            <div className="flex gap-2">
+              <Button size="sm" variant="outline" onClick={refresh}>
+                Refresh
+              </Button>
+              <Button
+                size="sm"
+                onClick={onBulkApprove}
+                disabled={posts.length === 0}
+              >
+                {selected.size > 0
+                  ? `Approve selected (${selected.size})`
+                  : "Approve all"}
+              </Button>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="text-sm text-muted-foreground">Loading…</div>
+          ) : posts.length === 0 ? (
+            <div className="text-sm text-muted-foreground">
+              Nothing to review. Either generation is off-queue or every post has
+              been handled.
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {posts.map((p) => {
+                const dirty = drafts[p.id] !== undefined && drafts[p.id] !== p.text;
+                const tSet = targetSel[p.id] ?? new Set<number>();
+                return (
+                  <div
+                    key={p.id}
+                    className="rounded-md border p-3 space-y-3 bg-card"
+                  >
+                    <div className="flex items-start justify-between gap-2 flex-wrap">
+                      <label className="flex items-center gap-2 text-xs">
+                        <input
+                          type="checkbox"
+                          checked={selected.has(p.id)}
+                          onChange={() => toggleSelected(p.id)}
+                        />
+                        <Badge variant="warning">pending_review</Badge>
+                        <Badge variant="outline">{p.post_type}</Badge>
+                        <span className="text-muted-foreground">
+                          #{p.id} · {formatDate(p.created_at)}
+                        </span>
+                      </label>
+                      <div className="flex gap-1">
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          onClick={() => onFeedback(p, "up")}
+                          title="Thumbs up"
+                        >
+                          <ThumbsUp className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          onClick={() => onFeedback(p, "down")}
+                          title="Thumbs down"
+                        >
+                          <ThumbsDown className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </div>
+                    <Textarea
+                      rows={6}
+                      value={drafts[p.id] ?? p.text}
+                      onChange={(e) =>
+                        setDrafts((prev) => ({
+                          ...prev,
+                          [p.id]: e.target.value,
+                        }))
+                      }
+                    />
+                    {dirty && (
+                      <div className="flex gap-2 text-xs">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => saveEdit(p)}
+                          disabled={busy === p.id}
+                        >
+                          Save edit
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() =>
+                            setDrafts((prev) => ({ ...prev, [p.id]: p.text }))
+                          }
+                        >
+                          Discard
+                        </Button>
+                      </div>
+                    )}
+                    {p.image_url && (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={p.image_url}
+                        alt=""
+                        className="max-h-48 rounded border"
+                      />
+                    )}
+                    {approvedTargets.length > 0 && (
+                      <div className="text-xs space-y-1">
+                        <div className="text-muted-foreground">
+                          Publish to (optional — leave empty to just approve
+                          into DRAFT):
+                        </div>
+                        <div className="flex flex-wrap gap-2">
+                          {approvedTargets.map((t) => (
+                            <label
+                              key={t.id}
+                              className="flex items-center gap-1 rounded border px-2 py-1 cursor-pointer"
+                            >
+                              <input
+                                type="checkbox"
+                                checked={tSet.has(t.id)}
+                                onChange={() => toggleTarget(p.id, t.id)}
+                              />
+                              <span>{t.name}</span>
+                            </label>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                    <div className="flex gap-2 flex-wrap">
+                      <Button
+                        size="sm"
+                        onClick={() => onApprove(p, false)}
+                        disabled={busy === p.id}
+                      >
+                        <CheckCircle2 className="h-4 w-4 mr-1" />
+                        Approve → Draft
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        onClick={() => onApprove(p, true)}
+                        disabled={busy === p.id || tSet.size === 0}
+                        title={
+                          tSet.size === 0
+                            ? "Pick at least one target to schedule"
+                            : "Schedule in 5 minutes"
+                        }
+                      >
+                        <Send className="h-4 w-4 mr-1" />
+                        Approve → Schedule (+5min)
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => onRegenerate(p)}
+                        disabled={busy === p.id}
+                      >
+                        <RefreshCw className="h-4 w-4 mr-1" />
+                        Regenerate
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="destructive"
+                        onClick={() => onReject(p)}
+                        disabled={busy === p.id}
+                      >
+                        <XCircle className="h-4 w-4 mr-1" />
+                        Reject
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => onDelete(p)}
+                        disabled={busy === p.id}
+                      >
+                        Delete
+                      </Button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/dashboard/app/targets/page.tsx
+++ b/dashboard/app/targets/page.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import {
+  createTarget,
+  deleteTarget,
+  listTargets,
+  patchTarget,
+  syncTargets,
+  type Target,
+} from "@/lib/api";
+import { formatDate } from "@/lib/utils";
+import { Trash2, RefreshCw } from "lucide-react";
+
+export default function TargetsPage() {
+  const [targets, setTargets] = useState<Target[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [syncing, setSyncing] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [form, setForm] = useState({ external_id: "", name: "", tags: "" });
+
+  const refresh = async () => {
+    setLoading(true);
+    try {
+      setTargets(await listTargets());
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const onCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setMessage(null);
+    try {
+      await createTarget({
+        platform_id: "facebook",
+        external_id: form.external_id.trim(),
+        name: form.name.trim() || form.external_id.trim(),
+        tags: form.tags
+          .split(",")
+          .map((t) => t.trim())
+          .filter(Boolean),
+        active: true,
+      });
+      setForm({ external_id: "", name: "", tags: "" });
+      await refresh();
+    } catch (e) {
+      setMessage(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  const onSync = async () => {
+    setSyncing(true);
+    setMessage(null);
+    try {
+      const synced = await syncTargets();
+      setMessage(`Synced ${synced.length} targets from extension.`);
+      await refresh();
+    } catch (e) {
+      setMessage(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSyncing(false);
+    }
+  };
+
+  const onToggle = async (t: Target) => {
+    await patchTarget(t.id, { active: !t.active });
+    await refresh();
+  };
+
+  const onDelete = async (id: number) => {
+    if (!confirm("Delete this target?")) return;
+    await deleteTarget(id);
+    await refresh();
+  };
+
+  return (
+    <div className="space-y-4 max-w-5xl">
+      <Card>
+        <CardHeader>
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <CardTitle>Targets</CardTitle>
+              <CardDescription>
+                Places to post to. For FB, use the group URL
+                (https://www.facebook.com/groups/...).
+              </CardDescription>
+            </div>
+            <Button
+              variant="outline"
+              onClick={onSync}
+              disabled={syncing}
+              type="button"
+            >
+              <RefreshCw
+                className={"h-4 w-4 " + (syncing ? "animate-spin" : "")}
+              />
+              {syncing ? "Syncing…" : "Sync from extension"}
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <form
+            onSubmit={onCreate}
+            className="grid grid-cols-1 md:grid-cols-4 gap-3 items-end"
+          >
+            <div className="space-y-1.5 md:col-span-2">
+              <Label>External URL or ID</Label>
+              <Input
+                required
+                placeholder="https://www.facebook.com/groups/123456789"
+                value={form.external_id}
+                onChange={(e) =>
+                  setForm({ ...form, external_id: e.target.value })
+                }
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Display name</Label>
+              <Input
+                value={form.name}
+                onChange={(e) => setForm({ ...form, name: e.target.value })}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Tags (comma sep)</Label>
+              <div className="flex gap-2">
+                <Input
+                  value={form.tags}
+                  onChange={(e) =>
+                    setForm({ ...form, tags: e.target.value })
+                  }
+                  placeholder="eu, saas"
+                />
+                <Button type="submit">Add</Button>
+              </div>
+            </div>
+          </form>
+          {message && (
+            <div className="text-sm text-muted-foreground">{message}</div>
+          )}
+          <div className="rounded-md border">
+            <table className="w-full text-sm">
+              <thead className="border-b bg-muted/50">
+                <tr className="text-left">
+                  <th className="py-2 px-3">Name</th>
+                  <th className="py-2 px-3">Platform</th>
+                  <th className="py-2 px-3">External ID</th>
+                  <th className="py-2 px-3">Tags</th>
+                  <th className="py-2 px-3">Status</th>
+                  <th className="py-2 px-3">Added</th>
+                  <th className="py-2 px-3 w-20"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {loading ? (
+                  <tr>
+                    <td colSpan={7} className="p-4 text-muted-foreground">
+                      Loading…
+                    </td>
+                  </tr>
+                ) : targets.length === 0 ? (
+                  <tr>
+                    <td colSpan={7} className="p-4 text-muted-foreground">
+                      No targets yet. Add one above or sync from the
+                      extension.
+                    </td>
+                  </tr>
+                ) : (
+                  targets.map((t) => (
+                    <tr key={t.id} className="border-b last:border-0">
+                      <td className="py-2 px-3 font-medium">{t.name}</td>
+                      <td className="py-2 px-3">{t.platform_id}</td>
+                      <td
+                        className="py-2 px-3 truncate max-w-[240px]"
+                        title={t.external_id}
+                      >
+                        {t.external_id}
+                      </td>
+                      <td className="py-2 px-3">
+                        <div className="flex flex-wrap gap-1">
+                          {t.tags.map((tag) => (
+                            <Badge key={tag} variant="secondary">
+                              {tag}
+                            </Badge>
+                          ))}
+                        </div>
+                      </td>
+                      <td className="py-2 px-3">
+                        <button
+                          onClick={() => onToggle(t)}
+                          className="cursor-pointer"
+                        >
+                          <Badge
+                            variant={t.active ? "success" : "outline"}
+                          >
+                            {t.active ? "active" : "inactive"}
+                          </Badge>
+                        </button>
+                      </td>
+                      <td className="py-2 px-3 text-muted-foreground">
+                        {formatDate(t.created_at)}
+                      </td>
+                      <td className="py-2 px-3">
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          onClick={() => onDelete(t.id)}
+                          title="Delete"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/dashboard/app/targets/page.tsx
+++ b/dashboard/app/targets/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Card,
   CardContent,
@@ -13,21 +13,46 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import {
+  bulkReviewTargets,
+  clusterTargets,
   createTarget,
   deleteTarget,
+  discoverTargets,
   listTargets,
   patchTarget,
+  scoreTargets,
   syncTargets,
   type Target,
+  type TargetReviewStatus,
 } from "@/lib/api";
 import { formatDate } from "@/lib/utils";
-import { Trash2, RefreshCw } from "lucide-react";
+import {
+  Check,
+  Compass,
+  Layers,
+  Loader2,
+  RefreshCw,
+  Sparkles,
+  Trash2,
+  X,
+} from "lucide-react";
+
+type StatusFilter = "all" | TargetReviewStatus;
+
+const STATUS_COLORS: Record<TargetReviewStatus, string> = {
+  pending: "bg-amber-100 text-amber-800 border-amber-200",
+  approved: "bg-green-100 text-green-800 border-green-200",
+  rejected: "bg-red-100 text-red-800 border-red-200",
+};
 
 export default function TargetsPage() {
   const [targets, setTargets] = useState<Target[]>([]);
   const [loading, setLoading] = useState(true);
-  const [syncing, setSyncing] = useState(false);
+  const [busy, setBusy] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
+  const [filter, setFilter] = useState<StatusFilter>("all");
+  const [listFilter, setListFilter] = useState<string>("all");
+  const [selected, setSelected] = useState<Set<number>>(new Set());
   const [form, setForm] = useState({ external_id: "", name: "", tags: "" });
 
   const refresh = async () => {
@@ -43,6 +68,41 @@ export default function TargetsPage() {
     refresh();
   }, []);
 
+  const lists = useMemo(() => {
+    const set = new Set<string>();
+    for (const t of targets) if (t.list_name) set.add(t.list_name);
+    return [...set].sort();
+  }, [targets]);
+
+  const filtered = useMemo(() => {
+    return targets.filter((t) => {
+      if (filter !== "all" && t.review_status !== filter) return false;
+      if (listFilter === "__none__" && t.list_name) return false;
+      if (listFilter !== "all" && listFilter !== "__none__" && t.list_name !== listFilter)
+        return false;
+      return true;
+    });
+  }, [targets, filter, listFilter]);
+
+  const allSelected = filtered.length > 0 && filtered.every((t) => selected.has(t.id));
+  const toggleAll = () => {
+    if (allSelected) {
+      const next = new Set(selected);
+      for (const t of filtered) next.delete(t.id);
+      setSelected(next);
+    } else {
+      const next = new Set(selected);
+      for (const t of filtered) next.add(t.id);
+      setSelected(next);
+    }
+  };
+  const toggleOne = (id: number) => {
+    const next = new Set(selected);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    setSelected(next);
+  };
+
   const onCreate = async (e: React.FormEvent) => {
     e.preventDefault();
     setMessage(null);
@@ -51,10 +111,7 @@ export default function TargetsPage() {
         platform_id: "facebook",
         external_id: form.external_id.trim(),
         name: form.name.trim() || form.external_id.trim(),
-        tags: form.tags
-          .split(",")
-          .map((t) => t.trim())
-          .filter(Boolean),
+        tags: form.tags.split(",").map((t) => t.trim()).filter(Boolean),
         active: true,
       });
       setForm({ external_id: "", name: "", tags: "" });
@@ -64,19 +121,52 @@ export default function TargetsPage() {
     }
   };
 
-  const onSync = async () => {
-    setSyncing(true);
+  const run = async (key: string, fn: () => Promise<string | void>) => {
+    setBusy(key);
     setMessage(null);
     try {
-      const synced = await syncTargets();
-      setMessage(`Synced ${synced.length} targets from extension.`);
+      const result = await fn();
+      if (result) setMessage(result);
       await refresh();
     } catch (e) {
       setMessage(e instanceof Error ? e.message : String(e));
     } finally {
-      setSyncing(false);
+      setBusy(null);
     }
   };
+
+  const onSync = () =>
+    run("sync", async () => {
+      const synced = await syncTargets();
+      return `Synced ${synced.length} joined groups.`;
+    });
+
+  const onDiscover = () =>
+    run("discover", async () => {
+      const r = await discoverTargets();
+      return `Discovered ${r.created} new groups (${r.updated} updated).`;
+    });
+
+  const onScore = () =>
+    run("score", async () => {
+      const ids = selected.size > 0 ? [...selected] : [];
+      const r = await scoreTargets(ids);
+      return `Scored ${r.scored.length} targets (cost $${r.cost_usd.toFixed(4)}).`;
+    });
+
+  const onCluster = () =>
+    run("cluster", async () => {
+      const r = await clusterTargets();
+      return `Organized into ${r.lists.length} lists (cost $${r.cost_usd.toFixed(4)}).`;
+    });
+
+  const onBulkReview = (status: TargetReviewStatus) =>
+    run("bulk-" + status, async () => {
+      if (selected.size === 0) return "Select targets first.";
+      await bulkReviewTargets([...selected], status);
+      setSelected(new Set());
+      return `Marked ${selected.size} targets as ${status}.`;
+    });
 
   const onToggle = async (t: Target) => {
     await patchTarget(t.id, { active: !t.active });
@@ -90,28 +180,49 @@ export default function TargetsPage() {
   };
 
   return (
-    <div className="space-y-4 max-w-5xl">
+    <div className="space-y-4 max-w-6xl">
       <Card>
         <CardHeader>
-          <div className="flex items-start justify-between gap-4">
+          <div className="flex items-start justify-between gap-4 flex-wrap">
             <div>
               <CardTitle>Targets</CardTitle>
               <CardDescription>
-                Places to post to. For FB, use the group URL
-                (https://www.facebook.com/groups/...).
+                FB groups, pages, subreddits. Use <strong>Sync</strong> for your joined
+                groups, <strong>Discover</strong> to pull suggested groups,{" "}
+                <strong>Score</strong> to ask the AI which are a good fit, and{" "}
+                <strong>Cluster</strong> to organize approved ones into segments.
               </CardDescription>
             </div>
-            <Button
-              variant="outline"
-              onClick={onSync}
-              disabled={syncing}
-              type="button"
-            >
-              <RefreshCw
-                className={"h-4 w-4 " + (syncing ? "animate-spin" : "")}
-              />
-              {syncing ? "Syncing…" : "Sync from extension"}
-            </Button>
+            <div className="flex flex-wrap gap-2">
+              <Button variant="outline" onClick={onSync} disabled={busy === "sync"}>
+                <RefreshCw
+                  className={"h-4 w-4 " + (busy === "sync" ? "animate-spin" : "")}
+                />
+                Sync joined
+              </Button>
+              <Button variant="outline" onClick={onDiscover} disabled={busy === "discover"}>
+                <Compass
+                  className={"h-4 w-4 " + (busy === "discover" ? "animate-pulse" : "")}
+                />
+                Discover suggested
+              </Button>
+              <Button variant="outline" onClick={onScore} disabled={busy === "score"}>
+                {busy === "score" ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Sparkles className="h-4 w-4" />
+                )}
+                Score {selected.size > 0 ? `(${selected.size})` : "pending"}
+              </Button>
+              <Button variant="outline" onClick={onCluster} disabled={busy === "cluster"}>
+                {busy === "cluster" ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Layers className="h-4 w-4" />
+                )}
+                Cluster approved
+              </Button>
+            </div>
           </div>
         </CardHeader>
         <CardContent className="space-y-4">
@@ -125,9 +236,7 @@ export default function TargetsPage() {
                 required
                 placeholder="https://www.facebook.com/groups/123456789"
                 value={form.external_id}
-                onChange={(e) =>
-                  setForm({ ...form, external_id: e.target.value })
-                }
+                onChange={(e) => setForm({ ...form, external_id: e.target.value })}
               />
             </div>
             <div className="space-y-1.5">
@@ -142,79 +251,187 @@ export default function TargetsPage() {
               <div className="flex gap-2">
                 <Input
                   value={form.tags}
-                  onChange={(e) =>
-                    setForm({ ...form, tags: e.target.value })
-                  }
+                  onChange={(e) => setForm({ ...form, tags: e.target.value })}
                   placeholder="eu, saas"
                 />
                 <Button type="submit">Add</Button>
               </div>
             </div>
           </form>
-          {message && (
-            <div className="text-sm text-muted-foreground">{message}</div>
-          )}
-          <div className="rounded-md border">
+
+          <div className="flex flex-wrap items-center gap-2 text-sm">
+            <span className="text-muted-foreground">Filter:</span>
+            {(["all", "pending", "approved", "rejected"] as const).map((s) => (
+              <button
+                key={s}
+                onClick={() => setFilter(s)}
+                className={`px-2 py-1 rounded-md border text-xs ${
+                  filter === s ? "bg-primary text-primary-foreground" : "bg-background"
+                }`}
+              >
+                {s}
+              </button>
+            ))}
+            {lists.length > 0 && (
+              <>
+                <span className="text-muted-foreground ml-3">List:</span>
+                <select
+                  value={listFilter}
+                  onChange={(e) => setListFilter(e.target.value)}
+                  className="h-8 px-2 text-xs rounded-md border bg-background"
+                >
+                  <option value="all">All</option>
+                  <option value="__none__">No list</option>
+                  {lists.map((l) => (
+                    <option key={l} value={l}>
+                      {l}
+                    </option>
+                  ))}
+                </select>
+              </>
+            )}
+            {selected.size > 0 && (
+              <div className="ml-auto flex gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => onBulkReview("approved")}
+                  disabled={busy?.startsWith("bulk-")}
+                >
+                  <Check className="h-3 w-3" />
+                  Approve {selected.size}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => onBulkReview("rejected")}
+                  disabled={busy?.startsWith("bulk-")}
+                >
+                  <X className="h-3 w-3" />
+                  Reject {selected.size}
+                </Button>
+              </div>
+            )}
+          </div>
+
+          {message && <div className="text-sm text-muted-foreground">{message}</div>}
+
+          <div className="rounded-md border overflow-x-auto">
             <table className="w-full text-sm">
               <thead className="border-b bg-muted/50">
                 <tr className="text-left">
+                  <th className="py-2 px-3 w-8">
+                    <input
+                      type="checkbox"
+                      checked={allSelected}
+                      onChange={toggleAll}
+                      aria-label="Select all filtered"
+                    />
+                  </th>
                   <th className="py-2 px-3">Name</th>
-                  <th className="py-2 px-3">Platform</th>
-                  <th className="py-2 px-3">External ID</th>
-                  <th className="py-2 px-3">Tags</th>
+                  <th className="py-2 px-3">Score</th>
+                  <th className="py-2 px-3">List</th>
                   <th className="py-2 px-3">Status</th>
-                  <th className="py-2 px-3">Added</th>
-                  <th className="py-2 px-3 w-20"></th>
+                  <th className="py-2 px-3">Members</th>
+                  <th className="py-2 px-3">Source</th>
+                  <th className="py-2 px-3">Active</th>
+                  <th className="py-2 px-3 w-12"></th>
                 </tr>
               </thead>
               <tbody>
                 {loading ? (
                   <tr>
-                    <td colSpan={7} className="p-4 text-muted-foreground">
+                    <td colSpan={9} className="p-4 text-muted-foreground">
                       Loading…
                     </td>
                   </tr>
-                ) : targets.length === 0 ? (
+                ) : filtered.length === 0 ? (
                   <tr>
-                    <td colSpan={7} className="p-4 text-muted-foreground">
-                      No targets yet. Add one above or sync from the
-                      extension.
+                    <td colSpan={9} className="p-4 text-muted-foreground">
+                      No targets match this filter.
                     </td>
                   </tr>
                 ) : (
-                  targets.map((t) => (
-                    <tr key={t.id} className="border-b last:border-0">
-                      <td className="py-2 px-3 font-medium">{t.name}</td>
-                      <td className="py-2 px-3">{t.platform_id}</td>
-                      <td
-                        className="py-2 px-3 truncate max-w-[240px]"
-                        title={t.external_id}
-                      >
-                        {t.external_id}
-                      </td>
+                  filtered.map((t) => (
+                    <tr key={t.id} className="border-b last:border-0 align-top">
                       <td className="py-2 px-3">
-                        <div className="flex flex-wrap gap-1">
-                          {t.tags.map((tag) => (
-                            <Badge key={tag} variant="secondary">
-                              {tag}
-                            </Badge>
-                          ))}
+                        <input
+                          type="checkbox"
+                          checked={selected.has(t.id)}
+                          onChange={() => toggleOne(t.id)}
+                        />
+                      </td>
+                      <td className="py-2 px-3 max-w-[320px]">
+                        <div className="font-medium truncate" title={t.name}>
+                          {t.name}
                         </div>
+                        {t.description_snippet && (
+                          <div
+                            className="text-xs text-muted-foreground line-clamp-2"
+                            title={t.description_snippet}
+                          >
+                            {t.description_snippet}
+                          </div>
+                        )}
+                        {t.ai_reasoning && (
+                          <div
+                            className="text-xs text-primary/80 italic mt-1 line-clamp-2"
+                            title={t.ai_reasoning}
+                          >
+                            AI: {t.ai_reasoning}
+                          </div>
+                        )}
+                        <a
+                          className="text-[11px] text-muted-foreground underline"
+                          href={t.external_id.startsWith("http") ? t.external_id : undefined}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          {t.external_id}
+                        </a>
                       </td>
                       <td className="py-2 px-3">
-                        <button
-                          onClick={() => onToggle(t)}
-                          className="cursor-pointer"
-                        >
+                        {t.relevance_score != null ? (
                           <Badge
-                            variant={t.active ? "success" : "outline"}
+                            variant="outline"
+                            className={
+                              t.relevance_score >= 70
+                                ? "border-green-400 text-green-800"
+                                : t.relevance_score >= 40
+                                  ? "border-amber-400 text-amber-800"
+                                  : "border-red-300 text-red-700"
+                            }
                           >
-                            {t.active ? "active" : "inactive"}
+                            {t.relevance_score}
+                          </Badge>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">—</span>
+                        )}
+                      </td>
+                      <td className="py-2 px-3 text-xs">
+                        {t.list_name ?? <span className="text-muted-foreground">—</span>}
+                      </td>
+                      <td className="py-2 px-3">
+                        <Badge
+                          variant="outline"
+                          className={STATUS_COLORS[t.review_status]}
+                        >
+                          {t.review_status}
+                        </Badge>
+                      </td>
+                      <td className="py-2 px-3 text-xs">
+                        {t.member_count?.toLocaleString() ?? "—"}
+                      </td>
+                      <td className="py-2 px-3 text-xs text-muted-foreground">
+                        {t.source}
+                        <div>{formatDate(t.created_at)}</div>
+                      </td>
+                      <td className="py-2 px-3">
+                        <button onClick={() => onToggle(t)} className="cursor-pointer">
+                          <Badge variant={t.active ? "success" : "outline"}>
+                            {t.active ? "on" : "off"}
                           </Badge>
                         </button>
-                      </td>
-                      <td className="py-2 px-3 text-muted-foreground">
-                        {formatDate(t.created_at)}
                       </td>
                       <td className="py-2 px-3">
                         <Button

--- a/dashboard/components/auth-gate.tsx
+++ b/dashboard/components/auth-gate.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getAuthStatus, login, type AuthStatus } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export function AuthGate({ children }: { children: React.ReactNode }) {
+  const [status, setStatus] = useState<AuthStatus | null>(null);
+  const [pin, setPin] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = async () => {
+    try {
+      const s = await getAuthStatus();
+      setStatus(s);
+    } catch {
+      // If /api/auth/status itself is gated, the backend is misconfigured —
+      // but in that case there's nothing useful we can render.
+      setStatus({ auth_required: true, authenticated: false });
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const submit = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await login(pin);
+      setPin("");
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Login failed");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (status === null) {
+    return null;
+  }
+  if (!status.auth_required || status.authenticated) {
+    return <>{children}</>;
+  }
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-6">
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle>Dashboard locked</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            Enter the PIN from your <code>.env</code> (DASHBOARD_PIN) to continue.
+          </p>
+          <Input
+            type="password"
+            value={pin}
+            onChange={(e) => setPin(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") submit();
+            }}
+            autoFocus
+          />
+          {error && <p className="text-xs text-destructive">{error}</p>}
+          <Button onClick={submit} disabled={busy || !pin}>
+            {busy ? "Signing in…" : "Unlock"}
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/dashboard/components/layout/sidebar.tsx
+++ b/dashboard/components/layout/sidebar.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import {
   Calendar,
+  CalendarDays,
   Home,
   ListChecks,
   PenSquare,
@@ -14,6 +15,7 @@ import {
 const NAV = [
   { href: "/profile", label: "Business Profile", icon: Home },
   { href: "/targets", label: "Targets", icon: Users },
+  { href: "/plans", label: "Content Plans", icon: CalendarDays },
   { href: "/compose", label: "Compose", icon: PenSquare },
   { href: "/queue", label: "Queue", icon: ListChecks },
 ];

--- a/dashboard/components/layout/sidebar.tsx
+++ b/dashboard/components/layout/sidebar.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+import {
+  Calendar,
+  Home,
+  ListChecks,
+  PenSquare,
+  Users,
+} from "lucide-react";
+
+const NAV = [
+  { href: "/profile", label: "Business Profile", icon: Home },
+  { href: "/targets", label: "Targets", icon: Users },
+  { href: "/compose", label: "Compose", icon: PenSquare },
+  { href: "/queue", label: "Queue", icon: ListChecks },
+];
+
+export function Sidebar() {
+  const pathname = usePathname();
+  return (
+    <aside className="w-60 border-r bg-card/50 h-screen sticky top-0 flex flex-col">
+      <div className="p-4 border-b">
+        <div className="flex items-center gap-2">
+          <Calendar className="h-5 w-5" />
+          <span className="font-semibold">autoposter-AI</span>
+        </div>
+        <div className="text-xs text-muted-foreground mt-1">
+          Local self-hosted v0.1
+        </div>
+      </div>
+      <nav className="flex-1 p-2 space-y-1">
+        {NAV.map(({ href, label, icon: Icon }) => {
+          const active =
+            pathname === href || pathname.startsWith(href + "/");
+          return (
+            <Link
+              key={href}
+              href={href}
+              className={cn(
+                "flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors",
+                active
+                  ? "bg-accent text-accent-foreground font-medium"
+                  : "hover:bg-accent/60",
+              )}
+            >
+              <Icon className="h-4 w-4" />
+              {label}
+            </Link>
+          );
+        })}
+      </nav>
+      <div className="p-3 text-xs text-muted-foreground border-t">
+        <p className="leading-relaxed">
+          Facebook automation breaks their ToS. Use a throwaway account and
+          respect rate limits.
+        </p>
+      </div>
+    </aside>
+  );
+}

--- a/dashboard/components/layout/sidebar.tsx
+++ b/dashboard/components/layout/sidebar.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils";
 import {
   Calendar,
   CalendarDays,
+  CheckSquare,
   Home,
   Image as ImageIcon,
   ListChecks,
@@ -20,6 +21,7 @@ const NAV = [
   { href: "/plans", label: "Content Plans", icon: CalendarDays },
   { href: "/library", label: "Media Library", icon: ImageIcon },
   { href: "/compose", label: "Compose", icon: PenSquare },
+  { href: "/review", label: "Review", icon: CheckSquare },
   { href: "/queue", label: "Queue", icon: ListChecks },
   { href: "/humanizer", label: "Humanizer", icon: ShieldCheck },
 ];

--- a/dashboard/components/layout/sidebar.tsx
+++ b/dashboard/components/layout/sidebar.tsx
@@ -7,6 +7,7 @@ import {
   Calendar,
   CalendarDays,
   Home,
+  Image as ImageIcon,
   ListChecks,
   PenSquare,
   Users,
@@ -16,6 +17,7 @@ const NAV = [
   { href: "/profile", label: "Business Profile", icon: Home },
   { href: "/targets", label: "Targets", icon: Users },
   { href: "/plans", label: "Content Plans", icon: CalendarDays },
+  { href: "/library", label: "Media Library", icon: ImageIcon },
   { href: "/compose", label: "Compose", icon: PenSquare },
   { href: "/queue", label: "Queue", icon: ListChecks },
 ];

--- a/dashboard/components/layout/sidebar.tsx
+++ b/dashboard/components/layout/sidebar.tsx
@@ -10,6 +10,7 @@ import {
   CheckSquare,
   Home,
   Image as ImageIcon,
+  Link2,
   ListChecks,
   PenSquare,
   ShieldCheck,
@@ -25,6 +26,7 @@ const NAV = [
   { href: "/review", label: "Review", icon: CheckSquare },
   { href: "/queue", label: "Queue", icon: ListChecks },
   { href: "/analytics", label: "Analytics", icon: BarChart3 },
+  { href: "/platforms", label: "Platforms", icon: Link2 },
   { href: "/humanizer", label: "Humanizer", icon: ShieldCheck },
 ];
 

--- a/dashboard/components/layout/sidebar.tsx
+++ b/dashboard/components/layout/sidebar.tsx
@@ -10,6 +10,7 @@ import {
   Image as ImageIcon,
   ListChecks,
   PenSquare,
+  ShieldCheck,
   Users,
 } from "lucide-react";
 
@@ -20,6 +21,7 @@ const NAV = [
   { href: "/library", label: "Media Library", icon: ImageIcon },
   { href: "/compose", label: "Compose", icon: PenSquare },
   { href: "/queue", label: "Queue", icon: ListChecks },
+  { href: "/humanizer", label: "Humanizer", icon: ShieldCheck },
 ];
 
 export function Sidebar() {

--- a/dashboard/components/layout/sidebar.tsx
+++ b/dashboard/components/layout/sidebar.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import {
+  BarChart3,
   Calendar,
   CalendarDays,
   CheckSquare,
@@ -23,6 +24,7 @@ const NAV = [
   { href: "/compose", label: "Compose", icon: PenSquare },
   { href: "/review", label: "Review", icon: CheckSquare },
   { href: "/queue", label: "Queue", icon: ListChecks },
+  { href: "/analytics", label: "Analytics", icon: BarChart3 },
   { href: "/humanizer", label: "Humanizer", icon: ShieldCheck },
 ];
 

--- a/dashboard/components/layout/status-bar.tsx
+++ b/dashboard/components/layout/status-bar.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getStatus, type StatusOut } from "@/lib/api";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+export function StatusBar() {
+  const [status, setStatus] = useState<StatusOut | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const s = await getStatus();
+        if (!cancelled) {
+          setStatus(s);
+          setError(null);
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : String(e));
+        }
+      }
+    };
+    tick();
+    const id = setInterval(tick, 10_000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
+
+  if (error) {
+    return (
+      <div className="flex items-center gap-2 rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm">
+        <span className="h-2 w-2 rounded-full bg-destructive" />
+        <span className="text-destructive">
+          Backend unreachable: {error}
+        </span>
+      </div>
+    );
+  }
+
+  if (!status) {
+    return (
+      <div className="rounded-md border px-3 py-2 text-sm text-muted-foreground">
+        Checking backend…
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-3 rounded-md border px-3 py-2 text-sm flex-wrap">
+      <div className="flex items-center gap-2">
+        <span
+          className={cn(
+            "h-2 w-2 rounded-full",
+            status.ok ? "bg-green-500" : "bg-red-500",
+          )}
+        />
+        Backend v{status.version}
+      </div>
+      <Badge variant={status.extension_connected ? "success" : "outline"}>
+        Extension: {status.extension_connected ? "connected" : "offline"}
+      </Badge>
+      <Badge variant={status.scheduler_running ? "success" : "warning"}>
+        Scheduler: {status.scheduler_running ? "running" : "stopped"}
+      </Badge>
+      <span className="text-muted-foreground ml-auto">
+        Pending: {status.pending_posts}
+      </span>
+    </div>
+  );
+}

--- a/dashboard/components/ui/badge.tsx
+++ b/dashboard/components/ui/badge.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium transition-colors",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground",
+        outline: "text-foreground",
+        success:
+          "border-transparent bg-green-600 text-white",
+        warning:
+          "border-transparent bg-amber-500 text-white",
+      },
+    },
+    defaultVariants: { variant: "default" },
+  },
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLSpanElement>,
+    VariantProps<typeof badgeVariants> {}
+
+export function Badge({ className, variant, ...props }: BadgeProps) {
+  return <span className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
+
+export { badgeVariants };

--- a/dashboard/components/ui/button.tsx
+++ b/dashboard/components/ui/button.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2",
+        sm: "h-8 px-3 text-xs",
+        lg: "h-10 px-6",
+        icon: "h-9 w-9",
+      },
+    },
+    defaultVariants: { variant: "default", size: "default" },
+  },
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => (
+    <button
+      ref={ref}
+      className={cn(buttonVariants({ variant, size }), className)}
+      {...props}
+    />
+  ),
+);
+Button.displayName = "Button";
+
+export { buttonVariants };

--- a/dashboard/components/ui/card.tsx
+++ b/dashboard/components/ui/card.tsx
@@ -1,0 +1,73 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      className,
+    )}
+    {...props}
+  />
+));
+Card.displayName = "Card";
+
+export const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+));
+CardHeader.displayName = "CardHeader";
+
+export const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn("font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+CardTitle.displayName = "CardTitle";
+
+export const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+CardDescription.displayName = "CardDescription";
+
+export const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+));
+CardContent.displayName = "CardContent";
+
+export const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+));
+CardFooter.displayName = "CardFooter";

--- a/dashboard/components/ui/input.tsx
+++ b/dashboard/components/ui/input.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => (
+    <input
+      type={type}
+      ref={ref}
+      className={cn(
+        "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+Input.displayName = "Input";

--- a/dashboard/components/ui/label.tsx
+++ b/dashboard/components/ui/label.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export const Label = React.forwardRef<
+  HTMLLabelElement,
+  React.LabelHTMLAttributes<HTMLLabelElement>
+>(({ className, ...props }, ref) => (
+  <label
+    ref={ref}
+    className={cn(
+      "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+      className,
+    )}
+    {...props}
+  />
+));
+Label.displayName = "Label";

--- a/dashboard/components/ui/select.tsx
+++ b/dashboard/components/ui/select.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export const Select = React.forwardRef<
+  HTMLSelectElement,
+  React.SelectHTMLAttributes<HTMLSelectElement>
+>(({ className, children, ...props }, ref) => (
+  <select
+    ref={ref}
+    className={cn(
+      "flex h-9 w-full items-center rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+  </select>
+));
+Select.displayName = "Select";

--- a/dashboard/components/ui/textarea.tsx
+++ b/dashboard/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => (
+    <textarea
+      ref={ref}
+      className={cn(
+        "flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+Textarea.displayName = "Textarea";

--- a/dashboard/components/warning-banner.tsx
+++ b/dashboard/components/warning-banner.tsx
@@ -1,0 +1,15 @@
+import { AlertTriangle } from "lucide-react";
+
+export function WarningBanner() {
+  return (
+    <div className="flex items-start gap-2 rounded-md border border-amber-500/50 bg-amber-500/10 px-3 py-2 text-sm text-amber-900 dark:text-amber-200">
+      <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+      <div>
+        <span className="font-medium">Facebook ToS notice.</span>{" "}
+        Automating posts violates Facebook&apos;s Terms. For personal use with
+        reasonable delays the risk is low but not zero. Do not use this with
+        your primary account.
+      </div>
+    </div>
+  );
+}

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -54,6 +54,8 @@ export interface BusinessProfile {
   updated_at: string;
 }
 
+export type TargetReviewStatus = "pending" | "approved" | "rejected";
+
 export interface Target {
   id: number;
   platform_id: string;
@@ -64,6 +66,12 @@ export interface Target {
   member_count: number | null;
   active: boolean;
   created_at: string;
+  description_snippet: string | null;
+  category: string | null;
+  source: string;
+  relevance_score: number | null;
+  ai_reasoning: string | null;
+  review_status: TargetReviewStatus;
 }
 
 export interface PostVariant {
@@ -188,6 +196,61 @@ export const patchTarget = (id: number, patch: Partial<Target>) =>
 
 export const syncTargets = () =>
   request<Target[]>("/api/targets/sync", { method: "POST" });
+
+export const listTargetsFiltered = (params: {
+  platform_id?: string;
+  active_only?: boolean;
+  review_status?: TargetReviewStatus;
+  list_name?: string;
+}) => {
+  const q = new URLSearchParams();
+  if (params.platform_id) q.set("platform_id", params.platform_id);
+  if (params.active_only) q.set("active_only", "true");
+  if (params.review_status) q.set("review_status", params.review_status);
+  if (params.list_name) q.set("list_name", params.list_name);
+  const qs = q.toString();
+  return request<Target[]>(`/api/targets${qs ? "?" + qs : ""}`);
+};
+
+export interface TargetDiscoverResult {
+  created: number;
+  updated: number;
+  targets: Target[];
+}
+
+export const discoverTargets = () =>
+  request<TargetDiscoverResult>("/api/targets/discover", { method: "POST" });
+
+export interface TargetScoreResponse {
+  scored: Array<{ target_id: number; score: number; reasoning: string }>;
+  cost_usd: number;
+}
+
+export const scoreTargets = (target_ids: number[] = []) =>
+  request<TargetScoreResponse>("/api/targets/score", {
+    method: "POST",
+    body: JSON.stringify({ target_ids }),
+  });
+
+export interface TargetClusterResponse {
+  lists: Array<{ list_name: string; target_ids: number[] }>;
+  cost_usd: number;
+}
+
+export const clusterTargets = (target_ids: number[] = []) =>
+  request<TargetClusterResponse>("/api/targets/cluster", {
+    method: "POST",
+    body: JSON.stringify({ target_ids }),
+  });
+
+export const bulkReviewTargets = (
+  target_ids: number[],
+  review_status: TargetReviewStatus,
+) =>
+  request<Target[]>("/api/targets/bulk-review", {
+    method: "POST",
+    body: JSON.stringify({ target_ids, review_status }),
+  });
 
 // ---------- Posts ----------
 

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -783,4 +783,48 @@ export const rejectProposal = (id: number) =>
 export const refreshFewShotStore = () =>
   request<{ inserted: number }>("/api/few-shot/refresh", { method: "POST" });
 
+// ---------- M7: Platforms (Instagram / Threads) ----------
+
+export interface PlatformCredential {
+  id: number;
+  platform_id: string;
+  account_id: string;
+  username: string | null;
+  token_expires_at: string | null;
+  extra: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface MetaOAuthUrl {
+  url: string;
+  state: string;
+}
+
+export interface MetaOAuthComplete {
+  instagram: PlatformCredential | null;
+  threads: PlatformCredential | null;
+  message: string;
+}
+
+export const getMetaOAuthUrl = () =>
+  request<MetaOAuthUrl>("/api/meta/oauth/url");
+
+export const addManualCredential = (payload: {
+  platform_id: "instagram" | "threads";
+  account_id: string;
+  username?: string;
+  access_token: string;
+}) =>
+  request<PlatformCredential>("/api/meta/credentials", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+
+export const listPlatformCredentials = () =>
+  request<PlatformCredential[]>("/api/platform-credentials");
+
+export const deletePlatformCredential = (id: number) =>
+  request<void>(`/api/platform-credentials/${id}`, { method: "DELETE" });
+
 export { ApiError };

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -50,6 +50,7 @@ export interface BusinessProfile {
   timezone: string;
   posts_per_day: number;
   review_before_posting: boolean;
+  auto_approve_types: string[];
   created_at: string;
   updated_at: string;
 }
@@ -321,6 +322,53 @@ export const schedulePost = (
   request<Post>(`/api/posts/${id}/schedule`, {
     method: "POST",
     body: JSON.stringify(payload),
+  });
+
+// ---------- Review & Approval (M5) ----------
+
+export const listPendingReview = () =>
+  request<Post[]>("/api/posts/review/pending");
+
+export const approvePost = (
+  id: number,
+  payload: { target_ids?: number[]; scheduled_for?: string | null } = {},
+) =>
+  request<Post>(`/api/posts/${id}/approve`, {
+    method: "POST",
+    body: JSON.stringify({
+      target_ids: payload.target_ids ?? [],
+      scheduled_for: payload.scheduled_for ?? null,
+    }),
+  });
+
+export const rejectPost = (id: number, reason?: string) =>
+  request<Post>(`/api/posts/${id}/reject`, {
+    method: "POST",
+    body: JSON.stringify({ reason: reason ?? null }),
+  });
+
+export const regeneratePost = (
+  id: number,
+  payload: { topic_hint?: string | null; generate_image?: boolean } = {},
+) =>
+  request<Post>(`/api/posts/${id}/regenerate`, {
+    method: "POST",
+    body: JSON.stringify({
+      topic_hint: payload.topic_hint ?? null,
+      generate_image: payload.generate_image ?? false,
+    }),
+  });
+
+export const approveAllPending = (payload: {
+  post_type?: PostType | null;
+  scheduled_for?: string | null;
+}) =>
+  request<Post[]>("/api/posts/review/approve-all", {
+    method: "POST",
+    body: JSON.stringify({
+      post_type: payload.post_type ?? null,
+      scheduled_for: payload.scheduled_for ?? null,
+    }),
   });
 
 // ---------- Feedback ----------

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -1,0 +1,292 @@
+/**
+ * Typed fetch wrapper for the backend REST API.
+ *
+ * Base URL comes from NEXT_PUBLIC_API_URL (set in .env.local).
+ * Falls back to http://localhost:8787 for local dev.
+ */
+
+const BASE =
+  process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, "") ?? "http://localhost:8787";
+
+export type PostType =
+  | "informative"
+  | "soft_sell"
+  | "hard_sell"
+  | "engagement"
+  | "story"
+  | "motivational"
+  | "testimonial"
+  | "hot_take"
+  | "seasonal";
+
+export type PostStatus =
+  | "draft"
+  | "pending_review"
+  | "scheduled"
+  | "posting"
+  | "posted"
+  | "failed"
+  | "skipped";
+
+export type Tone = "professional" | "casual" | "fun";
+export type Length = "short" | "medium" | "long";
+export type EmojiDensity = "none" | "light" | "medium" | "heavy";
+
+export interface BusinessProfile {
+  id: number;
+  name: string;
+  description: string;
+  website_url: string | null;
+  products: string | null;
+  target_audience: string | null;
+  call_to_action_url: string | null;
+  tone: Tone;
+  length: Length;
+  emoji_density: EmojiDensity;
+  language: string;
+  post_type_ratios: Record<string, number>;
+  posting_window_start_hour: number;
+  posting_window_end_hour: number;
+  timezone: string;
+  posts_per_day: number;
+  review_before_posting: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Target {
+  id: number;
+  platform_id: string;
+  external_id: string;
+  name: string;
+  tags: string[];
+  list_name: string | null;
+  member_count: number | null;
+  active: boolean;
+  created_at: string;
+}
+
+export interface PostVariant {
+  id: number;
+  post_id: number;
+  target_id: number;
+  text: string;
+  status: PostStatus;
+  scheduled_for: string | null;
+  posted_at: string | null;
+  external_post_id: string | null;
+  error: string | null;
+}
+
+export interface Post {
+  id: number;
+  post_type: PostType;
+  status: PostStatus;
+  text: string;
+  image_url: string | null;
+  image_prompt: string | null;
+  first_comment: string | null;
+  cta_url: string | null;
+  scheduled_for: string | null;
+  posted_at: string | null;
+  generation_model: string | null;
+  generation_cost_usd: number | null;
+  created_at: string;
+  variants: PostVariant[];
+}
+
+export interface StatusOut {
+  ok: boolean;
+  version: string;
+  extension_connected: boolean;
+  scheduler_running: boolean;
+  next_scheduled_post_at: string | null;
+  pending_posts: number;
+}
+
+class ApiError extends Error {
+  constructor(public status: number, public body: unknown, message: string) {
+    super(message);
+  }
+}
+
+async function request<T>(
+  path: string,
+  init: RequestInit = {},
+): Promise<T> {
+  const url = path.startsWith("http") ? path : `${BASE}${path}`;
+  const resp = await fetch(url, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init.headers ?? {}),
+    },
+  });
+  if (!resp.ok) {
+    let body: unknown;
+    try {
+      body = await resp.json();
+    } catch {
+      body = await resp.text();
+    }
+    const detail =
+      typeof body === "object" && body && "detail" in body
+        ? String((body as { detail: unknown }).detail)
+        : resp.statusText;
+    throw new ApiError(resp.status, body, detail);
+  }
+  if (resp.status === 204) return undefined as T;
+  return (await resp.json()) as T;
+}
+
+// ---------- Status ----------
+
+export const getStatus = () => request<StatusOut>("/api/status");
+
+// ---------- BusinessProfile ----------
+
+export const getBusinessProfile = () =>
+  request<BusinessProfile>("/api/business-profile").catch((e) => {
+    if (e instanceof ApiError && e.status === 404) return null;
+    throw e;
+  });
+
+export const upsertBusinessProfile = (payload: Partial<BusinessProfile>) =>
+  request<BusinessProfile>("/api/business-profile", {
+    method: "PUT",
+    body: JSON.stringify(payload),
+  });
+
+// ---------- Targets ----------
+
+export const listTargets = (params?: { active_only?: boolean }) => {
+  const q = params?.active_only ? "?active_only=true" : "";
+  return request<Target[]>(`/api/targets${q}`);
+};
+
+export const createTarget = (payload: {
+  platform_id?: string;
+  external_id: string;
+  name: string;
+  tags?: string[];
+  list_name?: string;
+  active?: boolean;
+}) =>
+  request<Target>("/api/targets", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+
+export const deleteTarget = (id: number) =>
+  request<void>(`/api/targets/${id}`, { method: "DELETE" });
+
+export const patchTarget = (id: number, patch: Partial<Target>) =>
+  request<Target>(`/api/targets/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(patch),
+  });
+
+export const syncTargets = () =>
+  request<Target[]>("/api/targets/sync", { method: "POST" });
+
+// ---------- Posts ----------
+
+export const listPosts = (status?: PostStatus) => {
+  const q = status ? `?status_filter=${status}` : "";
+  return request<Post[]>(`/api/posts${q}`);
+};
+
+export const getPost = (id: number) => request<Post>(`/api/posts/${id}`);
+
+export const createPost = (payload: {
+  post_type: PostType;
+  text: string;
+  image_url?: string | null;
+  image_prompt?: string | null;
+  first_comment?: string | null;
+  cta_url?: string | null;
+  scheduled_for?: string | null;
+}) =>
+  request<Post>("/api/posts", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+
+export const patchPost = (id: number, patch: Partial<Post>) =>
+  request<Post>(`/api/posts/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(patch),
+  });
+
+export const deletePost = (id: number) =>
+  request<void>(`/api/posts/${id}`, { method: "DELETE" });
+
+export const generatePost = (payload: {
+  post_type: PostType;
+  topic_hint?: string;
+  generate_image?: boolean;
+  use_few_shot?: boolean;
+}) =>
+  request<Post>("/api/posts/generate", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+
+export const publishPost = (
+  id: number,
+  payload: {
+    target_ids: number[];
+    generate_spintax?: boolean;
+  },
+) =>
+  request<{ post_id: number; status: PostStatus; variants: PostVariant[] }>(
+    `/api/posts/${id}/publish`,
+    {
+      method: "POST",
+      body: JSON.stringify(payload),
+    },
+  );
+
+export const schedulePost = (
+  id: number,
+  payload: {
+    target_ids: number[];
+    scheduled_for: string;
+    generate_spintax?: boolean;
+  },
+) =>
+  request<Post>(`/api/posts/${id}/schedule`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+
+// ---------- Feedback ----------
+
+export const sendFeedback = (payload: {
+  post_id: number;
+  rating: "up" | "down";
+  comment?: string;
+}) =>
+  request<unknown>("/api/feedback", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+
+// ---------- Media ----------
+
+export async function uploadMedia(
+  file: File,
+): Promise<{ url: string; filename: string; mime: string; size_bytes: number }> {
+  const form = new FormData();
+  form.append("file", file);
+  const resp = await fetch(`${BASE}/api/media/upload`, {
+    method: "POST",
+    body: form,
+  });
+  if (!resp.ok) {
+    throw new Error(`Upload failed: ${resp.status} ${resp.statusText}`);
+  }
+  return resp.json();
+}
+
+export { ApiError };

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -532,4 +532,84 @@ export const generatePostFromSlot = (slotId: number) =>
     { method: "POST" },
   );
 
+// ---------- Humanizer (M4) ----------
+
+export type SessionHealthStatus =
+  | "healthy"
+  | "warning"
+  | "checkpoint"
+  | "shadow_ban_suspected"
+  | "paused";
+
+export interface HumanizerProfile {
+  id: number;
+  typing_wpm_min: number;
+  typing_wpm_max: number;
+  mistake_rate: number;
+  pause_between_sentences_ms_min: number;
+  pause_between_sentences_ms_max: number;
+  mouse_path_curvature: number;
+  idle_scroll_before_post_sec_min: number;
+  idle_scroll_before_post_sec_max: number;
+  schedule_jitter_minutes: number;
+  consecutive_failures_threshold: number;
+  smart_pause_minutes: number;
+  smart_pause_until: string | null;
+  smart_pause_reason: string | null;
+}
+
+export interface SessionHealth {
+  platform_id: string;
+  status: SessionHealthStatus;
+  consecutive_failures: number;
+  last_failure_at: string | null;
+  last_failure_reason: string | null;
+  last_success_at: string | null;
+}
+
+export interface SmartPauseInfo {
+  paused: boolean;
+  until: string | null;
+  reason: string | null;
+}
+
+export interface BlackoutDate {
+  id: number;
+  date: string;
+  reason: string | null;
+}
+
+export const getHumanizer = () =>
+  request<HumanizerProfile>("/api/humanizer/profile");
+
+export const patchHumanizer = (patch: Partial<HumanizerProfile>) =>
+  request<HumanizerProfile>("/api/humanizer/profile", {
+    method: "PATCH",
+    body: JSON.stringify(patch),
+  });
+
+export const listSessionHealth = () =>
+  request<SessionHealth[]>("/api/humanizer/session-health");
+
+export const getPauseStatus = () =>
+  request<SmartPauseInfo>("/api/humanizer/pause");
+
+export const activatePause = () =>
+  request<SmartPauseInfo>("/api/humanizer/pause", { method: "POST" });
+
+export const resumeFromPause = () =>
+  request<SmartPauseInfo>("/api/humanizer/resume", { method: "POST" });
+
+export const listBlackouts = () =>
+  request<BlackoutDate[]>("/api/humanizer/blackout-dates");
+
+export const addBlackout = (payload: { date: string; reason?: string | null }) =>
+  request<BlackoutDate>("/api/humanizer/blackout-dates", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+
+export const deleteBlackout = (id: number) =>
+  request<void>(`/api/humanizer/blackout-dates/${id}`, { method: "DELETE" });
+
 export { ApiError };

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -274,9 +274,17 @@ export const sendFeedback = (payload: {
 
 // ---------- Media ----------
 
-export async function uploadMedia(
-  file: File,
-): Promise<{ url: string; filename: string; mime: string; size_bytes: number }> {
+export interface MediaUploadResult {
+  id: number;
+  url: string;
+  filename: string;
+  mime: string;
+  size_bytes: number;
+  width: number | null;
+  height: number | null;
+}
+
+export async function uploadMedia(file: File): Promise<MediaUploadResult> {
   const form = new FormData();
   form.append("file", file);
   const resp = await fetch(`${BASE}/api/media/upload`, {
@@ -288,6 +296,50 @@ export async function uploadMedia(
   }
   return resp.json();
 }
+
+export interface MediaAsset {
+  id: number;
+  kind: "image" | "video";
+  mime: string;
+  local_path: string;
+  filename: string;
+  size_bytes: number;
+  width: number | null;
+  height: number | null;
+  duration_sec: number | null;
+  ai_caption: string | null;
+  ai_tags: string[];
+  tags_user: string[];
+  tagged_at: string | null;
+  created_at: string;
+}
+
+export const listMedia = () => request<MediaAsset[]>("/api/media");
+export const getMedia = (id: number) => request<MediaAsset>(`/api/media/${id}`);
+export const deleteMedia = (id: number) =>
+  request<void>(`/api/media/${id}`, { method: "DELETE" });
+
+export const patchMedia = (id: number, patch: { tags_user?: string[] }) =>
+  request<MediaAsset>(`/api/media/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(patch),
+  });
+
+export const tagMedia = (id: number) =>
+  request<{ caption: string; tags: string[]; cost_usd: number }>(
+    `/api/media/${id}/tag`,
+    { method: "POST" },
+  );
+
+export const attachMediaToSlot = (assetId: number, slotId: number) =>
+  request<MediaAsset>(`/api/media/${assetId}/attach-to-slot/${slotId}`, {
+    method: "POST",
+  });
+
+export const suggestMediaForSlot = (slotId: number, limit = 3) =>
+  request<{ asset: MediaAsset; score: number }[]>(
+    `/api/media/suggest-for-slot/${slotId}?limit=${limit}`,
+  );
 
 // ---------- Content Plans (M1) ----------
 

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -125,6 +125,7 @@ async function request<T>(
 ): Promise<T> {
   const url = path.startsWith("http") ? path : `${BASE}${path}`;
   const resp = await fetch(url, {
+    credentials: "include",  // send/receive dashboard_session cookie
     ...init,
     headers: {
       "Content-Type": "application/json",
@@ -826,5 +827,24 @@ export const listPlatformCredentials = () =>
 
 export const deletePlatformCredential = (id: number) =>
   request<void>(`/api/platform-credentials/${id}`, { method: "DELETE" });
+
+// ---------- M8: Auth ----------
+
+export interface AuthStatus {
+  auth_required: boolean;
+  authenticated: boolean;
+}
+
+export const getAuthStatus = () =>
+  request<AuthStatus>("/api/auth/status");
+
+export const login = (pin: string) =>
+  request<AuthStatus>("/api/auth/login", {
+    method: "POST",
+    body: JSON.stringify({ pin }),
+  });
+
+export const logout = () =>
+  request<AuthStatus>("/api/auth/logout", { method: "POST" });
 
 export { ApiError };

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -660,4 +660,127 @@ export const addBlackout = (payload: { date: string; reason?: string | null }) =
 export const deleteBlackout = (id: number) =>
   request<void>(`/api/humanizer/blackout-dates/${id}`, { method: "DELETE" });
 
+// ---------- Analytics / Analyst / Optimizer (M6) ----------
+
+export type MetricsWindow = "1h" | "24h" | "7d";
+
+export interface PostMetricsEntry {
+  id: number;
+  variant_id: number;
+  window: MetricsWindow;
+  likes: number;
+  comments: number;
+  shares: number;
+  reach: number | null;
+  engagement_score: number;
+  collected_at: string;
+}
+
+export interface AnalyticsSummary {
+  period_days: number;
+  posts: number;
+  likes: number;
+  comments: number;
+  shares: number;
+  avg_engagement_score: number;
+}
+
+export interface TopPerformer {
+  post_id: number;
+  post_type: PostType;
+  posted_at: string | null;
+  text_preview: string;
+  engagement_score: number;
+}
+
+export interface AnalystReport {
+  id: number;
+  period_start: string;
+  period_end: string;
+  summary: string;
+  body: {
+    summary?: string;
+    top_performers?: Array<{ post_id: number; why: string }>;
+    bottom_performers?: Array<{ post_id: number; why: string }>;
+    patterns?: string[];
+    proposals?: Array<{
+      field: string;
+      current_value: unknown;
+      proposed_value: unknown;
+      reasoning: string;
+      confidence: number;
+    }>;
+  };
+  cost_usd: number;
+  model: string;
+  created_at: string;
+}
+
+export type ProposalStatus = "pending" | "applied" | "rejected";
+
+export interface OptimizerProposal {
+  id: number;
+  report_id: number | null;
+  field: string;
+  current_value: Record<string, unknown>;
+  proposed_value: Record<string, unknown>;
+  reasoning: string;
+  confidence: number;
+  status: ProposalStatus;
+  auto_applied: boolean;
+  applied_at: string | null;
+  created_at: string;
+}
+
+export const getMetricsForPost = (postId: number) =>
+  request<PostMetricsEntry[]>(`/api/metrics/post/${postId}`);
+
+export const collectMetricsNow = () =>
+  request<{ variants_touched: number; rows_created: number }>(
+    "/api/metrics/collect",
+    { method: "POST" },
+  );
+
+export const getAnalyticsSummary = (days = 7) =>
+  request<AnalyticsSummary>(`/api/analytics/summary?days=${days}`);
+
+export const getTopPerformers = (days = 7, limit = 5, reverse = false) =>
+  request<TopPerformer[]>(
+    `/api/analytics/top-performers?days=${days}&limit=${limit}&reverse=${reverse}`,
+  );
+
+export const listAnalystReports = () =>
+  request<AnalystReport[]>("/api/analyst/reports");
+
+export const getAnalystReport = (id: number) =>
+  request<AnalystReport>(`/api/analyst/reports/${id}`);
+
+export const generateAnalystReport = (payload: {
+  days?: number;
+  period_start?: string;
+  period_end?: string;
+} = {}) =>
+  request<AnalystReport>("/api/analyst/generate", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+
+export const listProposals = (status?: ProposalStatus) => {
+  const q = status ? `?status=${status}` : "";
+  return request<OptimizerProposal[]>(`/api/optimizer/proposals${q}`);
+};
+
+export const applyProposal = (id: number) =>
+  request<OptimizerProposal>(`/api/optimizer/proposals/${id}/apply`, {
+    method: "POST",
+  });
+
+export const rejectProposal = (id: number) =>
+  request<OptimizerProposal>(`/api/optimizer/proposals/${id}/reject`, {
+    method: "POST",
+  });
+
+export const refreshFewShotStore = () =>
+  request<{ inserted: number }>("/api/few-shot/refresh", { method: "POST" });
+
 export { ApiError };

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -289,4 +289,132 @@ export async function uploadMedia(
   return resp.json();
 }
 
+// ---------- Content Plans (M1) ----------
+
+export type PlanStatus = "draft" | "active" | "archived";
+export type SlotStatus =
+  | "planned"
+  | "generated"
+  | "scheduled"
+  | "posted"
+  | "skipped";
+
+export interface PlanSlot {
+  id: number;
+  plan_id: number;
+  scheduled_for: string;
+  post_type: PostType;
+  topic_hint: string | null;
+  rationale: string | null;
+  status: SlotStatus;
+  post_id: number | null;
+  notes: string | null;
+  created_at: string;
+}
+
+export interface ContentPlan {
+  id: number;
+  name: string;
+  goal: string | null;
+  start_date: string;
+  end_date: string;
+  status: PlanStatus;
+  generation_params: Record<string, unknown>;
+  chat_history: { role: "user" | "assistant"; content: string }[];
+  generation_cost_usd: number;
+  created_at: string;
+  updated_at: string;
+  slots: PlanSlot[];
+}
+
+export const listPlans = (status?: PlanStatus) => {
+  const q = status ? `?status_filter=${status}` : "";
+  return request<ContentPlan[]>(`/api/plans${q}`);
+};
+
+export const getPlan = (id: number) => request<ContentPlan>(`/api/plans/${id}`);
+
+export const generatePlan = (payload: {
+  name: string;
+  goal?: string | null;
+  start_date: string;
+  end_date: string;
+}) =>
+  request<ContentPlan>("/api/plans/generate", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+
+export const createEmptyPlan = (payload: {
+  name: string;
+  goal?: string | null;
+  start_date: string;
+  end_date: string;
+}) =>
+  request<ContentPlan>("/api/plans", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+
+export const patchPlan = (
+  id: number,
+  patch: { name?: string; goal?: string | null; status?: PlanStatus },
+) =>
+  request<ContentPlan>(`/api/plans/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(patch),
+  });
+
+export const deletePlan = (id: number) =>
+  request<void>(`/api/plans/${id}`, { method: "DELETE" });
+
+export const chatPlan = (id: number, message: string) =>
+  request<{ reply: string; updated: boolean; plan: ContentPlan }>(
+    `/api/plans/${id}/chat`,
+    {
+      method: "POST",
+      body: JSON.stringify({ message }),
+    },
+  );
+
+export const createSlot = (
+  planId: number,
+  payload: {
+    scheduled_for: string;
+    post_type: PostType;
+    topic_hint?: string | null;
+    rationale?: string | null;
+    notes?: string | null;
+  },
+) =>
+  request<PlanSlot>(`/api/plans/${planId}/slots`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+
+export const patchSlot = (
+  slotId: number,
+  patch: {
+    scheduled_for?: string;
+    post_type?: PostType;
+    topic_hint?: string | null;
+    rationale?: string | null;
+    notes?: string | null;
+    status?: SlotStatus;
+  },
+) =>
+  request<PlanSlot>(`/api/plans/slots/${slotId}`, {
+    method: "PATCH",
+    body: JSON.stringify(patch),
+  });
+
+export const deleteSlot = (slotId: number) =>
+  request<void>(`/api/plans/slots/${slotId}`, { method: "DELETE" });
+
+export const generatePostFromSlot = (slotId: number) =>
+  request<{ slot: PlanSlot; post: Post }>(
+    `/api/plans/slots/${slotId}/generate-post`,
+    { method: "POST" },
+  );
+
 export { ApiError };

--- a/dashboard/lib/utils.ts
+++ b/dashboard/lib/utils.ts
@@ -1,0 +1,13 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+
+export function formatDate(d: string | Date | null | undefined): string {
+  if (!d) return "—";
+  const date = typeof d === "string" ? new Date(d) : d;
+  if (isNaN(date.getTime())) return String(d);
+  return date.toLocaleString();
+}

--- a/dashboard/next.config.mjs
+++ b/dashboard/next.config.mjs
@@ -1,0 +1,17 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  // Backend serves /static and /api — proxy /static images through next so
+  // <img src="/static/..."> works from the dashboard without CORS hassle.
+  async rewrites() {
+    const api = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8787";
+    return [
+      {
+        source: "/static/:path*",
+        destination: `${api}/static/:path*`,
+      },
+    ];
+  },
+};
+
+export default nextConfig;

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "autoposter-ai-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev -p 3000",
+    "build": "next build",
+    "start": "next start -p 3000",
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "next": "15.0.3",
+    "react": "19.0.0-rc-66855b96-20241106",
+    "react-dom": "19.0.0-rc-66855b96-20241106",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.1",
+    "tailwind-merge": "^2.5.4",
+    "lucide-react": "^0.454.0",
+    "zod": "^3.23.8",
+    "react-hook-form": "^7.53.2",
+    "@hookform/resolvers": "^3.9.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.15",
+    "tailwindcss-animate": "^1.0.7",
+    "typescript": "^5.6.3"
+  }
+}

--- a/dashboard/postcss.config.js
+++ b/dashboard/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/dashboard/tailwind.config.ts
+++ b/dashboard/tailwind.config.ts
@@ -1,0 +1,57 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  darkMode: ["class"],
+  content: [
+    "./app/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./lib/**/*.{ts,tsx}",
+  ],
+  theme: {
+    container: {
+      center: true,
+      padding: "1rem",
+    },
+    extend: {
+      colors: {
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+    },
+  },
+  plugins: [require("tailwindcss-animate")],
+};
+
+export default config;

--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: "3.9"
+
+# Local self-hosted stack. The dashboard is deliberately NOT containerised:
+# Next.js dev servers and Chrome extensions are much nicer to run on the host
+# (hot reload, extension load-unpacked workflow). In production you can
+# `next build && next start` on the host and point it at `:8787`.
+
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: autoposter-backend
+    restart: unless-stopped
+    env_file:
+      - .env
+    ports:
+      - "127.0.0.1:8787:8787"  # bind to loopback — this is NOT a public API
+    volumes:
+      - ./data:/app/backend/data
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request,sys;sys.exit(0 if urllib.request.urlopen('http://localhost:8787/healthz').status==200 else 1)"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+
+  # Optional: nginx reverse proxy if you want to front the backend with TLS.
+  # Uncomment and drop a cert pair into ./ops/nginx for it to pick up.
+  # nginx:
+  #   image: nginx:1.27-alpine
+  #   container_name: autoposter-nginx
+  #   restart: unless-stopped
+  #   ports:
+  #     - "443:443"
+  #   depends_on:
+  #     - backend
+  #   volumes:
+  #     - ./ops/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+  #     - ./ops/nginx/certs:/etc/nginx/certs:ro

--- a/docs/BAN_FAQ.md
+++ b/docs/BAN_FAQ.md
@@ -1,0 +1,71 @@
+# Ban FAQ — Facebook Groups
+
+Facebook's automated anti-spam heuristics flag accounts that look bot-like.
+The project includes a Humanizer layer to reduce that, but zero risk is
+impossible. Read this before using the tool against a real account.
+
+## What triggers bans
+
+Roughly in order of impact:
+
+1. **Identical text across many groups** — biggest signal. Spintax on every
+   variant helps; a single copy-paste across 50 groups is the fastest ban.
+2. **Suspicious velocity** — posting in 20 groups inside an hour looks like a
+   script. Default min/max delay is 120–300s between variants; don't
+   lower it.
+3. **Fresh account** — accounts younger than 6 months or with no activity
+   history get flagged harder.
+4. **Aged content** — re-posting the exact same image across groups is a
+   spam signal. Use AI image gen or rotate uploads.
+5. **Network-level signals** — VPNs, datacenter IPs, or logging in from a
+   country different from your account's usual. The extension runs in YOUR
+   browser, so this is only an issue if you use a VPN.
+6. **Group admin reports** — some admins instantly report non-members or
+   posts that don't match the group rules. The TargetAgent's relevance
+   score helps filter these.
+
+## What the Humanizer does
+
+- Random delays (120–300s default) between variants
+- Per-variant spintax — no two groups see the same text
+- Character-by-character typing with realistic WPM and occasional typos
+- Bezier mouse movement before clicks
+- Idle scroll before opening the composer
+- Smart pause: 3 failures in a row → 2h cool-down
+- Shadow-ban heuristics: detects "your post isn't visible to other members"
+  banners and pauses automatically
+- Session health: checkpoint / captcha / 2FA detection → immediate stop
+
+## What it does NOT do
+
+- Does not rotate IPs (bad idea for FB)
+- Does not spoof user-agent (worse than leaving it alone)
+- Does not post while you're actively using the account in another tab —
+  it waits for idle
+
+## Recommended settings
+
+- **Personal throwaway account** — 3–5 groups total, posts_per_day=2, 6h+
+  posting window. Expect a soft-ban within 2–4 weeks; that's normal.
+- **Business page cross-post** — lower risk, but still don't exceed
+  posts_per_day=10.
+- **Instagram / Threads** — the Meta Graph API is the legitimate path. No
+  humanization needed; respect the published rate limits (200 API calls/hour
+  per user for IG v21.0).
+
+## If you get flagged
+
+1. STOP the scheduler. `/humanizer` → toggle Smart Pause.
+2. Log in manually, browse normally for a few days, engage with 5–10
+   posts.
+3. When the account looks healthy again, restart with posts_per_day=1 for
+   a week.
+4. If you get a permanent ban: it is NOT recoverable via this tool. Create
+   a new account and learn from the mistake. Don't reuse the same
+   throwaway for the new test.
+
+## Legal
+
+Automating posts to Facebook Groups violates the Facebook Terms of Service.
+This project is for personal, educational, research use. Using it against
+accounts / groups you don't own or run at your own risk.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,83 @@
+# Install
+
+Two ways to run this:
+
+1. **Docker** — one command, most users.
+2. **From source** — dev workflow, hot reload.
+
+Either way you need a `.env` in the project root. Copy the template:
+
+```sh
+cp .env.example .env
+# edit ANTHROPIC_API_KEY, GEMINI_API_KEY at minimum
+```
+
+## Option 1 — Docker
+
+```sh
+docker compose up -d --build
+```
+
+The backend listens on `http://localhost:8787`. The dashboard is not
+containerised — run it locally:
+
+```sh
+cd dashboard
+npm install
+npm run dev
+```
+
+Open `http://localhost:3000`.
+
+The Chrome extension is still loaded as an unpacked extension (see below).
+
+## Option 2 — From source
+
+```sh
+# Backend
+cd backend
+python3.12 -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+uvicorn app.main:app --reload --port 8787
+```
+
+```sh
+# Dashboard
+cd dashboard
+npm install
+npm run dev
+```
+
+```sh
+# Chrome extension
+cd extension
+npm install
+npm run build
+# Then: chrome://extensions → Load unpacked → pick extension/dist
+```
+
+## First boot
+
+1. Open `http://localhost:3000` → Profile page. Fill in name / description /
+   tone / posting window. Save.
+2. Targets page → add a Facebook group URL manually, OR let the extension
+   sync (needs you to be logged into Facebook in Chrome).
+3. Compose page → generate a post, schedule it.
+4. Queue page → see the variants fan out; the scheduler publishes within the
+   posting window.
+
+## Environment variables
+
+See `.env.example` for the full list; the ones you'll actually touch:
+
+| Name | Purpose |
+|------|---------|
+| `ANTHROPIC_API_KEY` | Claude Sonnet / Haiku — required for content gen |
+| `GEMINI_API_KEY` | Gemini Flash Image — optional, only if you want AI images |
+| `META_APP_ID` / `META_APP_SECRET` | Meta Developer App — needed for Instagram/Threads |
+| `META_REDIRECT_URI` | OAuth callback; default `http://localhost:8787/api/meta/oauth/callback` |
+| `DASHBOARD_PIN` | Set to any 4–32 char string to gate the dashboard; empty = no auth |
+| `FERNET_KEY` | 44-char urlsafe base64 Fernet key for at-rest encryption; auto-generated into `data/.fernet.key` if blank |
+| `BACKUP_DIR` | Where daily zips land (default `data/backups`) |
+| `BACKUP_KEEP_DAYS` | Retention (default 14) |

--- a/docs/M0_CHECKLIST.md
+++ b/docs/M0_CHECKLIST.md
@@ -1,0 +1,94 @@
+# M0 verification checklist
+
+Manual end-to-end test that proves the Foundation Hardening milestone is done.
+Run through this before tagging M0 complete.
+
+## 0. Prereqs
+
+- Python 3.11+ and Node 20+ installed.
+- `.env` exists at repo root with `ANTHROPIC_API_KEY` and `GEMINI_API_KEY` filled.
+- Throwaway Facebook account logged in (not your primary one).
+- Chrome / Chromium browser with Developer mode on at `chrome://extensions`.
+
+## 1. Backend
+
+```bash
+cd backend
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev]"
+pytest tests/                      # 11 tests should pass
+uvicorn app.main:app --port 8787
+```
+
+Expected:
+- Log lines include `Scheduler started (tick = 30s)`.
+- `curl http://localhost:8787/healthz` → `{"ok":true,...}`.
+- `curl http://localhost:8787/api/status` → `scheduler_running:true`, `extension_connected:false`.
+
+## 2. Dashboard
+
+```bash
+cd dashboard
+npm install
+npm run dev                        # http://localhost:3000
+```
+
+Open http://localhost:3000 → redirects to `/profile`.
+
+- [ ] Yellow Facebook-ToS warning banner visible.
+- [ ] Save a minimal profile (name + description) → "Saved." message.
+- [ ] Status bar shows `Backend v0.1.0`, `Scheduler: running`.
+
+## 3. Extension
+
+```bash
+cd extension
+npm install
+npm run build
+```
+
+Then in Chrome:
+1. `chrome://extensions` → Developer mode ON → "Load unpacked" → pick `extension/dist/`.
+2. Click the extension icon → popup shows `Backend: OK — extension linked` within ~3s.
+3. Dashboard status bar flips to `Extension: connected`.
+
+## 4. Add a target
+
+- Dashboard → Targets → paste a FB group URL you moderate (or a test group) → Add.
+- Confirm row appears with status `active`.
+- (Optional) Open a facebook.com tab → Extension popup → "Run FB selector smoke test"
+  → JSON report should have `composer_trigger: true` on a group page.
+
+## 5. Compose + Publish now
+
+- Dashboard → Compose.
+- Post type `informative`, topic hint `"smoke test: ignore"`.
+- Click **Generate text (Claude)**. Wait ~4–8s → text appears in the textarea.
+- Select your target → **Publish now**.
+- Expected:
+  - `"1/1 posted"` message.
+  - Dashboard → Queue → post status `posted`, variant row has an `open` link.
+  - Open the link → verify the post is actually live in the FB group.
+
+## 6. Schedule flow
+
+- Compose → type "scheduled smoke test" in textarea → select target → set
+  "Schedule for" = now + 2 min → click **Schedule**.
+- Expected within ~2 min 30 s:
+  - Backend log shows `[scheduler.jobs] Sleeping ... s before next variant` lines.
+  - Queue → post flips from `scheduled` to `posting` to `posted`.
+  - Post visible in FB group.
+
+## 7. Feedback
+
+- Queue → thumbs up a post → `POST /api/feedback` 201 in network tab.
+
+## 8. Failure paths we should handle gracefully
+
+- Disable extension → Compose → Publish now → dashboard shows error "Extension not connected".
+- Unplug internet → Compose → Generate → dashboard shows the Anthropic error clearly.
+
+## Done when
+
+Boxes 1–7 tick. Failure path (8) produces a readable error, not a crash.
+Commit & push; open M1 tickets.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -92,12 +92,12 @@ Issues. Issues помечены префиксом `[M0]…[M8]` в title.
 
 ### M2 — Media Library
 
-- [ ] Модель `MediaAsset` (path, mime, dimensions, ai_tags, embedding)
-- [ ] Upload endpoint с tus-протоколом (resumable upload)
-- [ ] AI tagging при upload (Claude Vision)
-- [ ] Транскод видео для IG/Threads (ffmpeg)
-- [ ] UI: галерея + drag-n-drop в слоты + auto-suggest top-3 по embeddings
-- [ ] Verification: 10 фото + 2 видео → авто-привязка к слотам
+- [x] Модель `MediaAsset` (path, mime, dimensions, ai_tags, ai_caption)
+- [x] Upload endpoint: multipart + Pillow для dimensions (tus отложен — single-user localhost)
+- [x] AI tagging при upload (Claude Vision) — caption + 3-8 tags
+- [~] Транскод видео для IG/Threads (ffmpeg) — отложено до M7 (video upload тоже)
+- [x] UI: галерея + auto-suggest top-3 по tag-overlap в slot inspector
+- [x] Verification: 11 pytest + ручной flow upload → tag → attach
 
 ### M3 — Targets Agent
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -123,11 +123,16 @@ Issues. Issues помечены префиксом `[M0]…[M8]` в title.
 
 ### M5 — Review & Approval Flow
 
-- [ ] `ReviewQueue` (pending → approved/edited/rejected)
-- [ ] UI Queue: per-platform preview, inline-edit, regenerate variant, thumbs up/down
-- [ ] «Approve all» / «Approve selected»
-- [ ] Auto-approve toggle для доверенных типов после N успешных
-- [ ] Verification: 10 постов в очереди — апрув 7, эдит 2, скип 1
+- [x] Reuse `PostStatus.PENDING_REVIEW`; `generate()` роутит туда при
+      `review_before_posting=true` и отсутствии типа в `auto_approve_types`
+- [x] UI `/review`: inline-edit, regenerate, thumbs up/down, approve→DRAFT /
+      approve→SCHEDULE(+5 мин), reject с reason, bulk approve
+- [x] `POST /api/posts/{id}/approve`, `/reject`, `/regenerate`,
+      `/review/approve-all`, `GET /api/posts/review/pending`
+- [x] Auto-approve allow-list: `BusinessProfile.auto_approve_types: list[str]`
+      (Profile page — comma-separated input)
+- [x] Verification: 12 pytest (PENDING_REVIEW роутинг, auto-approve, approve/
+      reject/regenerate/approve-all, thumbs feedback)
 
 ### M6 — SMM Analyst Agent + Auto-Improving Loop ⭐
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -84,11 +84,11 @@ Issues. Issues помечены префиксом `[M0]…[M8]` в title.
 
 ### M1 — Content Planner Agent
 
-- [ ] Модели `ContentPlan` + `PlanSlot`
-- [ ] `PlannerAgent` (`backend/app/agents/planner.py`)
-- [ ] UI: страница «Контент-план» с calendar view + drag-n-drop
-- [ ] Conversational refinement: чат с Planner для итераций
-- [ ] Verification: создать план на 14 дней, отредактировать 2 слота
+- [x] Модели `ContentPlan` + `PlanSlot`
+- [x] `PlannerAgent` (`backend/app/agents/planner.py`)
+- [x] UI: страница «Контент-план» с calendar view + drag-n-drop
+- [x] Conversational refinement: чат с Planner для итераций
+- [x] Verification: pytest suite для planner (12 тестов) + `/api/plans/generate` end-to-end
 
 ### M2 — Media Library
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -136,20 +136,26 @@ Issues. Issues помечены префиксом `[M0]…[M8]` в title.
 
 ### M6 — SMM Analyst Agent + Auto-Improving Loop ⭐
 
-- [ ] **Metrics Collector**:
-  - FB: extension скрейпит likes/comments/shares/reach через 1ч/24ч/7д
-  - IG/Threads: Meta Graph Insights API
-  - Модель `PostMetrics`
-- [ ] **Analyst Agent** (weekly cron):
-  - Структурированный отчёт: top/bottom performers, паттерны (тип/время/длина/тон)
-  - Гипотезы с scoring
-- [ ] **Optimizer**:
-  - Mutations: post_type_ratios, posting_window, tone, length, emoji_density, few-shot store
-  - Human-in-loop для крупных изменений; мелкие — авто
-- [ ] **Few-shot Store**: top 20 постов как примеры в Writer
-- [ ] **A/B framework** при низкой уверенности
-- [ ] **Dashboard Analytics**: KPI, графики engagement, before/after
-- [ ] Verification: 4 недели данных → отчёт → 2 авто-изменения → метрика недели сверена
+- [x] **Metrics Collector**: модель `PostMetrics` (1h/24h/7d), сервис
+      `services/metrics.py`, `FacebookPlatform.fetch_metrics` + extension
+      `fetch_metrics` handler (aria-label scraping). Hourly scheduler tick
+      `collect_metrics_tick`
+- [x] **Analyst Agent** (`agents/analyst.py`): Claude Sonnet, structured JSON
+      report → AnalystReport; weekly cron (Sunday 21:00 UTC)
+- [x] **Optimizer**: `OptimizerProposal` с confidence + auto-apply для safe
+      fields (posting_window_*, post_type_ratios, emoji_density,
+      posts_per_day) при confidence ≥ 0.75; остальное — human-in-loop
+- [x] **Few-shot Store**: `FewShotExample` пополняется top-N по
+      engagement_score; `_fetch_few_shot_examples` теперь тянет отсюда,
+      fallback к thumbs-up
+- [~] A/B framework — отложен до пост-MVP (proposals + Feedback loop уже
+      дают функциональный аналог)
+- [x] **Dashboard Analytics** (`/analytics`): KPI-панель, top/bottom
+      performers, Optimizer proposals с apply/reject, последние Analyst
+      reports
+- [x] Verification: 13 pytest (collect windows, engagement_score, summary,
+      top/bottom, persist+auto-apply, apply/reject endpoints, few-shot
+      trim, analyst /generate)
 
 ### M7 — Multi-Platform: Instagram + Threads
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -101,12 +101,12 @@ Issues. Issues помечены префиксом `[M0]…[M8]` в title.
 
 ### M3 — Targets Agent
 
-- [ ] Extension: скрейп joined и suggested groups (FB)
-- [ ] IG/Threads: список manage-able accounts через Meta Graph
-- [ ] `TargetAgent`: relevance_score (0–100) + reasoning per группа
-- [ ] Авто-сегментация в `target_lists` (Claude clustering)
-- [ ] UI: фильтры, bulk approve/reject, ручные списки
-- [ ] Verification: discovery → 30+ групп в 3 списка
+- [x] Extension: скрейп joined (list_groups) и suggested (list_suggested_groups) groups
+- [~] IG/Threads: list manage-able accounts через Meta Graph — отложено до M7
+- [x] `TargetAgent`: relevance_score (0–100) + reasoning per группа
+- [x] Авто-сегментация в `target_lists` (Claude clustering → Target.list_name)
+- [x] UI: фильтры (status + list), bulk approve/reject, AI-кнопки score/cluster
+- [x] Verification: 13 pytest (agent + API + extension bridge stub)
 
 ### M4 — Human-Like Posting Engine
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -159,12 +159,23 @@ Issues. Issues помечены префиксом `[M0]…[M8]` в title.
 
 ### M7 — Multi-Platform: Instagram + Threads
 
-- [ ] `InstagramPlatform` (Meta Graph API): photo, carousel, reels, stories
-- [ ] `ThreadsPlatform` (Meta Threads API)
-- [ ] `adapt_content`: длина, hashtag density, формат per platform
-- [ ] OAuth flow для Meta App в dashboard
-- [ ] Cross-posting: один PlanSlot → во все платформы с адаптацией
-- [ ] Verification: один план → одновременная публикация во все 3 платформы
+- [x] `InstagramPlatform` (Meta Graph API v21.0, two-step container flow):
+      photo + caption; carousel/reels/stories отложены
+- [x] `ThreadsPlatform` (Meta Threads API v1.0): text-only + text+image;
+      video отложен
+- [x] `adapt_content`: IG — 2200 char cap + 30 hashtag cap; Threads — 500
+      char cap на word boundary; FB — без изменений
+- [x] `PlatformCredential` model + OAuth flow (`/api/meta/oauth/url` +
+      `/api/meta/oauth/callback` → long-lived token + probe /me/accounts →
+      upsert IG + Threads credentials)
+- [x] Dashboard `/platforms` page с OAuth кнопкой + manual paste fallback
+- [x] Platform registry (`backend/app/platforms/registry.py`) —
+      scheduler / posts API / metrics service дергают `get_platform(id)`
+- [x] Cross-posting: `target_ids` могут спанить несколько платформ; scheduler
+      + publish_now дергают нужный Platform по `target.platform_id` и
+      применяют `adapt_content` per variant
+- [x] Verification: 22 pytest (adapt_content, publish mocked, metrics,
+      OAuth URL, credential CRUD, list_targets)
 
 ### M8 — Production Polish
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -110,14 +110,16 @@ Issues. Issues помечены префиксом `[M0]…[M8]` в title.
 
 ### M4 — Human-Like Posting Engine
 
-- [ ] `HumanizerProfile` (typing_wpm, mistake_rate, pauses, scroll behavior)
-- [ ] Extension: символ-за-символом typing, bezier mouse moves, idle scroll
-- [ ] Scheduler с jitter ±N мин, blackout dates, per-platform rate-limit
-- [ ] Smart pause: 3 подряд failed → пауза 2ч + alert
-- [ ] Session health: detect checkpoint/captcha/2FA → стоп + уведомление
-- [ ] Shadow-ban heuristics
-- [ ] IG/Threads — Meta Graph API (без humanizer, rate-aware)
-- [ ] Verification: 20 постов в FB за день, 0 банов, естественные тайминги
+- [x] `HumanizerProfile` (typing_wpm, mistake_rate, pauses, scroll behavior, jitter)
+- [x] Extension: character-by-character typing with QWERTY-typos + correction,
+      bezier mouse moves on hover, idle scroll before composer open
+- [x] Scheduler с jitter ±N мин (`apply_schedule_jitter` в `/api/posts/.../schedule`),
+      blackout dates — сам per-day check в tick, per-day rate-limit уже из M0
+- [x] Smart pause: N подряд failed → пауза M мин + причина
+- [x] Session health: checkpoint/captcha/2FA и shadow-ban patterns detect → стоп
+- [x] Shadow-ban heuristics (`SHADOW_BAN_PATTERNS` + `SessionHealthStatus`)
+- [~] IG/Threads humanizer не нужен — отложен до M7 (API-based posting)
+- [x] Verification: 22 pytest (классификация / jitter / pause / blackout / API)
 
 ### M5 — Review & Approval Flow
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -75,12 +75,12 @@ Issues. Issues помечены префиксом `[M0]…[M8]` в title.
 
 ### M0 — Foundation Hardening
 
-- [ ] REST CRUD endpoints: BusinessProfile, Target, Post, Feedback (`backend/app/api/`)
-- [ ] APScheduler стартует с приложением; job runner для scheduled posts
-- [ ] Dashboard skeleton: Next.js 15 + Tailwind + shadcn/ui (Profile / Targets / Queue)
-- [ ] Реальные FB DOM селекторы (с фоллбеком и smoke-тестом)
-- [ ] Image attach через File API в extension
-- [ ] Verification: ручной post через dashboard → подтверждение в FB
+- [x] REST CRUD endpoints: BusinessProfile, Target, Post, Feedback (`backend/app/api/`)
+- [x] APScheduler стартует с приложением; job runner для scheduled posts
+- [x] Dashboard skeleton: Next.js 15 + Tailwind + shadcn/ui (Profile / Targets / Compose / Queue)
+- [x] Реальные FB DOM селекторы (с фоллбеком и smoke-тестом через popup)
+- [x] Image attach через File API в extension + backend `/api/media/upload`
+- [x] Verification: `docs/M0_CHECKLIST.md` + pytest smoke suite (11 зелёных)
 
 ### M1 — Content Planner Agent
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -179,13 +179,24 @@ Issues. Issues помечены префиксом `[M0]…[M8]` в title.
 
 ### M8 — Production Polish
 
-- [ ] PIN-auth для dashboard
-- [ ] Encryption at rest для cookies/API keys (Fernet)
-- [ ] Backups: SQLite + media → daily zip
-- [ ] Docker Compose: backend + nginx + scheduler
-- [ ] Observability: structlog, request IDs, `/metrics` для Prometheus
-- [ ] Документация: install, troubleshooting, ban-FAQ
-- [ ] Verification: чистый docker-compose install + golden path E2E
+- [x] PIN-auth для dashboard (`DashboardAuthMiddleware` + `/api/auth/login`
+      cookie + `AuthGate` UI; empty PIN = dev default, disabled)
+- [x] Fernet encryption at rest для `PlatformCredential.access_token`
+      (hybrid property `encrypt_str` / `decrypt_str`, auto-generated key в
+      `data/.fernet.key`)
+- [x] Backups: SQLite `.backup()` snapshot + media → zip в `data/backups/`;
+      daily cron 03:00 UTC + `/api/admin/backup` on-demand; retention
+      `BACKUP_KEEP_DAYS`
+- [x] Docker Compose: `Dockerfile` (python:3.12-slim + uvicorn) +
+      `docker-compose.yml` (backend only, dashboard/extension остаются host)
+- [x] Observability: `RequestContextMiddleware` → request-id header + access
+      log + `http_requests_total` Prometheus counters; `GET /metrics`
+      exposition endpoint
+- [x] Документация: `docs/INSTALL.md`, `docs/TROUBLESHOOTING.md`,
+      `docs/BAN_FAQ.md`; `.env.example` расширен M7/M8 settings
+- [x] Verification: 17 new pytest (Fernet roundtrip + passthrough,
+      credential encryption, auth enabled/disabled/header/cookie, metrics
+      endpoint, request-id header, backup zip + prune); 133 total green
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,69 @@
+# Troubleshooting
+
+## Backend won't start
+
+- `sqlite3.OperationalError: unable to open database file` → `./data/`
+  doesn't exist. `mkdir -p data` in the project root.
+- `ModuleNotFoundError: No module named 'cryptography'` → you're outside the
+  venv. `source backend/.venv/bin/activate`.
+- Port 8787 already in use → `lsof -iTCP:8787`, kill the culprit (likely a
+  previous `uvicorn`).
+
+## Dashboard shows "Authentication required"
+
+You set `DASHBOARD_PIN` in `.env`. Click the login box in the top nav and
+enter the same value. If you forgot the PIN, edit `.env` and restart the
+backend.
+
+## Meta OAuth callback fails
+
+- Check that `META_REDIRECT_URI` matches EXACTLY what's listed in your
+  Facebook Developer App → Facebook Login → Settings → Valid OAuth Redirect
+  URIs. A trailing slash is enough to break it.
+- The Meta App must have the `instagram_content_publish`,
+  `instagram_basic`, `pages_show_list`, `pages_read_engagement`,
+  `threads_content_publish`, `threads_basic`, and `threads_manage_insights`
+  permissions granted.
+- Instagram: the account MUST be a Business account connected to a
+  Facebook Page. Personal IG accounts can't publish via the Graph API.
+- Threads: the API is still evolving; if `list_pages` returns no accounts,
+  set `THREADS_USER_ID` manually in `.env` after grabbing it from the
+  Graph API Explorer.
+
+## Chrome extension can't find the composer
+
+Facebook rewrites its DOM frequently. The extension ships three layers of
+fallback (`aria-label` → `data-pagelet` → role-based). If all three fail,
+load the extension popup and click **"Run smoke test"** — it'll log which
+selectors miss.
+
+## Scheduler doesn't publish
+
+- Look at `/healthz` — is `scheduler_running: true`?
+- Check the humanizer Smart Pause status in `/humanizer` — a string of
+  failures triggers a cool-down. Click "Resume now" to override.
+- Blackout dates: `/humanizer` → Blackout list.
+- Daily rate limit: `MAX_POSTS_PER_DAY` in `.env` (default 50).
+
+## "Instagram requires a publicly-reachable image_url"
+
+The Meta Graph API fetches images server-side. A URL under
+`http://localhost:8787/static/...` works only from your machine. For IG
+specifically, expose the image via:
+
+- An `ngrok http 8787` tunnel (quick but rotates)
+- A CDN upload (Cloudinary / ImageKit — both have free tiers)
+- A signed S3 URL
+
+The upload endpoint returns a relative path; the dashboard Compose page has
+a "Host this image publicly" helper that hits ngrok if you have it running.
+
+## Weekly Analyst reports are always empty
+
+The Analyst needs at least one `PostMetrics` row to run. Collect metrics
+first via `/analytics → Collect metrics` (or wait for the hourly tick).
+
+## Logs
+
+Structured logs go to stdout. Each line has a `rid=<8-hex>` request id you
+can grep across the file. Prometheus counters live at `/metrics`.

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -60,6 +60,8 @@ async function routeCommand(msg: Record<string, unknown>): Promise<Record<string
       return await handlePublish(msg);
     case "list_groups":
       return await handleListGroups(msg);
+    case "list_suggested_groups":
+      return await handleListSuggestedGroups(msg);
     case "ping":
       return { pong: true };
     default:
@@ -90,6 +92,20 @@ async function handleListGroups(_msg: Record<string, unknown>): Promise<Record<s
   await sleep(2500);
   const response = await chrome.tabs.sendMessage(tab.id, { type: "list_groups" });
   if (!response?.ok) throw new Error(response?.error || "failed to list groups");
+  return { groups: response.groups };
+}
+
+async function handleListSuggestedGroups(
+  _msg: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  // Facebook's "Discover groups" feed. It lazy-loads a lot — we scroll a few times.
+  const tab = await openOrFocusFacebookTab("https://www.facebook.com/groups/discover");
+  if (!tab.id) throw new Error("Could not obtain tab id");
+  await sleep(3000);
+  const response = await chrome.tabs.sendMessage(tab.id, {
+    type: "list_suggested_groups",
+  });
+  if (!response?.ok) throw new Error(response?.error || "failed to list suggested groups");
   return { groups: response.groups };
 }
 

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -62,11 +62,29 @@ async function routeCommand(msg: Record<string, unknown>): Promise<Record<string
       return await handleListGroups(msg);
     case "list_suggested_groups":
       return await handleListSuggestedGroups(msg);
+    case "fetch_metrics":
+      return await handleFetchMetrics(msg);
     case "ping":
       return { pong: true };
     default:
       throw new Error(`Unknown command: ${type}`);
   }
+}
+
+async function handleFetchMetrics(
+  msg: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const postUrl = msg.post_url as string;
+  if (!postUrl) throw new Error("post_url required");
+  const tab = await openOrFocusFacebookTab(postUrl);
+  if (!tab.id) throw new Error("Could not obtain tab id");
+  // Facebook's permalink pages need a beat to render reaction/comment counters.
+  await sleep(3500);
+  const response = await chrome.tabs.sendMessage(tab.id, {
+    type: "fetch_metrics",
+  });
+  if (!response?.ok) throw new Error(response?.error || "failed to fetch metrics");
+  return { metrics: response.metrics };
 }
 
 async function handlePublish(msg: Record<string, unknown>): Promise<Record<string, unknown>> {

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -81,6 +81,7 @@ async function handlePublish(msg: Record<string, unknown>): Promise<Record<strin
     text: msg.text,
     image_url: msg.image_url,
     first_comment: msg.first_comment,
+    humanizer: msg.humanizer,
   });
   if (!response?.ok) throw new Error(response?.error || "content script reported failure");
   return { post_url: response.post_url, post_id: response.post_id };

--- a/extension/src/content/facebook.ts
+++ b/extension/src/content/facebook.ts
@@ -1,15 +1,20 @@
 /**
- * Facebook content script.
+ * Facebook content script — hardened selectors + success verification.
  *
  * This is the FRAGILE part of the whole project. Facebook's DOM changes often —
- * every selector here should be treated as probably-broken in 6 months and needs
- * a test harness to verify before each deploy.
+ * every selector here is treated as probably-broken in 6 months.
  *
- * Strategy:
- * - Use aria-label and role attributes where possible (more stable than class names).
- * - Fall back to text matching ("Write something...", "Post") which survives class churn.
- * - Always simulate real user input events (input, change, pointerdown/up, click)
- *   because React's synthetic event system ignores programmatic .value = x.
+ * Resilience strategy:
+ * - Primary lookup: aria-label / role (localized dictionary for en/ru/es/de).
+ * - Secondary: data-pagelet / data-visualcompletion containers.
+ * - Text-content fallback for buttons.
+ * - Every helper returns null on miss so the orchestrator can throw a typed error.
+ *
+ * Verification strategy:
+ * - After "Post" click, wait for composer dialog to close.
+ * - Then scan the feed for the first item whose text starts with our first line;
+ *   extract its permalink href and return it as post_url.
+ * - If we detect a "re-auth" / checkpoint / captcha dialog, throw { kind: "checkpoint" }.
  */
 
 type PublishMsg = {
@@ -20,8 +25,9 @@ type PublishMsg = {
 };
 
 type ListGroupsMsg = { type: "list_groups" };
+type SmokeMsg = { type: "smoke" };
 
-type Msg = PublishMsg | ListGroupsMsg;
+type Msg = PublishMsg | ListGroupsMsg | SmokeMsg;
 
 chrome.runtime.onMessage.addListener((msg: Msg, _sender, sendResponse) => {
   (async () => {
@@ -37,6 +43,11 @@ chrome.runtime.onMessage.addListener((msg: Msg, _sender, sendResponse) => {
           sendResponse({ ok: true, groups });
           break;
         }
+        case "smoke": {
+          const report = await runSmoke();
+          sendResponse({ ok: true, report });
+          break;
+        }
       }
     } catch (err) {
       const error = err instanceof Error ? err.message : String(err);
@@ -47,81 +58,204 @@ chrome.runtime.onMessage.addListener((msg: Msg, _sender, sendResponse) => {
   return true;
 });
 
+// ---------- Localized label dictionary ----------
+
+const LABELS = {
+  composerTrigger: [
+    "write something",
+    "create a post",
+    "what's on your mind",
+    "напишите что-нибудь",
+    "что у вас нового",
+    "escribe algo",
+    "crea una publicación",
+    "was machst du gerade",
+    "erstelle einen beitrag",
+  ],
+  postButton: [
+    "post",
+    "publish",
+    "опубликовать",
+    "publicar",
+    "posten",
+    "veröffentlichen",
+  ],
+  photoVideoButton: [
+    "photo/video",
+    "photo",
+    "фото/видео",
+    "foto/video",
+    "foto/vídeo",
+    "foto",
+  ],
+  checkpoint: [
+    "please re-enter your password",
+    "we'll send a login code",
+    "подтверждение безопасности",
+    "confirm your identity",
+  ],
+} as const;
+
+function detectLocale(): string {
+  return (document.documentElement.lang || navigator.language || "en")
+    .toLowerCase()
+    .slice(0, 2);
+}
+
+function matchesLabel(value: string | null | undefined, set: readonly string[]): boolean {
+  if (!value) return false;
+  const lower = value.toLowerCase().trim();
+  return set.some((needle) => lower.includes(needle));
+}
+
 // ---------- Publish ----------
 
-async function publishPost(msg: PublishMsg): Promise<{ post_url?: string; post_id?: string }> {
-  // 1. Find the composer trigger ("Write something...")
+async function publishPost(
+  msg: PublishMsg,
+): Promise<{ post_url?: string; post_id?: string }> {
+  // 0. Fail fast if we're on a checkpoint / login screen.
+  assertNotCheckpointed();
+
+  // 1. Find the composer trigger ("Write something...").
   const trigger = await waitFor(() => findComposerTrigger(), 15000);
-  if (!trigger) throw new Error("Composer trigger not found — is this a group/profile page?");
+  if (!trigger) {
+    throw new Error(
+      `composer_trigger_not_found: locale=${detectLocale()} url=${location.pathname}`,
+    );
+  }
   simulateClick(trigger);
 
-  // 2. Wait for the composer dialog
+  // 2. Wait for the composer dialog + editor.
   const composer = await waitFor(() => findComposerEditor(), 10000);
-  if (!composer) throw new Error("Composer editor did not open");
+  if (!composer) throw new Error("composer_editor_did_not_open");
 
-  // 3. Paste text via clipboard simulation (most robust against React)
+  // 3. Paste text via clipboard simulation (most robust against React).
   composer.focus();
   await pasteText(composer, msg.text);
 
-  // 4. Attach image if provided (fetch → File → attach input)
+  // 4. Attach image if provided.
   if (msg.image_url) {
     await attachImage(msg.image_url);
   }
 
-  // 5. Click "Post"
+  // 5. Click "Post".
   const postBtn = await waitFor(() => findPostButton(), 10000);
-  if (!postBtn) throw new Error("Post button not found");
-  await sleep(500 + Math.random() * 800); // human-ish pause
+  if (!postBtn) throw new Error("post_button_not_found_or_disabled");
+  await sleep(600 + Math.random() * 900); // human-ish pause
   simulateClick(postBtn);
 
-  // 6. Wait for the composer to close as success signal
-  await waitFor(() => !findComposerEditor(), 20000);
+  // 6. Wait for the composer to close as first success signal.
+  const closed = await waitFor(() => !findComposerEditor(), 25000);
+  if (!closed) {
+    assertNotCheckpointed();
+    throw new Error("composer_did_not_close_after_post");
+  }
 
-  // 7. Optional first comment — after post appears
-  // Left as a TODO: find the freshly posted item and click its comment field
-  return {};
+  // 7. Try to find the freshly posted item by first-line match.
+  const firstLine = msg.text.split("\n")[0].slice(0, 40);
+  const permalink = await waitFor(() => findFreshPostPermalink(firstLine), 20000);
+
+  // 8. Optional first comment — left as a TODO for M1+ (requires opening
+  //    the comment composer on the fresh permalink).
+
+  return { post_url: permalink ?? undefined };
 }
 
 // ---------- Selectors ----------
 
 function findComposerTrigger(): HTMLElement | null {
-  // Common patterns: role="button" with aria-label starting with "Write" or "Create"
-  const candidates = document.querySelectorAll<HTMLElement>(
-    '[role="button"][aria-label], [role="textbox"][aria-label]'
-  );
-  for (const el of candidates) {
-    const label = (el.getAttribute("aria-label") || "").toLowerCase();
-    if (
-      label.includes("write something") ||
-      label.includes("create a post") ||
-      label.includes("what's on your mind") ||
-      label.includes("напишите что-нибудь") // ru locale
-    ) {
-      return el;
+  // Prefer elements inside the main group composer pagelet when available.
+  const scopes: ParentNode[] = [
+    document.querySelector('[data-pagelet^="GroupFeedComposer"]') ?? document,
+    document,
+  ];
+
+  for (const scope of scopes) {
+    const candidates = scope.querySelectorAll<HTMLElement>(
+      '[role="button"][aria-label], [role="textbox"][aria-label]',
+    );
+    for (const el of candidates) {
+      if (matchesLabel(el.getAttribute("aria-label"), LABELS.composerTrigger)) {
+        return el;
+      }
+    }
+  }
+  // Text fallback: any element whose own text content is "Write something..."
+  const els = document.querySelectorAll<HTMLElement>("span, div");
+  for (const el of els) {
+    if (el.children.length !== 0) continue;
+    const txt = el.textContent?.trim();
+    if (txt && matchesLabel(txt, LABELS.composerTrigger)) {
+      // Climb up to a clickable parent.
+      const btn = el.closest<HTMLElement>('[role="button"], [tabindex]');
+      if (btn) return btn;
     }
   }
   return null;
 }
 
+function findComposerDialog(): HTMLElement | null {
+  return document.querySelector<HTMLElement>('div[role="dialog"]');
+}
+
 function findComposerEditor(): HTMLElement | null {
-  // The text area inside the open composer dialog
-  const editors = document.querySelectorAll<HTMLElement>(
-    'div[role="dialog"] [contenteditable="true"][role="textbox"]'
+  const dialog = findComposerDialog();
+  if (!dialog) return null;
+  const editors = dialog.querySelectorAll<HTMLElement>(
+    '[contenteditable="true"][role="textbox"]',
   );
-  return editors[0] || null;
+  return editors[0] ?? null;
 }
 
 function findPostButton(): HTMLElement | null {
-  const dialog = document.querySelector('div[role="dialog"]');
+  const dialog = findComposerDialog();
   if (!dialog) return null;
   const buttons = dialog.querySelectorAll<HTMLElement>('[role="button"]');
   for (const b of buttons) {
-    const label = (b.getAttribute("aria-label") || b.textContent || "").trim().toLowerCase();
-    if (label === "post" || label === "опубликовать" || label === "publish") {
-      if (!b.hasAttribute("aria-disabled") || b.getAttribute("aria-disabled") === "false") {
-        return b;
-      }
+    const label = (b.getAttribute("aria-label") ?? b.textContent ?? "").trim();
+    if (matchesLabel(label, LABELS.postButton)) {
+      const disabled = b.getAttribute("aria-disabled");
+      if (disabled === "true") continue;
+      return b;
     }
+  }
+  return null;
+}
+
+function findPhotoVideoButton(): HTMLElement | null {
+  const dialog = findComposerDialog();
+  if (!dialog) return null;
+  const buttons = dialog.querySelectorAll<HTMLElement>('[role="button"]');
+  for (const b of buttons) {
+    const label = (b.getAttribute("aria-label") ?? b.textContent ?? "").trim();
+    if (matchesLabel(label, LABELS.photoVideoButton)) return b;
+  }
+  return null;
+}
+
+function assertNotCheckpointed(): void {
+  const body = document.body?.innerText?.toLowerCase() ?? "";
+  for (const needle of LABELS.checkpoint) {
+    if (body.includes(needle)) {
+      throw new Error(`checkpoint_detected: "${needle}"`);
+    }
+  }
+}
+
+// ---------- Success verification ----------
+
+function findFreshPostPermalink(firstLine: string): string | null {
+  if (!firstLine) return null;
+  const needle = firstLine.toLowerCase();
+  // FB feed items live under role=article. Permalinks look like `/groups/{id}/posts/{id}` or `/permalink/{id}`.
+  const articles = document.querySelectorAll<HTMLElement>('div[role="article"]');
+  for (const art of articles) {
+    const text = (art.innerText || "").toLowerCase();
+    if (!text.includes(needle)) continue;
+    const link = art.querySelector<HTMLAnchorElement>(
+      'a[href*="/posts/"], a[href*="/permalink/"], a[href*="/groups/"][href*="/permalink"]',
+    );
+    if (link?.href) return link.href;
   }
   return null;
 }
@@ -129,44 +263,66 @@ function findPostButton(): HTMLElement | null {
 // ---------- Image attach ----------
 
 async function attachImage(imageUrl: string): Promise<void> {
-  // Fetch the image bytes from our local backend
-  const full = imageUrl.startsWith("http") ? imageUrl : `http://localhost:8787/static/${imageUrl}`;
+  // Fetch the image bytes from our local backend (or absolute URL).
+  const full = imageUrl.startsWith("http")
+    ? imageUrl
+    : `http://localhost:8787${imageUrl.startsWith("/") ? imageUrl : `/${imageUrl}`}`;
   const resp = await fetch(full);
-  if (!resp.ok) throw new Error(`Failed to fetch image: ${resp.status}`);
+  if (!resp.ok) throw new Error(`fetch_image_failed: ${resp.status}`);
   const blob = await resp.blob();
-  const file = new File([blob], "image.png", { type: blob.type || "image/png" });
+  const ext = (blob.type.split("/")[1] || "png").split(";")[0];
+  const file = new File([blob], `image.${ext}`, { type: blob.type || "image/png" });
 
-  // Find the file input inside the composer dialog. FB hides it — aria-label often says "Photo/Video"
-  const input = await waitFor(
-    () =>
-      document.querySelector<HTMLInputElement>(
-        'div[role="dialog"] input[type="file"][accept*="image"]'
-      ),
-    5000
+  // First try: FB often renders the file input lazily only after you click
+  // "Photo/Video". Attempt both paths with a short fallback.
+  let input = document.querySelector<HTMLInputElement>(
+    'div[role="dialog"] input[type="file"][accept*="image"]',
   );
-  if (!input) throw new Error("Image file input not found");
+  if (!input) {
+    const pvBtn = findPhotoVideoButton();
+    if (pvBtn) {
+      simulateClick(pvBtn);
+      await sleep(600);
+    }
+    input = await waitFor(
+      () =>
+        document.querySelector<HTMLInputElement>(
+          'div[role="dialog"] input[type="file"][accept*="image"]',
+        ),
+      5000,
+    );
+  }
+  if (!input) throw new Error("image_file_input_not_found");
 
   const dt = new DataTransfer();
   dt.items.add(file);
   input.files = dt.files;
   input.dispatchEvent(new Event("change", { bubbles: true }));
 
-  // Wait for preview to render
-  await sleep(2000);
+  // Verify preview thumbnail actually rendered inside the dialog.
+  const preview = await waitFor(
+    () => document.querySelector<HTMLImageElement>('div[role="dialog"] img[src^="blob:"]'),
+    8000,
+  );
+  if (!preview) throw new Error("image_preview_not_rendered");
 }
 
 // ---------- List groups ----------
 
-async function listGroups(): Promise<Array<{ url: string; name: string; role?: string }>> {
-  // The /groups/joins page lists groups the user belongs to.
-  // This is a best-effort scrape — returns whatever we can find on the current viewport.
+async function listGroups(): Promise<
+  Array<{ url: string; name: string; role?: string }>
+> {
   const results: Array<{ url: string; name: string }> = [];
   const seen = new Set<string>();
-  const links = document.querySelectorAll<HTMLAnchorElement>('a[href*="/groups/"]');
+  const links = document.querySelectorAll<HTMLAnchorElement>(
+    'a[href*="/groups/"]',
+  );
   for (const a of links) {
     const href = a.href;
     const m = href.match(/\/groups\/([^/?#]+)/);
     if (!m) continue;
+    // Skip "join", "search", "feed", "create" etc. — pseudo-pages, not real groups.
+    if (/^(joins|feed|search|create|discover)$/.test(m[1])) continue;
     const url = `https://www.facebook.com/groups/${m[1]}`;
     if (seen.has(url)) continue;
     const text = a.textContent?.trim();
@@ -175,6 +331,44 @@ async function listGroups(): Promise<Array<{ url: string; name: string; role?: s
     results.push({ url, name: text });
   }
   return results;
+}
+
+// ---------- Smoke test (popup-triggered) ----------
+
+async function runSmoke(): Promise<{
+  locale: string;
+  url: string;
+  composer_trigger: boolean;
+  composer_editor_when_open: boolean;
+  post_button_when_open: boolean;
+  photo_video_button_when_open: boolean;
+  groups_detected: number;
+}> {
+  const report = {
+    locale: detectLocale(),
+    url: location.href,
+    composer_trigger: !!findComposerTrigger(),
+    composer_editor_when_open: false,
+    post_button_when_open: false,
+    photo_video_button_when_open: false,
+    groups_detected: (await listGroups()).length,
+  };
+
+  // If we can find the trigger, open the composer and probe inner controls.
+  const trigger = findComposerTrigger();
+  if (trigger) {
+    simulateClick(trigger);
+    await sleep(1500);
+    report.composer_editor_when_open = !!findComposerEditor();
+    report.post_button_when_open = !!findPostButton();
+    report.photo_video_button_when_open = !!findPhotoVideoButton();
+    // Try to close
+    const dialog = findComposerDialog();
+    dialog
+      ?.querySelector<HTMLElement>('[aria-label="Close"], [aria-label="Закрыть"]')
+      ?.click();
+  }
+  return report;
 }
 
 // ---------- Utils ----------
@@ -189,23 +383,24 @@ function simulateClick(el: HTMLElement): void {
 }
 
 async function pasteText(el: HTMLElement, text: string): Promise<void> {
-  // ContentEditable with React fiber — clipboard paste is the most reliable path
   el.focus();
   const dt = new DataTransfer();
   dt.setData("text/plain", text);
-  const evt = new ClipboardEvent("paste", { clipboardData: dt, bubbles: true, cancelable: true });
+  const evt = new ClipboardEvent("paste", {
+    clipboardData: dt,
+    bubbles: true,
+    cancelable: true,
+  });
   el.dispatchEvent(evt);
-  // Fallback: execCommand still works in most browsers for contenteditable
   if (!el.textContent?.includes(text.slice(0, 20))) {
     document.execCommand("insertText", false, text);
   }
-  // Human-like typing delay jitter
   await sleep(300 + Math.random() * 500);
 }
 
 function waitFor<T>(
   predicate: () => T | null | undefined | false,
-  timeoutMs: number
+  timeoutMs: number,
 ): Promise<T | null> {
   return new Promise((resolve) => {
     const start = Date.now();
@@ -223,4 +418,4 @@ function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
 
-console.log("[autoposter-AI] content script loaded");
+console.log("[autoposter-AI] content script loaded", { locale: detectLocale() });

--- a/extension/src/content/facebook.ts
+++ b/extension/src/content/facebook.ts
@@ -49,9 +49,15 @@ type PublishMsg = {
 
 type ListGroupsMsg = { type: "list_groups" };
 type ListSuggestedMsg = { type: "list_suggested_groups" };
+type FetchMetricsMsg = { type: "fetch_metrics" };
 type SmokeMsg = { type: "smoke" };
 
-type Msg = PublishMsg | ListGroupsMsg | ListSuggestedMsg | SmokeMsg;
+type Msg =
+  | PublishMsg
+  | ListGroupsMsg
+  | ListSuggestedMsg
+  | FetchMetricsMsg
+  | SmokeMsg;
 
 chrome.runtime.onMessage.addListener((msg: Msg, _sender, sendResponse) => {
   (async () => {
@@ -70,6 +76,11 @@ chrome.runtime.onMessage.addListener((msg: Msg, _sender, sendResponse) => {
         case "list_suggested_groups": {
           const groups = await listSuggestedGroups();
           sendResponse({ ok: true, groups });
+          break;
+        }
+        case "fetch_metrics": {
+          const metrics = await scrapePostMetrics();
+          sendResponse({ ok: true, metrics });
           break;
         }
         case "smoke": {
@@ -456,6 +467,90 @@ async function listSuggestedGroups(): Promise<ScrapedSuggestedGroup[]> {
   }
 
   return [...byUrl.values()];
+}
+
+// ---------- Post metrics scraping ----------
+
+type ScrapedMetrics = {
+  likes: number;
+  comments: number;
+  shares: number;
+  reach: number | null;
+};
+
+function parseCount(text: string): number | null {
+  if (!text) return null;
+  // Strip commas; match the first number with optional K/M suffix.
+  const m = text.match(/([\d.,]+)\s*([KkMm])?/);
+  if (!m) return null;
+  const raw = m[1].replace(/,/g, "");
+  const n = parseFloat(raw);
+  if (Number.isNaN(n)) return null;
+  const suffix = (m[2] || "").toLowerCase();
+  if (suffix === "k") return Math.round(n * 1000);
+  if (suffix === "m") return Math.round(n * 1_000_000);
+  return Math.round(n);
+}
+
+/**
+ * Scrape engagement counters off a permalink page.
+ *
+ * FB constantly reshuffles markup, so we look for any of:
+ * - `aria-label` strings matching "123 reactions", "12 comments", "3 shares"
+ * - role="button" elements whose text starts with digits + "comments/shares"
+ *
+ * We return zeros for things we couldn't find (rather than throwing) — the
+ * backend records a sparse row and tries again next window.
+ */
+async function scrapePostMetrics(): Promise<ScrapedMetrics> {
+  // Give the page one more beat for async counters to hydrate.
+  await sleep(800);
+
+  const result: ScrapedMetrics = {
+    likes: 0,
+    comments: 0,
+    shares: 0,
+    reach: null,
+  };
+
+  const labelPatterns: Array<{ key: keyof ScrapedMetrics; rx: RegExp }> = [
+    { key: "likes", rx: /(?:^|\s)([\d.,]+[KkMm]?)\s*(?:reactions?|likes?|reactions and|реакци|likes)/i },
+    { key: "comments", rx: /([\d.,]+[KkMm]?)\s*(?:comments?|комментари|comentarios?)/i },
+    { key: "shares", rx: /([\d.,]+[KkMm]?)\s*(?:shares?|поделились|compartidos?)/i },
+  ];
+
+  const allText = new Set<string>();
+  // aria-label carries the canonical counts on reaction/comment/share buttons.
+  document
+    .querySelectorAll<HTMLElement>("[aria-label]")
+    .forEach((el) => {
+      const v = el.getAttribute("aria-label");
+      if (v) allText.add(v);
+    });
+  // role=button / role=link elements often have the visible count as textContent.
+  document
+    .querySelectorAll<HTMLElement>('[role="button"], [role="link"], span')
+    .forEach((el) => {
+      const t = el.textContent?.trim() || "";
+      if (t && t.length < 80) allText.add(t);
+    });
+
+  for (const pattern of labelPatterns) {
+    for (const t of allText) {
+      const m = t.match(pattern.rx);
+      if (m) {
+        const n = parseCount(m[1]);
+        if (n !== null && n > result[pattern.key]) {
+          // Highest match wins — FB sometimes renders both "123" and "123 reactions"
+          // in different positions; we want the explicit count.
+          (result as unknown as Record<string, number>)[pattern.key] = n;
+          break;
+        }
+      }
+    }
+  }
+
+  return result;
 }
 
 // ---------- Smoke test (popup-triggered) ----------

--- a/extension/src/content/facebook.ts
+++ b/extension/src/content/facebook.ts
@@ -17,11 +17,34 @@
  * - If we detect a "re-auth" / checkpoint / captcha dialog, throw { kind: "checkpoint" }.
  */
 
+type HumanizerConfig = {
+  typing_wpm_min: number;
+  typing_wpm_max: number;
+  mistake_rate: number;
+  pause_between_sentences_ms_min: number;
+  pause_between_sentences_ms_max: number;
+  mouse_path_curvature: number;
+  idle_scroll_before_post_sec_min: number;
+  idle_scroll_before_post_sec_max: number;
+};
+
+const DEFAULT_HUMANIZER: HumanizerConfig = {
+  typing_wpm_min: 35,
+  typing_wpm_max: 70,
+  mistake_rate: 0.02,
+  pause_between_sentences_ms_min: 250,
+  pause_between_sentences_ms_max: 900,
+  mouse_path_curvature: 0.35,
+  idle_scroll_before_post_sec_min: 3,
+  idle_scroll_before_post_sec_max: 12,
+};
+
 type PublishMsg = {
   type: "publish";
   text: string;
   image_url?: string | null;
   first_comment?: string | null;
+  humanizer?: HumanizerConfig | null;
 };
 
 type ListGroupsMsg = { type: "list_groups" };
@@ -122,6 +145,11 @@ async function publishPost(
   // 0. Fail fast if we're on a checkpoint / login screen.
   assertNotCheckpointed();
 
+  const hz: HumanizerConfig = { ...DEFAULT_HUMANIZER, ...(msg.humanizer || {}) };
+
+  // Warm-up: idle scroll before interacting — a human reads the feed first.
+  await humanIdleScroll(hz);
+
   // 1. Find the composer trigger ("Write something...").
   const trigger = await waitFor(() => findComposerTrigger(), 15000);
   if (!trigger) {
@@ -129,15 +157,16 @@ async function publishPost(
       `composer_trigger_not_found: locale=${detectLocale()} url=${location.pathname}`,
     );
   }
+  await humanHover(trigger, hz);
   simulateClick(trigger);
 
   // 2. Wait for the composer dialog + editor.
   const composer = await waitFor(() => findComposerEditor(), 10000);
   if (!composer) throw new Error("composer_editor_did_not_open");
 
-  // 3. Paste text via clipboard simulation (most robust against React).
+  // 3. Type text character-by-character with humanizer pacing.
   composer.focus();
-  await pasteText(composer, msg.text);
+  await humanType(composer, msg.text, hz);
 
   // 4. Attach image if provided.
   if (msg.image_url) {
@@ -147,7 +176,8 @@ async function publishPost(
   // 5. Click "Post".
   const postBtn = await waitFor(() => findPostButton(), 10000);
   if (!postBtn) throw new Error("post_button_not_found_or_disabled");
-  await sleep(600 + Math.random() * 900); // human-ish pause
+  await humanHover(postBtn, hz);
+  await sleep(600 + Math.random() * 900); // final hesitation
   simulateClick(postBtn);
 
   // 6. Wait for the composer to close as first success signal.
@@ -511,6 +541,168 @@ function waitFor<T>(
 
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
+}
+
+function rand(min: number, max: number): number {
+  return min + Math.random() * (max - min);
+}
+
+function randInt(min: number, max: number): number {
+  return Math.floor(rand(min, max + 1));
+}
+
+// ---------- Humanizer helpers ----------
+
+async function humanIdleScroll(hz: HumanizerConfig): Promise<void> {
+  const durSec = rand(
+    hz.idle_scroll_before_post_sec_min,
+    hz.idle_scroll_before_post_sec_max,
+  );
+  const end = Date.now() + durSec * 1000;
+  while (Date.now() < end) {
+    // Small irregular scrolls, occasional pauses — mimics "reading".
+    window.scrollBy({
+      top: Math.random() < 0.15 ? -randInt(80, 250) : randInt(120, 420),
+      behavior: "smooth",
+    });
+    await sleep(randInt(600, 1800));
+  }
+}
+
+async function humanHover(target: HTMLElement, hz: HumanizerConfig): Promise<void> {
+  // Simulate a bezier-curve mouse approach without actually moving the OS
+  // cursor (we can't). We dispatch mousemove/mouseover events along the path,
+  // which is enough to unlock hover states / analytics FB relies on.
+  const rect = target.getBoundingClientRect();
+  if (rect.width === 0 || rect.height === 0) return;
+
+  const endX = rect.left + rect.width / 2;
+  const endY = rect.top + rect.height / 2;
+  const startX = endX + (Math.random() - 0.5) * 400;
+  const startY = endY + (Math.random() - 0.5) * 400;
+  // Control points bend the path.
+  const curve = hz.mouse_path_curvature;
+  const cx = (startX + endX) / 2 + (Math.random() - 0.5) * 200 * curve;
+  const cy = (startY + endY) / 2 + (Math.random() - 0.5) * 200 * curve;
+
+  const steps = randInt(12, 28);
+  for (let i = 0; i <= steps; i++) {
+    const t = i / steps;
+    // Quadratic bezier
+    const x = (1 - t) * (1 - t) * startX + 2 * (1 - t) * t * cx + t * t * endX;
+    const y = (1 - t) * (1 - t) * startY + 2 * (1 - t) * t * cy + t * t * endY;
+    const evt = new MouseEvent("mousemove", {
+      clientX: x,
+      clientY: y,
+      bubbles: true,
+      cancelable: true,
+      view: window,
+    });
+    document.elementFromPoint(x, y)?.dispatchEvent(evt);
+    await sleep(randInt(8, 24));
+  }
+  target.dispatchEvent(
+    new MouseEvent("mouseover", {
+      clientX: endX,
+      clientY: endY,
+      bubbles: true,
+      view: window,
+    }),
+  );
+}
+
+const QWERTY_NEIGHBORS: Record<string, string> = {
+  a: "sqwz",
+  b: "vghn",
+  c: "xdfv",
+  d: "serfcx",
+  e: "wrdsf",
+  f: "drtgvc",
+  g: "ftyhbv",
+  h: "gyujnb",
+  i: "uojkl",
+  j: "huikmn",
+  k: "jiolm",
+  l: "kop",
+  m: "njk",
+  n: "bhjm",
+  o: "iklp",
+  p: "ol",
+  q: "was",
+  r: "edft",
+  s: "awdxz",
+  t: "rfgy",
+  u: "yhji",
+  v: "cfgb",
+  w: "qase",
+  x: "zsdc",
+  y: "tghu",
+  z: "asx",
+};
+
+function typoFor(ch: string): string {
+  const lower = ch.toLowerCase();
+  const neighbors = QWERTY_NEIGHBORS[lower];
+  if (!neighbors) return ch;
+  const pick = neighbors[randInt(0, neighbors.length - 1)];
+  return ch === lower ? pick : pick.toUpperCase();
+}
+
+async function humanType(
+  el: HTMLElement,
+  text: string,
+  hz: HumanizerConfig,
+): Promise<void> {
+  el.focus();
+  // Convert WPM to ms-per-char. Avg word = 5 chars.
+  const wpm = rand(hz.typing_wpm_min, hz.typing_wpm_max);
+  const avgMsPerChar = 60_000 / (wpm * 5);
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    // Occasional typo + correction
+    if (/[a-zA-Z]/.test(ch) && Math.random() < hz.mistake_rate) {
+      const wrong = typoFor(ch);
+      insertChar(el, wrong);
+      await sleep(avgMsPerChar * rand(0.8, 1.5));
+      // Backspace correction
+      insertBackspace(el);
+      await sleep(avgMsPerChar * rand(0.3, 0.8));
+    }
+    insertChar(el, ch);
+    // Variance per-char: +/- 50% around avg.
+    let delay = avgMsPerChar * rand(0.5, 1.5);
+    if (ch === "." || ch === "!" || ch === "?" || ch === "\n") {
+      delay += rand(
+        hz.pause_between_sentences_ms_min,
+        hz.pause_between_sentences_ms_max,
+      );
+    }
+    await sleep(delay);
+  }
+  // Verify — fall back to whole-text paste if somehow the editor didn't receive it.
+  if (!el.textContent?.includes(text.slice(0, 20))) {
+    await pasteText(el, text);
+  }
+}
+
+function insertChar(el: HTMLElement, ch: string): void {
+  // Fire key events so React/FB's composer validates content.
+  el.dispatchEvent(new KeyboardEvent("keydown", { key: ch, bubbles: true }));
+  if (ch === "\n") {
+    document.execCommand("insertLineBreak", false);
+  } else {
+    document.execCommand("insertText", false, ch);
+  }
+  el.dispatchEvent(new KeyboardEvent("keyup", { key: ch, bubbles: true }));
+  el.dispatchEvent(new InputEvent("input", { data: ch, bubbles: true }));
+}
+
+function insertBackspace(el: HTMLElement): void {
+  el.dispatchEvent(new KeyboardEvent("keydown", { key: "Backspace", bubbles: true }));
+  document.execCommand("delete", false);
+  el.dispatchEvent(new KeyboardEvent("keyup", { key: "Backspace", bubbles: true }));
+  el.dispatchEvent(new InputEvent("input", { inputType: "deleteContentBackward", bubbles: true }));
 }
 
 console.log("[autoposter-AI] content script loaded", { locale: detectLocale() });

--- a/extension/src/content/facebook.ts
+++ b/extension/src/content/facebook.ts
@@ -25,9 +25,10 @@ type PublishMsg = {
 };
 
 type ListGroupsMsg = { type: "list_groups" };
+type ListSuggestedMsg = { type: "list_suggested_groups" };
 type SmokeMsg = { type: "smoke" };
 
-type Msg = PublishMsg | ListGroupsMsg | SmokeMsg;
+type Msg = PublishMsg | ListGroupsMsg | ListSuggestedMsg | SmokeMsg;
 
 chrome.runtime.onMessage.addListener((msg: Msg, _sender, sendResponse) => {
   (async () => {
@@ -40,6 +41,11 @@ chrome.runtime.onMessage.addListener((msg: Msg, _sender, sendResponse) => {
         }
         case "list_groups": {
           const groups = await listGroups();
+          sendResponse({ ok: true, groups });
+          break;
+        }
+        case "list_suggested_groups": {
+          const groups = await listSuggestedGroups();
           sendResponse({ ok: true, groups });
           break;
         }
@@ -309,6 +315,19 @@ async function attachImage(imageUrl: string): Promise<void> {
 
 // ---------- List groups ----------
 
+function parseMemberCount(text: string): number | null {
+  // FB renders "12K members", "1,234 участников", "2.4M members", etc.
+  const m = text.match(/([\d.,]+)\s*([KkMm])?/);
+  if (!m) return null;
+  const raw = m[1].replace(/,/g, "");
+  const n = parseFloat(raw);
+  if (Number.isNaN(n)) return null;
+  const suffix = (m[2] || "").toLowerCase();
+  if (suffix === "k") return Math.round(n * 1000);
+  if (suffix === "m") return Math.round(n * 1_000_000);
+  return Math.round(n);
+}
+
 async function listGroups(): Promise<
   Array<{ url: string; name: string; role?: string }>
 > {
@@ -331,6 +350,82 @@ async function listGroups(): Promise<
     results.push({ url, name: text });
   }
   return results;
+}
+
+// ---------- Suggested groups ----------
+
+type ScrapedSuggestedGroup = {
+  url: string;
+  external_id: string;
+  name: string;
+  member_count?: number;
+  description?: string;
+  category?: string;
+};
+
+async function listSuggestedGroups(): Promise<ScrapedSuggestedGroup[]> {
+  // FB's discover page lazy-loads — scroll a few times to pull in more cards.
+  for (let i = 0; i < 6; i++) {
+    window.scrollBy({ top: window.innerHeight, behavior: "instant" as ScrollBehavior });
+    await sleep(700);
+  }
+
+  // Each card tends to have a heading-link to the group, a member count line,
+  // and (sometimes) a description paragraph. We key off the anchor to
+  // `/groups/<id>/` inside the main discovery area.
+  const anchors = document.querySelectorAll<HTMLAnchorElement>(
+    'a[href*="/groups/"][role="link"]',
+  );
+  const byUrl = new Map<string, ScrapedSuggestedGroup>();
+
+  for (const a of anchors) {
+    const m = a.href.match(/\/groups\/([^/?#]+)\/?/);
+    if (!m) continue;
+    const slug = m[1];
+    if (/^(joins|feed|search|create|discover)$/.test(slug)) continue;
+    const url = `https://www.facebook.com/groups/${slug}`;
+
+    const name = (a.textContent || "").trim();
+    if (!name || name.length < 2 || name.length > 200) continue;
+
+    // Climb to the closest card container to grab member_count + description.
+    const card =
+      a.closest<HTMLElement>('[role="article"], [data-visualcompletion="ignore-dynamic"]') ??
+      a.parentElement?.parentElement ??
+      null;
+
+    let member_count: number | undefined;
+    let description: string | undefined;
+    if (card) {
+      const text = card.innerText || "";
+      const lines = text
+        .split("\n")
+        .map((l) => l.trim())
+        .filter(Boolean);
+      for (const line of lines) {
+        if (!member_count && /member|участник|miembro|mitglied/i.test(line)) {
+          const parsed = parseMemberCount(line);
+          if (parsed != null) member_count = parsed;
+        }
+        if (!description && line.length > 40 && line !== name) {
+          description = line.slice(0, 500);
+        }
+      }
+    }
+
+    const existing = byUrl.get(url);
+    if (!existing || (!existing.description && description)) {
+      byUrl.set(url, {
+        url,
+        external_id: url,
+        name,
+        member_count,
+        description,
+      });
+    }
+  }
+
+  return [...byUrl.values()];
 }
 
 // ---------- Smoke test (popup-triggered) ----------

--- a/extension/src/popup/popup.html
+++ b/extension/src/popup/popup.html
@@ -6,37 +6,56 @@
     <style>
       body {
         font-family: system-ui, -apple-system, sans-serif;
-        width: 280px;
-        padding: 16px;
+        width: 320px;
+        padding: 14px;
         margin: 0;
       }
       h1 {
         font-size: 14px;
-        margin: 0 0 12px;
+        margin: 0 0 10px;
       }
       .status {
         font-size: 12px;
-        padding: 8px 12px;
+        padding: 8px 10px;
         border-radius: 6px;
         background: #f3f4f6;
+        margin-bottom: 10px;
       }
-      .status.ok {
-        background: #dcfce7;
-        color: #14532d;
+      .status.ok { background: #dcfce7; color: #14532d; }
+      .status.warn { background: #fef3c7; color: #78350f; }
+      .status.err { background: #fee2e2; color: #7f1d1d; }
+      a { font-size: 12px; color: #2563eb; }
+      button {
+        width: 100%;
+        padding: 8px;
+        font-size: 13px;
+        background: #2563eb;
+        color: white;
+        border: 0;
+        border-radius: 6px;
+        cursor: pointer;
+        margin-bottom: 8px;
       }
-      .status.err {
-        background: #fee2e2;
-        color: #7f1d1d;
-      }
-      a {
-        font-size: 12px;
-        color: #2563eb;
+      button:disabled { background: #9ca3af; cursor: not-allowed; }
+      pre {
+        font-size: 11px;
+        background: #f9fafb;
+        border: 1px solid #e5e7eb;
+        border-radius: 4px;
+        padding: 6px;
+        max-height: 180px;
+        overflow: auto;
+        white-space: pre-wrap;
+        word-break: break-all;
+        margin: 0;
       }
     </style>
   </head>
   <body>
     <h1>autoposter-AI</h1>
-    <div id="status" class="status">Checking backend...</div>
+    <div id="status" class="status">Checking backend…</div>
+    <button id="smoke">Run FB selector smoke test</button>
+    <pre id="smoke-out"></pre>
     <p><a href="http://localhost:3000" target="_blank">Open dashboard</a></p>
     <script>
       fetch("http://localhost:8787/healthz")
@@ -45,10 +64,10 @@
           const el = document.getElementById("status");
           if (d.extension_connected) {
             el.className = "status ok";
-            el.textContent = "Connected to backend";
+            el.textContent = "Backend: OK — extension linked";
           } else {
-            el.className = "status";
-            el.textContent = "Backend running, extension not linked yet";
+            el.className = "status warn";
+            el.textContent = "Backend: OK — waiting for extension WS";
           }
         })
         .catch(() => {
@@ -56,6 +75,26 @@
           el.className = "status err";
           el.textContent = "Backend not reachable on :8787";
         });
+
+      document.getElementById("smoke").addEventListener("click", async () => {
+        const btn = document.getElementById("smoke");
+        const out = document.getElementById("smoke-out");
+        btn.disabled = true;
+        out.textContent = "Running on active tab…";
+        try {
+          const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+          if (!tab?.id || !tab.url?.includes("facebook.com")) {
+            out.textContent = "Open a facebook.com tab first.";
+            return;
+          }
+          const result = await chrome.tabs.sendMessage(tab.id, { type: "smoke" });
+          out.textContent = JSON.stringify(result, null, 2);
+        } catch (e) {
+          out.textContent = "Error: " + (e?.message || e);
+        } finally {
+          btn.disabled = false;
+        }
+      });
     </script>
   </body>
 </html>

--- a/scripts/dev_smoke.sh
+++ b/scripts/dev_smoke.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Backend-only smoke test: hits every REST surface without touching Claude,
+# Gemini, or the Chrome extension. Useful for a quick "does it boot" after a refactor.
+#
+# Usage:
+#   ./scripts/dev_smoke.sh [PORT]
+#
+# Assumes the backend is already running (uvicorn app.main:app --port 8787).
+set -euo pipefail
+
+PORT="${1:-8787}"
+API="http://localhost:${PORT}"
+
+say() { printf "\n\033[1;36m== %s ==\033[0m\n" "$1"; }
+
+say "healthz"
+curl -sf "$API/healthz" | python -m json.tool
+
+say "status"
+curl -sf "$API/api/status" | python -m json.tool
+
+say "upsert business profile"
+curl -sf -X PUT "$API/api/business-profile" \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"Smoke Inc.","description":"Dev-only test profile."}' \
+  | python -m json.tool
+
+say "create target"
+curl -sf -X POST "$API/api/targets" \
+  -H 'Content-Type: application/json' \
+  -d '{"platform_id":"facebook","external_id":"https://www.facebook.com/groups/smoke","name":"Smoke Test Group"}' \
+  | python -m json.tool || true
+
+say "list targets"
+curl -sf "$API/api/targets" | python -m json.tool
+
+say "create manual draft post"
+POST_ID=$(curl -sf -X POST "$API/api/posts" \
+  -H 'Content-Type: application/json' \
+  -d '{"post_type":"informative","text":"Manual draft for smoke test."}' \
+  | python -c 'import json,sys;print(json.load(sys.stdin)["id"])')
+echo "Draft id: $POST_ID"
+
+say "list posts"
+curl -sf "$API/api/posts" | python -m json.tool | head -40
+
+say "feedback"
+curl -sf -X POST "$API/api/feedback" \
+  -H 'Content-Type: application/json' \
+  -d "{\"post_id\": $POST_ID, \"rating\": \"up\"}" \
+  | python -m json.tool
+
+echo
+echo "Smoke test done. Delete the test row if you care:"
+echo "  curl -X DELETE $API/api/posts/$POST_ID"


### PR DESCRIPTION
## Summary

Делаем review по всем 9 милестоунам разом — от пустого скелета до
production-ready self-hosted AI-автопостера. 133 pytest зелёных.

### Что внутри

| # | Milestone | Что реально работает |
|---|-----------|----------------------|
| **M0** | Foundation | REST CRUD (Profile/Targets/Posts/Feedback/Media), APScheduler, dashboard, FB DOM hardening, image attach |
| **M1** | Content Planner | `PlannerAgent` + `ContentPlan`/`PlanSlot`, calendar + drag-n-drop, chat-refinement |
| **M2** | Media Library | Upload + Pillow dims + Claude Vision caption/tags + auto-suggest top-3 per slot |
| **M3** | Targets Agent | Scrape joined/suggested FB groups, relevance score + AI clustering в target_lists |
| **M4** | Humanizer | Char-by-char typing + bezier mouse + scheduler jitter + smart pause + session health |
| **M5** | Review Queue | `PENDING_REVIEW` routing + approve/reject/regenerate/approve-all + thumbs feedback |
| **M6** | SMM Analyst ⭐ | `PostMetrics` (1h/24h/7d), weekly Claude report, Optimizer proposals с auto-apply (safe fields, conf ≥0.75), few-shot store |
| **M7** | IG + Threads | Meta Graph v21.0 / Threads v1.0 clients, `InstagramPlatform` + `ThreadsPlatform`, OAuth flow, `PlatformCredential` model, platform registry, cross-posting |
| **M8** | Production Polish | PIN auth middleware + AuthGate UI, Fernet at-rest encryption, daily sqlite+media zip backup, Dockerfile + compose, request-id log + `/metrics`, install/troubleshooting/ban-FAQ docs |

### Test plan

- [x] `cd backend && source .venv/bin/activate && pytest -q` — **133 passed**
- [ ] `cp .env.example .env` → fill `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`
- [ ] `docker compose up -d --build` → `curl http://localhost:8787/healthz` returns 200
- [ ] `cd dashboard && npm install && npm run dev` → `http://localhost:3000/profile` renders, form saves
- [ ] `cd extension && npm install && npm run build` → load unpacked от `dist/`, popup показывает `WS connected`
- [ ] Dashboard → create BusinessProfile → create Target → generate post → Publish Now → Queue показывает POSTED с permalink
- [ ] Schedule post +2 min → scheduler сам публикует в назначенное время
- [ ] Set `DASHBOARD_PIN=1234` в `.env` → restart → dashboard показывает login card → unlock работает
- [ ] `POST /api/meta/credentials` (manual token) → `/platforms` page показывает connected account → publish на IG target → MediaPublishResult возвращает media id
- [ ] `POST /api/admin/backup` → `data/backups/autoposter-*.zip` содержит `app.db` + `images/`
- [ ] `GET /metrics` возвращает Prometheus counters `http_requests_total{...}`

### Что сознательно отложено (post-MVP)

- Carousel/Reels/Stories для IG (M7 покрывает single image + text)
- Video upload + transcode через ffmpeg (отложено из M2)
- A/B framework (M6 — proposals + Feedback loop дают функциональный аналог)
- nginx TLS layer (docker-compose.yml оставлен закомментированным)
- Multi-tenant `user_id` — весь v1 single-user

https://claude.ai/code/session_01Bg355hCeynbYag6DVp8WNi