### PR TITLE
Fix review-main-build issues and add Phase 1 reliability features

### DIFF
--- a/backend/app/agents/__init__.py
+++ b/backend/app/agents/__init__.py
@@ -1,1 +1,10 @@
 """Long-running AI agents: Planner (M1), Target (M3), Analyst (M6), Optimizer (M6)."""
+from __future__ import annotations
+
+
+class MalformedLLMResponse(ValueError):
+    """Raised when an agent can't parse structured output (JSON) from the model.
+
+    A ValueError subclass so legacy callers that already `except ValueError`
+    keep working. Surfaced by the API layer as HTTP 502 (upstream problem).
+    """

--- a/backend/app/agents/analyst.py
+++ b/backend/app/agents/analyst.py
@@ -27,6 +27,7 @@ from datetime import UTC, datetime, timedelta
 from anthropic import Anthropic
 from sqlalchemy.orm import Session
 
+from app.agents import MalformedLLMResponse
 from app.config import settings
 from app.db.models import (
     AnalystReport,
@@ -141,8 +142,14 @@ def _extract_json(text: str) -> dict:
     first = text.find("{")
     last = text.rfind("}")
     if first == -1 or last == -1 or first > last:
-        raise ValueError(f"No JSON in analyst response: {text[:300]!r}")
-    return json.loads(text[first : last + 1])
+        raise MalformedLLMResponse(f"No JSON in analyst response: {text[:300]!r}")
+    snippet = text[first : last + 1]
+    try:
+        return json.loads(snippet)
+    except json.JSONDecodeError as exc:
+        raise MalformedLLMResponse(
+            f"Analyst returned malformed JSON: {exc.msg} (snippet: {snippet[:200]!r})"
+        ) from exc
 
 
 def _posts_block(db: Session, period_start: datetime, period_end: datetime) -> str:

--- a/backend/app/agents/planner.py
+++ b/backend/app/agents/planner.py
@@ -24,6 +24,7 @@ from datetime import UTC, datetime, timedelta
 
 from anthropic import Anthropic
 
+from app.agents import MalformedLLMResponse
 from app.config import settings
 from app.db.models import BusinessProfile, PostType
 
@@ -111,9 +112,16 @@ def _extract_json(text: str) -> dict:
     first = text.find("{")
     last = text.rfind("}")
     if first == -1 or last == -1 or first > last:
-        raise ValueError(f"No JSON object found in model response: {text[:200]!r}")
+        raise MalformedLLMResponse(
+            f"No JSON object found in model response: {text[:200]!r}"
+        )
     snippet = text[first : last + 1]
-    return json.loads(snippet)
+    try:
+        return json.loads(snippet)
+    except json.JSONDecodeError as exc:
+        raise MalformedLLMResponse(
+            f"Model returned malformed JSON: {exc.msg} (snippet: {snippet[:200]!r})"
+        ) from exc
 
 
 def _build_user_prompt(

--- a/backend/app/agents/targets.py
+++ b/backend/app/agents/targets.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass, field
 
 from anthropic import Anthropic
 
+from app.agents import MalformedLLMResponse
 from app.config import settings
 from app.db.models import BusinessProfile, Target
 
@@ -121,8 +122,16 @@ def _extract_json(text: str) -> dict:
     first = text.find("{")
     last = text.rfind("}")
     if first == -1 or last == -1 or first > last:
-        raise ValueError(f"No JSON object in model response: {text[:200]!r}")
-    return json.loads(text[first : last + 1])
+        raise MalformedLLMResponse(
+            f"No JSON object in model response: {text[:200]!r}"
+        )
+    snippet = text[first : last + 1]
+    try:
+        return json.loads(snippet)
+    except json.JSONDecodeError as exc:
+        raise MalformedLLMResponse(
+            f"Targets agent returned malformed JSON: {exc.msg} (snippet: {snippet[:200]!r})"
+        ) from exc
 
 
 def _call_claude(system: str, user: str) -> tuple[str, int, int]:

--- a/backend/app/ai/image.py
+++ b/backend/app/ai/image.py
@@ -76,14 +76,25 @@ def generate_image(post_text: str, business_desc: str, tone: str = "casual") -> 
         ),
     )
 
-    # Extract image bytes from response
+    # Extract image bytes from response. Gemini can drop `candidates`, `content`,
+    # or `parts` entirely when a safety filter fires or on transient API errors —
+    # guard each access so we surface a readable error instead of AttributeError.
+    candidates = getattr(response, "candidates", None) or []
+    if not candidates:
+        raise RuntimeError("Gemini returned no candidates (safety filter or API error)")
+    content = getattr(candidates[0], "content", None)
+    parts = getattr(content, "parts", None) or []
     image_bytes: bytes | None = None
-    for part in response.candidates[0].content.parts:
-        if part.inline_data is not None:
-            data = part.inline_data.data
-            # SDK may return bytes directly or base64-encoded str
-            image_bytes = data if isinstance(data, bytes) else base64.b64decode(data)
-            break
+    for part in parts:
+        inline = getattr(part, "inline_data", None)
+        if inline is None:
+            continue
+        data = getattr(inline, "data", None)
+        if data is None:
+            continue
+        # SDK may return bytes directly or base64-encoded str
+        image_bytes = data if isinstance(data, bytes) else base64.b64decode(data)
+        break
 
     if image_bytes is None:
         raise RuntimeError("Gemini returned no image data")

--- a/backend/app/api/analytics.py
+++ b/backend/app/api/analytics.py
@@ -18,7 +18,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session, selectinload
 
 from app.agents import analyst as analyst_agent
-from app.db import get_session
+from app.db import get_current_profile, get_session
 from app.db.models import (
     AnalystReport,
     BusinessProfile,
@@ -169,7 +169,7 @@ async def generate_report(
     db: Session = Depends(get_session),
 ) -> AnalystReport:
     """Kick off a fresh analyst run. Blocks until Claude responds."""
-    profile = db.query(BusinessProfile).order_by(BusinessProfile.id.asc()).first()
+    profile = get_current_profile(db)
     if profile is None:
         raise HTTPException(status_code=400, detail="Business profile required.")
 
@@ -214,7 +214,7 @@ def apply_proposal(proposal_id: int, db: Session = Depends(get_session)) -> Opti
             status_code=409,
             detail=f"Proposal is already {proposal.status.value}.",
         )
-    profile = db.query(BusinessProfile).order_by(BusinessProfile.id.asc()).first()
+    profile = get_current_profile(db)
     if profile is None:
         raise HTTPException(status_code=400, detail="Business profile required.")
     # Unwrap scalar container if that's how the agent stored it.

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -3,8 +3,17 @@
 - POST /api/auth/login { pin } → sets signed cookie
 - POST /api/auth/logout        → clears cookie
 - GET  /api/auth/status        → { authenticated, auth_required }
+
+Brute-force protection: login attempts are throttled per client IP. See
+`_LOGIN_WINDOW_SEC` / `_LOGIN_MAX_ATTEMPTS`. Simple in-memory deque — good
+enough for the single-user localhost scope; anything bigger should sit
+behind a real reverse proxy with rate-limit.
 """
 from __future__ import annotations
+
+import time
+from collections import deque
+from threading import Lock
 
 from fastapi import APIRouter, HTTPException, Request, Response
 from pydantic import BaseModel
@@ -19,6 +28,46 @@ from app.security import (
 )
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
+
+
+# Rate-limit: 5 failed attempts per 60 s per IP. Successful logins don't count.
+_LOGIN_WINDOW_SEC = 60.0
+_LOGIN_MAX_ATTEMPTS = 5
+_login_failures: dict[str, deque[float]] = {}
+_login_lock = Lock()
+
+
+def _client_ip(request: Request) -> str:
+    # Single-user localhost: trust X-Forwarded-For if present (reverse proxy),
+    # otherwise fall back to request.client.host. Not spoofing-resistant on its
+    # own — that's fine, we just want basic brute-force slowdown.
+    fwd = request.headers.get("x-forwarded-for", "")
+    if fwd:
+        return fwd.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+def _check_login_rate_limit(request: Request) -> None:
+    now = time.monotonic()
+    ip = _client_ip(request)
+    with _login_lock:
+        bucket = _login_failures.setdefault(ip, deque())
+        while bucket and now - bucket[0] > _LOGIN_WINDOW_SEC:
+            bucket.popleft()
+        if len(bucket) >= _LOGIN_MAX_ATTEMPTS:
+            retry_after = int(_LOGIN_WINDOW_SEC - (now - bucket[0])) + 1
+            raise HTTPException(
+                status_code=429,
+                detail="Too many login attempts. Slow down.",
+                headers={"Retry-After": str(retry_after)},
+            )
+
+
+def _record_login_failure(request: Request) -> None:
+    now = time.monotonic()
+    ip = _client_ip(request)
+    with _login_lock:
+        _login_failures.setdefault(ip, deque()).append(now)
 
 
 class LoginIn(BaseModel):
@@ -41,11 +90,13 @@ def status(request: Request) -> AuthStatus:
 
 
 @router.post("/login", response_model=AuthStatus)
-def login(payload: LoginIn, response: Response) -> AuthStatus:
+def login(payload: LoginIn, request: Request, response: Response) -> AuthStatus:
     pin = settings.dashboard_pin.strip()
     if not pin:
         return AuthStatus(auth_required=False, authenticated=True)
+    _check_login_rate_limit(request)
     if not verify_pin(payload.pin):
+        _record_login_failure(request)
         raise HTTPException(status_code=401, detail="Invalid PIN")
     response.set_cookie(
         key=_COOKIE_NAME,

--- a/backend/app/api/business_profile.py
+++ b/backend/app/api/business_profile.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
-from app.db import get_session
+from app.db import get_current_profile, get_session, invalidate_profile_cache
 from app.db.models import BusinessProfile
 from app.schemas import BusinessProfileIn, BusinessProfileOut
 
@@ -12,8 +12,9 @@ router = APIRouter(prefix="/api/business-profile", tags=["business-profile"])
 
 
 @router.get("", response_model=BusinessProfileOut)
-def get_profile(db: Session = Depends(get_session)) -> BusinessProfile:
-    profile = db.query(BusinessProfile).order_by(BusinessProfile.id.asc()).first()
+def get_profile(
+    profile: BusinessProfile | None = Depends(get_current_profile),
+) -> BusinessProfile:
     if profile is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -27,7 +28,7 @@ def upsert_profile(
     payload: BusinessProfileIn,
     db: Session = Depends(get_session),
 ) -> BusinessProfile:
-    profile = db.query(BusinessProfile).order_by(BusinessProfile.id.asc()).first()
+    profile = get_current_profile(db)
     if profile is None:
         profile = BusinessProfile(**payload.model_dump())
         db.add(profile)
@@ -36,4 +37,5 @@ def upsert_profile(
             setattr(profile, key, value)
     db.commit()
     db.refresh(profile)
+    invalidate_profile_cache()
     return profile

--- a/backend/app/api/plans.py
+++ b/backend/app/api/plans.py
@@ -133,7 +133,8 @@ def create_plan_empty(
     db.add(plan)
     db.commit()
     refreshed = _eager(db, plan.id)
-    assert refreshed is not None
+    if refreshed is None:
+        raise HTTPException(status_code=500, detail="Plan vanished after commit")
     return refreshed
 
 
@@ -177,7 +178,8 @@ def generate_plan(
     _apply_slot_proposals(db, plan, proposal.slots, replace=False)
     db.commit()
     refreshed = _eager(db, plan.id)
-    assert refreshed is not None
+    if refreshed is None:
+        raise HTTPException(status_code=500, detail="Plan vanished after commit")
     return refreshed
 
 
@@ -194,7 +196,8 @@ def patch_plan(
         setattr(plan, key, value)
     db.commit()
     refreshed = _eager(db, plan.id)
-    assert refreshed is not None
+    if refreshed is None:
+        raise HTTPException(status_code=500, detail="Plan vanished after commit")
     return refreshed
 
 
@@ -249,7 +252,8 @@ def chat_refine(
 
     db.commit()
     refreshed = _eager(db, plan.id)
-    assert refreshed is not None
+    if refreshed is None:
+        raise HTTPException(status_code=500, detail="Plan vanished after commit")
     return PlanChatResponse(
         reply=result.reply,
         updated=bool(result.slots),

--- a/backend/app/api/plans.py
+++ b/backend/app/api/plans.py
@@ -30,7 +30,7 @@ from app.agents.planner import (
     refine_plan,
 )
 from app.ai.content import generate_post
-from app.db import get_session
+from app.db import get_current_profile, get_session
 from app.db.models import (
     BusinessProfile,
     ContentPlan,
@@ -67,7 +67,7 @@ def _eager(db: Session, plan_id: int) -> ContentPlan | None:
 
 
 def _require_profile(db: Session) -> BusinessProfile:
-    bp = db.query(BusinessProfile).order_by(BusinessProfile.id.asc()).first()
+    bp = get_current_profile(db)
     if bp is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/app/api/posts.py
+++ b/backend/app/api/posts.py
@@ -76,9 +76,10 @@ def create_post(payload: PostIn, db: Session = Depends(get_session)) -> Post:
     post = Post(**payload.model_dump(), status=PostStatus.DRAFT)
     db.add(post)
     db.commit()
-    post = _eager_load(db, post.id)
-    assert post is not None
-    return post
+    refreshed = _eager_load(db, post.id)
+    if refreshed is None:
+        raise HTTPException(status_code=500, detail="Post vanished after commit")
+    return refreshed
 
 
 @router.patch("/{post_id}", response_model=PostOut)
@@ -94,7 +95,8 @@ def patch_post(
         setattr(post, key, value)
     db.commit()
     refreshed = _eager_load(db, post.id)
-    assert refreshed is not None
+    if refreshed is None:
+        raise HTTPException(status_code=500, detail="Post vanished after commit")
     return refreshed
 
 
@@ -162,7 +164,8 @@ def generate(
     db.add(post)
     db.commit()
     refreshed = _eager_load(db, post.id)
-    assert refreshed is not None
+    if refreshed is None:
+        raise HTTPException(status_code=500, detail="Post vanished after commit")
     return refreshed
 
 
@@ -298,7 +301,8 @@ async def publish_now(
     db.commit()
 
     refreshed = _eager_load(db, post.id)
-    assert refreshed is not None
+    if refreshed is None:
+        raise HTTPException(status_code=500, detail="Post vanished after commit")
     return PublishResultOut(
         post_id=refreshed.id,
         status=refreshed.status,
@@ -346,7 +350,8 @@ def schedule(
     db.commit()
 
     refreshed = _eager_load(db, post.id)
-    assert refreshed is not None
+    if refreshed is None:
+        raise HTTPException(status_code=500, detail="Post vanished after commit")
     return refreshed
 
 
@@ -416,7 +421,8 @@ def approve_post(
     profile = db.query(BusinessProfile).order_by(BusinessProfile.id.asc()).first()
     _approve_single(db, post, payload.target_ids, payload.scheduled_for, profile)
     refreshed = _eager_load(db, post.id)
-    assert refreshed is not None
+    if refreshed is None:
+        raise HTTPException(status_code=500, detail="Post vanished after commit")
     return refreshed
 
 
@@ -442,7 +448,8 @@ def reject_post(
         post.generation_prompt = (existing + f"\n[REJECTED] {payload.reason}").strip()
     db.commit()
     refreshed = _eager_load(db, post.id)
-    assert refreshed is not None
+    if refreshed is None:
+        raise HTTPException(status_code=500, detail="Post vanished after commit")
     return refreshed
 
 
@@ -487,7 +494,8 @@ def regenerate_post(
         post.generation_cost_usd += img.cost_usd
     db.commit()
     refreshed = _eager_load(db, post.id)
-    assert refreshed is not None
+    if refreshed is None:
+        raise HTTPException(status_code=500, detail="Post vanished after commit")
     return refreshed
 
 

--- a/backend/app/api/posts.py
+++ b/backend/app/api/posts.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import Session, selectinload
 
 from app.ai.content import generate_post, generate_spintax_variant
 from app.ai.image import generate_image
-from app.db import get_session
+from app.db import get_current_profile, get_session
 from app.db.models import (
     BusinessProfile,
     Post,
@@ -114,7 +114,7 @@ def generate(
     payload: PostGenerate,
     db: Session = Depends(get_session),
 ) -> Post:
-    profile = db.query(BusinessProfile).order_by(BusinessProfile.id.asc()).first()
+    profile = get_current_profile(db)
     if profile is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -266,7 +266,7 @@ async def publish_now(
         if not target_ids:
             raise HTTPException(status_code=400, detail="No active targets. Add some first.")
 
-    profile = db.query(BusinessProfile).order_by(BusinessProfile.id.asc()).first()
+    profile = get_current_profile(db)
 
     variants = _ensure_variants(
         db,
@@ -338,7 +338,7 @@ def schedule(
 
     humanizer_profile = hz.get_or_create_profile(db)
     post.scheduled_for = hz.apply_schedule_jitter(payload.scheduled_for, humanizer_profile)
-    profile = db.query(BusinessProfile).order_by(BusinessProfile.id.asc()).first()
+    profile = get_current_profile(db)
     _ensure_variants(
         db,
         post,
@@ -418,7 +418,7 @@ def approve_post(
     post = _eager_load(db, post_id)
     if post is None:
         raise HTTPException(status_code=404, detail="Post not found")
-    profile = db.query(BusinessProfile).order_by(BusinessProfile.id.asc()).first()
+    profile = get_current_profile(db)
     _approve_single(db, post, payload.target_ids, payload.scheduled_for, profile)
     refreshed = _eager_load(db, post.id)
     if refreshed is None:
@@ -467,7 +467,7 @@ def regenerate_post(
             status_code=409,
             detail="Only PENDING_REVIEW / DRAFT posts can be regenerated.",
         )
-    profile = db.query(BusinessProfile).order_by(BusinessProfile.id.asc()).first()
+    profile = get_current_profile(db)
     if profile is None:
         raise HTTPException(status_code=400, detail="Business profile required.")
 
@@ -508,7 +508,7 @@ def approve_all(
     if payload.post_type is not None:
         q = q.filter(Post.post_type == payload.post_type)
     pending = q.all()
-    profile = db.query(BusinessProfile).order_by(BusinessProfile.id.asc()).first()
+    profile = get_current_profile(db)
     approved: list[Post] = []
     for post in pending:
         _approve_single(db, post, [], payload.scheduled_for, profile)

--- a/backend/app/api/targets.py
+++ b/backend/app/api/targets.py
@@ -18,7 +18,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from app.agents.targets import cluster_targets, score_targets
-from app.db import get_session
+from app.db import get_current_profile, get_session
 from app.db.models import BusinessProfile, Target, TargetReviewStatus
 from app.platforms.facebook import FacebookPlatform
 from app.schemas import (
@@ -42,7 +42,7 @@ router = APIRouter(prefix="/api/targets", tags=["targets"])
 
 
 def _require_profile(db: Session) -> BusinessProfile:
-    profile = db.query(BusinessProfile).first()
+    profile = get_current_profile(db)
     if profile is None:
         raise HTTPException(
             status_code=400,

--- a/backend/app/db/__init__.py
+++ b/backend/app/db/__init__.py
@@ -1,3 +1,15 @@
-from app.db.session import SessionLocal, get_session, init_db
+from app.db.session import (
+    SessionLocal,
+    get_current_profile,
+    get_session,
+    init_db,
+    invalidate_profile_cache,
+)
 
-__all__ = ["SessionLocal", "get_session", "init_db"]
+__all__ = [
+    "SessionLocal",
+    "get_current_profile",
+    "get_session",
+    "init_db",
+    "invalidate_profile_cache",
+]

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -210,8 +210,8 @@ class PostVariant(Base):
     __tablename__ = "post_variants"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    post_id: Mapped[int] = mapped_column(ForeignKey("posts.id"))
-    target_id: Mapped[int] = mapped_column(ForeignKey("targets.id"))
+    post_id: Mapped[int] = mapped_column(ForeignKey("posts.id"), index=True)
+    target_id: Mapped[int] = mapped_column(ForeignKey("targets.id"), index=True)
     text: Mapped[str] = mapped_column(Text)
     status: Mapped[PostStatus] = mapped_column(Enum(PostStatus), default=PostStatus.SCHEDULED)
     scheduled_for: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
@@ -227,7 +227,7 @@ class Feedback(Base):
     __tablename__ = "feedback"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    post_id: Mapped[int] = mapped_column(ForeignKey("posts.id"))
+    post_id: Mapped[int] = mapped_column(ForeignKey("posts.id"), index=True)
     rating: Mapped[FeedbackRating] = mapped_column(Enum(FeedbackRating))
     comment: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -1,11 +1,14 @@
 """Database session factory. Sync for simplicity — we're local, low-volume."""
+import time
 from pathlib import Path
+from threading import Lock
 
-from sqlalchemy import create_engine
+from fastapi import Depends
+from sqlalchemy import create_engine, event
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.config import settings
-from app.db.models import Base
+from app.db.models import Base, BusinessProfile
 
 # Ensure data dir exists for SQLite
 if settings.db_url.startswith("sqlite"):
@@ -14,6 +17,27 @@ if settings.db_url.startswith("sqlite"):
 
 engine = create_engine(settings.db_url, echo=False, future=True)
 SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+
+# SQLite: WAL lets readers and writers run concurrently (default `DELETE` mode
+# serializes everything through one lock). `synchronous=NORMAL` pairs with WAL
+# and is safe for our single-host workload — we lose only the last ~200 ms of
+# writes on OS crash, never corruption. `foreign_keys=ON` enforces the FKs we
+# declared; SQLite ignores them by default.
+@event.listens_for(engine, "connect")
+def _sqlite_pragma(dbapi_conn, _conn_record):
+    if not settings.db_url.startswith("sqlite"):
+        return
+    # In-memory SQLite (":memory:" / "sqlite://") doesn't support WAL.
+    is_memory = settings.db_url in ("sqlite://", "sqlite:///:memory:")
+    cur = dbapi_conn.cursor()
+    try:
+        if not is_memory:
+            cur.execute("PRAGMA journal_mode=WAL")
+            cur.execute("PRAGMA synchronous=NORMAL")
+        cur.execute("PRAGMA foreign_keys=ON")
+    finally:
+        cur.close()
 
 
 def init_db() -> None:
@@ -28,3 +52,56 @@ def get_session() -> Session:
         yield db
     finally:
         db.close()
+
+
+# ---------- BusinessProfile cache ----------
+#
+# Every /api/* request used to do `db.query(BusinessProfile).order_by(id).first()`
+# — about 14 call sites. We cache the PK for 60 s so follow-up requests do a
+# cheap `db.get()` (hits the session identity map or a primary-key index)
+# instead of an ORDER BY scan. The cache holds the ID only, NOT the ORM
+# object, so we don't fight with session lifetimes.
+
+_PROFILE_CACHE_TTL = 60.0
+_profile_cache_id: int | None = None
+_profile_cache_at: float = 0.0
+_profile_cache_lock = Lock()
+
+
+def _load_current_profile(db: Session) -> BusinessProfile | None:
+    """Do the full ORDER BY query and refresh the cache."""
+    global _profile_cache_id, _profile_cache_at
+    profile = (
+        db.query(BusinessProfile).order_by(BusinessProfile.id.asc()).first()
+    )
+    with _profile_cache_lock:
+        _profile_cache_id = profile.id if profile is not None else None
+        _profile_cache_at = time.monotonic()
+    return profile
+
+
+def get_current_profile(db: Session = Depends(get_session)) -> BusinessProfile | None:
+    """Return the single BusinessProfile row, or None if none exists.
+
+    Usable as a FastAPI dependency (`profile: BusinessProfile | None = Depends(...)`)
+    or called directly with a session. Profile lookups hit a 60-second PK
+    cache to avoid repeated ORDER BY scans.
+    """
+    now = time.monotonic()
+    with _profile_cache_lock:
+        cached_id = _profile_cache_id
+        fresh = cached_id is not None and now - _profile_cache_at < _PROFILE_CACHE_TTL
+    if fresh:
+        hit = db.get(BusinessProfile, cached_id)
+        if hit is not None:
+            return hit
+        # Row disappeared under us — fall through to reload.
+    return _load_current_profile(db)
+
+
+def invalidate_profile_cache() -> None:
+    """Clear the cached ID — call after creating / patching the profile."""
+    global _profile_cache_id, _profile_cache_at
+    with _profile_cache_lock:
+        _profile_cache_id = None
+        _profile_cache_at = 0.0

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,10 +15,12 @@ import logging
 from contextlib import asynccontextmanager
 from pathlib import Path
 
-from fastapi import FastAPI, Response, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, Request, Response, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 
+from app.agents import MalformedLLMResponse
 from app.api import api_router
 from app.config import settings
 from app.db import init_db
@@ -72,6 +74,16 @@ app.mount("/static", StaticFiles(directory="data"), name="static")
 app.include_router(api_router)
 
 
+@app.exception_handler(MalformedLLMResponse)
+async def _malformed_llm_handler(request: Request, exc: MalformedLLMResponse) -> JSONResponse:
+    """LLM returned something we couldn't parse — treat as upstream (502)."""
+    log.warning("Malformed LLM response on %s: %s", request.url.path, exc)
+    return JSONResponse(
+        status_code=502,
+        content={"detail": "Upstream LLM returned malformed output. Try again."},
+    )
+
+
 @app.get("/metrics", include_in_schema=False)
 def prometheus_metrics() -> Response:
     """Prometheus scrape endpoint. Plain text exposition format."""
@@ -81,9 +93,30 @@ def prometheus_metrics() -> Response:
     )
 
 
+# Allowed Origin prefixes for /ws/ext. Only the Chrome extension (or a local
+# dev tool explicitly connecting without an Origin header, e.g. curl/websocat
+# during debugging) should ever reach this endpoint — any browser page would
+# send its own Origin header and must not be able to drive the bridge.
+_WS_ALLOWED_ORIGIN_PREFIXES = ("chrome-extension://", "moz-extension://")
+
+
+def _ws_origin_allowed(origin: str) -> bool:
+    if not origin:
+        # No Origin header — typically non-browser clients (test tools). Allow
+        # these so local debugging stays easy; a malicious browser page cannot
+        # omit Origin.
+        return True
+    return origin.startswith(_WS_ALLOWED_ORIGIN_PREFIXES)
+
+
 @app.websocket("/ws/ext")
 async def extension_ws(socket: WebSocket) -> None:
     """The Chrome extension connects here and we send it commands."""
+    origin = socket.headers.get("origin", "")
+    if not _ws_origin_allowed(origin):
+        log.warning("Rejecting /ws/ext connection from origin %r", origin)
+        await socket.close(code=1008)  # 1008 = policy violation
+        return
     await socket.accept()
     await bridge.attach(socket)
     try:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,10 +24,21 @@ from app.agents import MalformedLLMResponse
 from app.api import api_router
 from app.config import settings
 from app.db import init_db
-from app.observability import RequestContextMiddleware, render_prometheus
+from app.observability import (
+    RequestContextMiddleware,
+    register_gauge_sampler,
+    render_prometheus,
+)
 from app.scheduler import scheduler
 from app.security import DashboardAuthMiddleware
+from app.services import health as health_samplers
 from app.ws.extension_bridge import bridge
+
+# Register live-sampled gauges for /metrics. Must happen at import time so the
+# first scrape after startup already has everything wired.
+register_gauge_sampler(health_samplers.sample_extension_status)
+register_gauge_sampler(health_samplers.sample_backup_age)
+register_gauge_sampler(health_samplers.sample_scheduler_depth)
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(name)s] %(message)s")
 log = logging.getLogger("main")

--- a/backend/app/observability.py
+++ b/backend/app/observability.py
@@ -8,6 +8,12 @@ grep and still parseable with a small awk script.
 - publish_attempts_total{platform,ok}
 - metrics_rows_collected_total
 
+And expose gauges sampled live on each scrape:
+- autoposter_extension_connected       — 0/1 (WS bridge attached?)
+- autoposter_backup_age_seconds        — seconds since newest zip in backup_dir
+- autoposter_scheduler_due_posts       — SCHEDULED posts with past due time
+- autoposter_pending_review_posts      — PENDING_REVIEW count
+
 Counters live in-process; restarting the backend resets them. Good enough for
 a self-hosted tool.
 """
@@ -16,6 +22,7 @@ from __future__ import annotations
 import logging
 import time
 from collections import defaultdict
+from collections.abc import Callable
 from threading import Lock
 
 from fastapi import Request, Response
@@ -51,8 +58,38 @@ def _normalize_path(path: str) -> str:
     return "/".join(parts)
 
 
+# ---------- Gauges (live-sampled) ----------
+#
+# Unlike counters, gauges answer "what's the current value?" so they must be
+# computed at render time. We register sampler callbacks instead of keeping
+# stale values around — scrapes happen rarely enough that a handful of cheap
+# DB lookups on each scrape is fine.
+
+GaugeSample = tuple[str, dict[str, str], float]  # (name, labels, value)
+_samplers: list[Callable[[], list[GaugeSample]]] = []
+
+
+def register_gauge_sampler(fn: Callable[[], list[GaugeSample]]) -> None:
+    """Register a function that returns a list of gauge samples per scrape.
+
+    Samplers must be cheap and NEVER raise — wrap in try/except if they hit
+    IO. If a sampler returns nothing, nothing is emitted for it.
+    """
+    _samplers.append(fn)
+
+
+def _sampled_gauges() -> list[GaugeSample]:
+    out: list[GaugeSample] = []
+    for fn in _samplers:
+        try:
+            out.extend(fn())
+        except Exception:
+            log.exception("Gauge sampler crashed: %s", getattr(fn, "__name__", fn))
+    return out
+
+
 def render_prometheus() -> str:
-    """Emit counters in Prometheus exposition format."""
+    """Emit counters + live-sampled gauges in Prometheus exposition format."""
     lines: list[str] = []
     with _lock:
         for name, bucket in _counters.items():
@@ -63,6 +100,18 @@ def render_prometheus() -> str:
                     lines.append(f"{name}{{{lbl}}} {value}")
                 else:
                     lines.append(f"{name} {value}")
+    # Gauges — grouped by name so we can emit one TYPE line per gauge.
+    grouped: dict[str, list[tuple[dict[str, str], float]]] = defaultdict(list)
+    for name, labels, value in _sampled_gauges():
+        grouped[name].append((labels, value))
+    for name, samples in grouped.items():
+        lines.append(f"# TYPE {name} gauge")
+        for labels, value in samples:
+            if labels:
+                lbl = ",".join(f'{k}="{_escape(v)}"' for k, v in labels)
+                lines.append(f"{name}{{{lbl}}} {value}")
+            else:
+                lines.append(f"{name} {value}")
     return "\n".join(lines) + "\n"
 
 

--- a/backend/app/platforms/meta_graph.py
+++ b/backend/app/platforms/meta_graph.py
@@ -35,27 +35,55 @@ GRAPH_BASE = "https://graph.facebook.com/v21.0"
 THREADS_BASE = "https://graph.threads.net/v1.0"
 
 
+# Meta error codes that indicate rate-limiting / temporary throttling.
+# Reference: https://developers.facebook.com/docs/graph-api/overview/rate-limiting
+_RATE_LIMIT_CODES = {"4", "17", "32", "613"}
+
+
 @dataclass
 class MetaError(Exception):
     status: int
     code: str
     message: str
+    retry_after: int | None = None  # Seconds; None if not rate-limited.
 
     def __str__(self) -> str:
-        return f"[{self.status}/{self.code}] {self.message}"
+        suffix = f" (retry after {self.retry_after}s)" if self.retry_after else ""
+        return f"[{self.status}/{self.code}] {self.message}{suffix}"
+
+
+def _parse_retry_after(resp: httpx.Response) -> int | None:
+    """Read Retry-After. Meta usually sends seconds; occasionally an HTTP-date
+    which we don't bother parsing — treat unparseable as None.
+    """
+    header = resp.headers.get("retry-after")
+    if not header:
+        return None
+    try:
+        return max(0, int(header.strip()))
+    except ValueError:
+        return None
 
 
 def _raise_if_error(resp: httpx.Response) -> dict:
     try:
         data = resp.json()
     except ValueError:
-        raise MetaError(status=resp.status_code, code="invalid_json", message=resp.text[:200])
-    if resp.status_code >= 400 or (isinstance(data, dict) and data.get("error")):
-        err = data.get("error") if isinstance(data, dict) else {}
         raise MetaError(
             status=resp.status_code,
-            code=str(err.get("code", "unknown")) if err else "http_error",
+            code="invalid_json",
+            message=resp.text[:200],
+            retry_after=_parse_retry_after(resp) if resp.status_code == 429 else None,
+        )
+    if resp.status_code >= 400 or (isinstance(data, dict) and data.get("error")):
+        err = data.get("error") if isinstance(data, dict) else {}
+        code = str(err.get("code", "unknown")) if err else "http_error"
+        is_rate_limited = resp.status_code == 429 or code in _RATE_LIMIT_CODES
+        raise MetaError(
+            status=resp.status_code,
+            code=code,
             message=(err.get("message") if err else None) or resp.text[:300],
+            retry_after=_parse_retry_after(resp) if is_rate_limited else None,
         )
     return data
 

--- a/backend/app/scheduler/jobs.py
+++ b/backend/app/scheduler/jobs.py
@@ -226,12 +226,13 @@ async def weekly_analyst_tick() -> None:
     from datetime import timedelta
 
     from app.agents import analyst
-    from app.db.models import BusinessProfile, PostMetrics
+    from app.db import get_current_profile
+    from app.db.models import PostMetrics
     from app.services import few_shot
 
     db = SessionLocal()
     try:
-        profile = db.query(BusinessProfile).order_by(BusinessProfile.id.asc()).first()
+        profile = get_current_profile(db)
         if profile is None:
             log.info("weekly_analyst_tick: no profile, skipping")
             return

--- a/backend/app/services/health.py
+++ b/backend/app/services/health.py
@@ -1,0 +1,76 @@
+"""Gauge samplers for /metrics.
+
+Each `sample_*` function is called on every Prometheus scrape and returns a
+list of `(gauge_name, labels, value)` tuples. Samplers must be defensive —
+errors are logged in `observability._sampled_gauges` but the scrape still
+succeeds. Keep each one cheap (a single indexed query at most).
+
+Gauges:
+- autoposter_extension_connected       — 0/1, is the WS bridge attached
+- autoposter_backup_age_seconds        — age of the newest .zip in backup_dir
+                                          (or -1 if no backups yet)
+- autoposter_scheduler_due_posts       — SCHEDULED posts whose time has passed
+- autoposter_pending_review_posts      — PENDING_REVIEW queue depth
+"""
+from __future__ import annotations
+
+import glob
+import logging
+import os
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+from sqlalchemy import func
+
+from app.config import settings
+from app.db import session as db_session
+from app.db.models import Post, PostStatus
+from app.observability import GaugeSample
+from app.ws.extension_bridge import bridge
+
+log = logging.getLogger("health")
+
+
+def sample_extension_status() -> list[GaugeSample]:
+    return [("autoposter_extension_connected", {}, 1.0 if bridge.connected else 0.0)]
+
+
+def sample_backup_age() -> list[GaugeSample]:
+    backup_dir = Path(settings.backup_dir)
+    if not backup_dir.exists():
+        return [("autoposter_backup_age_seconds", {}, -1.0)]
+    zips = glob.glob(str(backup_dir / "*.zip"))
+    if not zips:
+        return [("autoposter_backup_age_seconds", {}, -1.0)]
+    newest = max(os.path.getmtime(p) for p in zips)
+    age = max(0.0, time.time() - newest)
+    return [("autoposter_backup_age_seconds", {}, age)]
+
+
+def sample_scheduler_depth() -> list[GaugeSample]:
+    """Count SCHEDULED posts due now, plus PENDING_REVIEW backlog."""
+    now = datetime.now(UTC)
+    # Late-bind SessionLocal so tests that monkeypatch it are respected.
+    db = db_session.SessionLocal()
+    try:
+        due = (
+            db.query(func.count(Post.id))
+            .filter(Post.status == PostStatus.SCHEDULED)
+            .filter(Post.scheduled_for.isnot(None))
+            .filter(Post.scheduled_for <= now)
+            .scalar()
+            or 0
+        )
+        pending = (
+            db.query(func.count(Post.id))
+            .filter(Post.status == PostStatus.PENDING_REVIEW)
+            .scalar()
+            or 0
+        )
+        return [
+            ("autoposter_scheduler_due_posts", {}, float(due)),
+            ("autoposter_pending_review_posts", {}, float(pending)),
+        ]
+    finally:
+        db.close()

--- a/backend/tests/test_phase1_reliability.py
+++ b/backend/tests/test_phase1_reliability.py
@@ -1,0 +1,234 @@
+"""Phase 1 reliability/perf additions.
+
+- FK indexes exist on post_variants / feedback.
+- BusinessProfile cache: second call is a PK lookup, not an ORDER BY scan.
+  Invalidation wipes the cache so mutations are immediately visible.
+- `/metrics` emits the new gauges and the scheduler depth reflects DB state.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+from sqlalchemy import inspect
+
+from app.db.models import Base, Post, PostStatus, PostType
+
+
+# ---------- FK indexes ----------
+
+
+def test_post_variant_fks_have_indexes(engine):
+    ins = inspect(engine)
+    idx_cols = {tuple(i["column_names"]) for i in ins.get_indexes("post_variants")}
+    assert ("post_id",) in idx_cols
+    assert ("target_id",) in idx_cols
+
+
+def test_feedback_post_id_has_index(engine):
+    ins = inspect(engine)
+    idx_cols = {tuple(i["column_names"]) for i in ins.get_indexes("feedback")}
+    assert ("post_id",) in idx_cols
+
+
+# ---------- BusinessProfile cache ----------
+
+
+@pytest.fixture()
+def _reset_profile_cache():
+    from app.db import invalidate_profile_cache
+
+    invalidate_profile_cache()
+    yield
+    invalidate_profile_cache()
+
+
+def test_profile_cache_returns_same_row_on_repeat_calls(db, _reset_profile_cache):
+    from app.db import get_current_profile
+    from app.db.models import BusinessProfile, Tone
+
+    bp = BusinessProfile(name="x", description="desc", tone=Tone.CASUAL)
+    db.add(bp)
+    db.commit()
+
+    a = get_current_profile(db)
+    b = get_current_profile(db)
+    assert a is not None and b is not None
+    assert a.id == b.id
+
+
+def test_profile_cache_skips_order_by_after_warm_up(
+    db, _reset_profile_cache, monkeypatch
+):
+    """Warm the cache with one call, then spy on db.query: a PK hit shouldn't
+    go through db.query(BusinessProfile).
+    """
+    from app.db import get_current_profile
+    from app.db.models import BusinessProfile, Tone
+
+    bp = BusinessProfile(name="x", description="desc", tone=Tone.CASUAL)
+    db.add(bp)
+    db.commit()
+
+    # First call warms cache.
+    get_current_profile(db)
+
+    # Replace db.query with a spy that records calls.
+    calls: list[type] = []
+    original_query = db.query
+
+    def _spy(entity):
+        calls.append(entity)
+        return original_query(entity)
+
+    monkeypatch.setattr(db, "query", _spy)
+
+    # Cache hit path should use db.get(), not db.query(BusinessProfile).
+    get_current_profile(db)
+    assert BusinessProfile not in calls
+
+
+def test_profile_cache_invalidation_sees_new_row(db, _reset_profile_cache):
+    from app.db import get_current_profile, invalidate_profile_cache
+    from app.db.models import BusinessProfile, Tone
+
+    first = BusinessProfile(name="first", description="a", tone=Tone.CASUAL)
+    db.add(first)
+    db.commit()
+    cached = get_current_profile(db)
+    assert cached.name == "first"
+
+    # Nuke the row and insert a different one. Without invalidation the cache
+    # would keep returning the stale ID (and a fresh db.get would miss).
+    db.delete(first)
+    db.commit()
+    second = BusinessProfile(name="second", description="b", tone=Tone.CASUAL)
+    db.add(second)
+    db.commit()
+    invalidate_profile_cache()
+
+    refreshed = get_current_profile(db)
+    assert refreshed is not None
+    assert refreshed.name == "second"
+
+
+def test_profile_cache_handles_no_profile(db, _reset_profile_cache):
+    from app.db import get_current_profile
+
+    assert get_current_profile(db) is None
+    # Second call also returns None without blowing up.
+    assert get_current_profile(db) is None
+
+
+def test_upsert_profile_invalidates_cache(client, _reset_profile_cache):
+    payload = {
+        "name": "biz",
+        "description": "desc",
+        "tone": "casual",
+        "length": "medium",
+        "emoji_density": "light",
+        "language": "en",
+        "post_type_ratios": {},
+        "posting_window_start_hour": 9,
+        "posting_window_end_hour": 20,
+        "timezone": "UTC",
+        "posts_per_day": 3,
+        "review_before_posting": True,
+        "auto_approve_types": [],
+    }
+    r = client.put("/api/business-profile", json=payload)
+    assert r.status_code == 200
+
+    # PATCH a field and confirm the GET sees it even though cache was hot.
+    payload["name"] = "updated"
+    r = client.put("/api/business-profile", json=payload)
+    assert r.status_code == 200
+    r = client.get("/api/business-profile")
+    assert r.status_code == 200
+    assert r.json()["name"] == "updated"
+
+
+# ---------- Health gauges ----------
+
+
+def _seed_post(db, status: PostStatus, scheduled_for=None) -> Post:
+    p = Post(
+        post_type=PostType.INFORMATIVE,
+        status=status,
+        text="hi",
+        scheduled_for=scheduled_for,
+    )
+    db.add(p)
+    db.commit()
+    return p
+
+
+def test_metrics_exposes_health_gauges(client):
+    r = client.get("/metrics")
+    assert r.status_code == 200
+    body = r.text
+    assert "autoposter_extension_connected" in body
+    assert "autoposter_backup_age_seconds" in body
+    assert "autoposter_scheduler_due_posts" in body
+    assert "autoposter_pending_review_posts" in body
+
+
+def test_scheduler_depth_counts_due_posts(client, db):
+    from datetime import UTC, datetime, timedelta
+
+    past = datetime.now(UTC) - timedelta(minutes=5)
+    future = datetime.now(UTC) + timedelta(hours=1)
+    _seed_post(db, PostStatus.SCHEDULED, scheduled_for=past)
+    _seed_post(db, PostStatus.SCHEDULED, scheduled_for=past)
+    _seed_post(db, PostStatus.SCHEDULED, scheduled_for=future)  # not due yet
+    _seed_post(db, PostStatus.PENDING_REVIEW)
+
+    body = client.get("/metrics").text
+    assert "autoposter_scheduler_due_posts 2.0" in body
+    assert "autoposter_pending_review_posts 1.0" in body
+
+
+def test_backup_age_gauge_reports_minus_one_when_empty(client, tmp_path, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "backup_dir", str(tmp_path / "nope"), raising=False)
+    body = client.get("/metrics").text
+    assert "autoposter_backup_age_seconds -1.0" in body
+
+
+def test_backup_age_gauge_reports_file_age(client, tmp_path, monkeypatch):
+    from app.config import settings
+
+    backup_dir = tmp_path / "backups"
+    backup_dir.mkdir()
+    f = backup_dir / "snap.zip"
+    f.write_bytes(b"x")
+    # Backdate 10 seconds.
+    ten_s_ago = time.time() - 10
+    import os
+    os.utime(f, (ten_s_ago, ten_s_ago))
+
+    monkeypatch.setattr(settings, "backup_dir", str(backup_dir), raising=False)
+    body = client.get("/metrics").text
+    # Parse the line and assert age is at least 9 seconds (race-safe).
+    for line in body.splitlines():
+        if line.startswith("autoposter_backup_age_seconds "):
+            value = float(line.split()[1])
+            assert value >= 9
+            break
+    else:
+        pytest.fail("autoposter_backup_age_seconds not found in /metrics output")
+
+
+def test_extension_connected_gauge_zero_by_default(client):
+    body = client.get("/metrics").text
+    # The test client never opens /ws/ext, so the bridge reports disconnected.
+    # (Some prior test may have connected, so we just check the label exists
+    # and is 0 OR 1 — mostly ensuring the gauge is wired.)
+    found = False
+    for line in body.splitlines():
+        if line.startswith("autoposter_extension_connected "):
+            value = float(line.split()[1])
+            assert value in (0.0, 1.0)
+            found = True
+    assert found

--- a/backend/tests/test_review_fixes.py
+++ b/backend/tests/test_review_fixes.py
@@ -1,0 +1,292 @@
+"""Regression tests for the review-main-build fix set.
+
+- /api/auth/login rate-limits after N failed attempts.
+- WebSocket /ws/ext rejects browser-page Origins.
+- Gemini image generation surfaces a clean error on empty/missing candidates.
+- Agent `_extract_json` wraps JSONDecodeError as MalformedLLMResponse.
+- Meta Graph `_raise_if_error` populates `retry_after` on 429 / throttling codes.
+- Posts/plans endpoints no longer rely on `assert`.
+"""
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from app.agents import MalformedLLMResponse
+
+
+# ---------- Login rate-limit ----------
+
+
+@pytest.fixture()
+def _reset_login_failures():
+    from app.api import auth as auth_mod
+
+    auth_mod._login_failures.clear()
+    yield
+    auth_mod._login_failures.clear()
+
+
+def test_login_rate_limited_after_five_failures(client, monkeypatch, _reset_login_failures):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "dashboard_pin", "1234", raising=False)
+    for _ in range(5):
+        r = client.post("/api/auth/login", json={"pin": "wrong"})
+        assert r.status_code == 401
+    r = client.post("/api/auth/login", json={"pin": "wrong"})
+    assert r.status_code == 429
+    assert "Retry-After" in r.headers
+
+
+def test_login_success_does_not_count_towards_limit(
+    client, monkeypatch, _reset_login_failures
+):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "dashboard_pin", "1234", raising=False)
+    for _ in range(10):
+        r = client.post("/api/auth/login", json={"pin": "1234"})
+        assert r.status_code == 200
+
+
+# ---------- WebSocket Origin check ----------
+
+
+def test_ws_rejects_browser_origin(client):
+    from starlette.websockets import WebSocketDisconnect
+
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with client.websocket_connect(
+            "/ws/ext", headers={"origin": "http://evil.example"}
+        ):
+            pass
+    assert exc_info.value.code == 1008
+
+
+def test_ws_accepts_chrome_extension_origin(client):
+    with client.websocket_connect(
+        "/ws/ext", headers={"origin": "chrome-extension://abcdef"}
+    ) as ws:
+        ws.close()
+
+
+def test_ws_accepts_missing_origin_for_cli_tools(client):
+    # Non-browser clients (tests, websocat) have no Origin — must pass through
+    # so local dev is painless.
+    with client.websocket_connect("/ws/ext") as ws:
+        ws.close()
+
+
+# ---------- Gemini image error handling ----------
+
+
+def test_generate_image_raises_when_no_candidates(monkeypatch):
+    from app.ai import image as image_mod
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "gemini_api_key", "x", raising=False)
+    monkeypatch.setattr(settings, "enable_image_gen", True, raising=False)
+
+    class _FakeClient:
+        def __init__(self, *a, **kw):
+            self.models = SimpleNamespace(
+                generate_content=lambda *a, **kw: SimpleNamespace(candidates=[])
+            )
+
+    monkeypatch.setattr(image_mod.genai, "Client", _FakeClient)
+    with pytest.raises(RuntimeError, match="no candidates"):
+        image_mod.generate_image("post text", "biz", "casual")
+
+
+def test_generate_image_raises_when_parts_have_no_inline_data(monkeypatch):
+    from app.ai import image as image_mod
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "gemini_api_key", "x", raising=False)
+    monkeypatch.setattr(settings, "enable_image_gen", True, raising=False)
+
+    fake_response = SimpleNamespace(
+        candidates=[
+            SimpleNamespace(
+                content=SimpleNamespace(parts=[SimpleNamespace(inline_data=None)])
+            )
+        ]
+    )
+
+    class _FakeClient:
+        def __init__(self, *a, **kw):
+            self.models = SimpleNamespace(
+                generate_content=lambda *a, **kw: fake_response
+            )
+
+    monkeypatch.setattr(image_mod.genai, "Client", _FakeClient)
+    with pytest.raises(RuntimeError, match="no image data"):
+        image_mod.generate_image("post text", "biz", "casual")
+
+
+# ---------- Agent _extract_json ----------
+
+
+def test_planner_extract_json_wraps_malformed():
+    from app.agents.planner import _extract_json
+
+    # Contains { and }, so passes the "found JSON object" check, but is not
+    # valid JSON — must now raise MalformedLLMResponse rather than bubble up
+    # json.JSONDecodeError.
+    with pytest.raises(MalformedLLMResponse, match="malformed JSON"):
+        _extract_json('{"slots": [unterminated}')
+
+
+def test_analyst_extract_json_wraps_malformed():
+    from app.agents.analyst import _extract_json
+
+    with pytest.raises(MalformedLLMResponse, match="malformed JSON"):
+        _extract_json('```json\n{"a": ,}\n```')
+
+
+def test_targets_extract_json_wraps_malformed():
+    from app.agents.targets import _extract_json
+
+    with pytest.raises(MalformedLLMResponse, match="malformed JSON"):
+        _extract_json('{"bogus": ,}')
+
+
+def test_planner_extract_json_wraps_missing_object():
+    from app.agents.planner import _extract_json
+
+    with pytest.raises(MalformedLLMResponse, match="No JSON object"):
+        _extract_json("no braces here at all")
+
+
+def test_planner_extract_json_parses_valid_payload():
+    from app.agents.planner import _extract_json
+
+    assert _extract_json('```json\n{"slots": []}\n```') == {"slots": []}
+
+
+# ---------- Meta Graph Retry-After parsing ----------
+
+
+def _mock_response(status: int, body: dict | str, headers: dict | None = None) -> httpx.Response:
+    payload = body if isinstance(body, str) else json.dumps(body)
+    return httpx.Response(
+        status_code=status,
+        content=payload.encode(),
+        headers={"content-type": "application/json", **(headers or {})},
+    )
+
+
+def test_meta_error_includes_retry_after_on_429():
+    from app.platforms.meta_graph import MetaError, _raise_if_error
+
+    resp = _mock_response(
+        429,
+        {"error": {"code": 4, "message": "rate limited"}},
+        {"retry-after": "17"},
+    )
+    with pytest.raises(MetaError) as exc_info:
+        _raise_if_error(resp)
+    assert exc_info.value.retry_after == 17
+    assert "17s" in str(exc_info.value)
+
+
+def test_meta_error_includes_retry_after_on_throttle_code_4():
+    from app.platforms.meta_graph import MetaError, _raise_if_error
+
+    resp = _mock_response(
+        200,
+        {"error": {"code": 4, "message": "rate limited"}},
+        {"retry-after": "30"},
+    )
+    with pytest.raises(MetaError) as exc_info:
+        _raise_if_error(resp)
+    assert exc_info.value.retry_after == 30
+
+
+def test_meta_error_no_retry_after_on_generic_400():
+    from app.platforms.meta_graph import MetaError, _raise_if_error
+
+    resp = _mock_response(400, {"error": {"code": 100, "message": "bad field"}})
+    with pytest.raises(MetaError) as exc_info:
+        _raise_if_error(resp)
+    assert exc_info.value.retry_after is None
+
+
+def test_meta_error_handles_missing_retry_after_header():
+    from app.platforms.meta_graph import MetaError, _raise_if_error
+
+    resp = _mock_response(429, {"error": {"code": 4, "message": "nope"}})
+    with pytest.raises(MetaError) as exc_info:
+        _raise_if_error(resp)
+    assert exc_info.value.retry_after is None
+
+
+# ---------- Asserts removed from posts/plans endpoints ----------
+
+
+def test_create_post_returns_object_after_commit(client):
+    # Success path: the create endpoint used to rely on `assert ... is not None`
+    # after commit. Ensure the happy path still returns 201 with the row.
+    r = client.post(
+        "/api/posts",
+        json={"post_type": "informative", "text": "hello world"},
+    )
+    assert r.status_code == 201
+    body = r.json()
+    assert body["text"] == "hello world"
+    assert body["post_type"] == "informative"
+
+
+# ---------- Malformed LLM surfaces as 502 via exception handler ----------
+
+
+def test_malformed_llm_response_maps_to_502(client, monkeypatch):
+    """If an agent raises MalformedLLMResponse inside an endpoint, the
+    app-level handler should return HTTP 502, not 500.
+    """
+    from app.api import plans as plans_api
+    from app.db import session as db_session
+    from app.db.models import BusinessProfile, Tone
+
+    # Seed a profile so `/api/plans/generate` passes `_require_profile`.
+    s = db_session.SessionLocal()
+    try:
+        s.add(
+            BusinessProfile(
+                name="x",
+                description="desc",
+                tone=Tone.CASUAL,
+                posts_per_day=1,
+                post_type_ratios={},
+                auto_approve_types=[],
+                posting_window_start_hour=9,
+                posting_window_end_hour=20,
+            )
+        )
+        s.commit()
+    finally:
+        s.close()
+
+    def _boom(**kwargs):
+        raise MalformedLLMResponse("forced")
+
+    # The endpoint imported `propose_plan` by name — patch the attribute on
+    # `app.api.plans` where the lookup happens.
+    monkeypatch.setattr(plans_api, "propose_plan", _boom)
+
+    r = client.post(
+        "/api/plans/generate",
+        json={
+            "name": "p",
+            "goal": None,
+            "start_date": "2026-04-20T00:00:00Z",
+            "end_date": "2026-04-25T00:00:00Z",
+        },
+    )
+    assert r.status_code == 502
+    assert "malformed" in r.json()["detail"].lower()


### PR DESCRIPTION
## Summary

This PR addresses six critical fixes from the review-main-build cycle and adds Phase 1 reliability/performance improvements. The changes focus on security hardening, error handling, database optimization, and observability.

## Key Changes

### Review-Main-Build Fixes

- **Login rate-limiting**: Added brute-force protection to `/api/auth/login` that throttles after 5 failed attempts per 60 seconds per IP, returning 429 with `Retry-After` header
- **WebSocket Origin validation**: `/ws/ext` now rejects browser-page origins (e.g., `http://evil.example`) while allowing Chrome extension origins and CLI tools without Origin headers
- **Gemini image error handling**: `generate_image()` now surfaces clean `RuntimeError` messages when API returns empty candidates or missing inline data, instead of `AttributeError`
- **Agent JSON parsing**: All three agents (`planner`, `analyst`, `targets`) now wrap `json.JSONDecodeError` as `MalformedLLMResponse` with a new app-level exception handler that returns HTTP 502
- **Meta Graph retry-after**: `_raise_if_error()` now parses `Retry-After` headers and populates `retry_after` field on 429 responses and throttling error codes (4, 17, 32, 613)
- **Removed unsafe asserts**: Posts/plans endpoints replaced `assert` statements with proper `HTTPException` error handling after database commits

### Phase 1 Reliability Features

- **BusinessProfile caching**: Implemented 60-second PK cache to avoid repeated `ORDER BY` scans across ~14 call sites. Cache is invalidated on profile mutations via `invalidate_profile_cache()`
- **Foreign key indexes**: Added indexes on `post_variants(post_id, target_id)` and `feedback(post_id)` for query performance
- **Health gauges**: Added live-sampled Prometheus gauges:
  - `autoposter_extension_connected` — WS bridge connection status
  - `autoposter_backup_age_seconds` — age of newest backup zip
  - `autoposter_scheduler_due_posts` — count of overdue scheduled posts
  - `autoposter_pending_review_posts` — review queue depth
- **SQLite pragmas**: Enabled WAL mode (concurrent readers/writers), `synchronous=NORMAL`, and `foreign_keys=ON` for better concurrency and data integrity

## Implementation Details

- Rate-limiting uses a simple in-memory deque per IP with monotonic time tracking and thread-safe locking
- Profile cache holds only the ID (not ORM objects) to avoid session lifetime conflicts; cache hits use `db.get()` for cheap PK lookups
- Gauge samplers are registered at import time and called on each Prometheus scrape; errors are logged but don't break the scrape
- `MalformedLLMResponse` extends `ValueError` for backward compatibility with existing exception handlers
- All database operations remain synchronous for simplicity in this single-host, low-volume context

## Testing

Comprehensive regression tests added in `test_review_fixes.py` and `test_phase1_reliability.py` covering all fixes and new features.

https://claude.ai/code/session_0134AfB5wht644Tdt6Gad7od