### PR TITLE
Add Phase 2 security & observability: audit logs, JSON formatting

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,29 @@
+name: gitleaks
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  scan:
+    name: Scan for leaked secrets
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so gitleaks can scan the PR diff.
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          # The action reads GITHUB_TOKEN automatically; declaring it keeps
+          # the permission requirement explicit.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Fail the build if any leak is found (default behaviour, but
+          # pinning it so future action updates don't silently switch).
+          GITLEAKS_ENABLE_COMMENTS: "true"
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "true"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,21 @@
+# gitleaks config for autoposter-AI.
+#
+# Starts from the built-in default ruleset (detects generic API keys, AWS,
+# GCP, Slack, etc.) and layers a couple of project-specific ignores so the
+# scanner doesn't cry wolf on intentional dev defaults committed to .env.example.
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Intentional dev-only placeholders and example values."
+paths = [
+  '''\.env\.example''',
+  '''docs/.*\.md''',
+  '''README\.md''',
+]
+regexes = [
+  # 44-char urlsafe base64 Fernet keys literally named as placeholders in docs.
+  '''FERNET_KEY=<.*>''',
+  '''FERNET_KEY=your-?.*''',
+]

--- a/backend/app/api/meta_oauth.py
+++ b/backend/app/api/meta_oauth.py
@@ -33,6 +33,7 @@ from app.schemas import (
     MetaOAuthUrlOut,
     PlatformCredentialOut,
 )
+from app.services.audit import audit_event
 
 log = logging.getLogger("api.meta_oauth")
 
@@ -68,7 +69,9 @@ def _upsert_credential(
         )
         .one_or_none()
     )
-    if row is None:
+    is_new = row is None
+    changed: list[str] = []
+    if is_new:
         row = PlatformCredential(
             platform_id=platform_id,
             account_id=account_id,
@@ -78,13 +81,25 @@ def _upsert_credential(
         )
         db.add(row)
     else:
-        row.access_token = access_token
-        if username:
+        if row.access_token_encrypted != access_token:
+            row.access_token = access_token
+            changed.append("access_token")
+        if username and row.username != username:
             row.username = username
-        if extra is not None:
+            changed.append("username")
+        if extra is not None and row.extra != extra:
             row.extra = extra
+            changed.append("extra")
     db.commit()
     db.refresh(row)
+    audit_event(
+        "created" if is_new else "updated",
+        "platform_credential",
+        credential_id=row.id,
+        platform_id=platform_id,
+        account_id=account_id,
+        changed_fields=None if is_new else changed,
+    )
     return row
 
 

--- a/backend/app/api/platform_credentials.py
+++ b/backend/app/api/platform_credentials.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 from app.db import get_session
 from app.db.models import PlatformCredential
 from app.schemas import PlatformCredentialOut
+from app.services.audit import audit_event
 
 router = APIRouter(prefix="/api/platform-credentials", tags=["platforms"])
 
@@ -30,5 +31,14 @@ def delete_credential(credential_id: int, db: Session = Depends(get_session)) ->
     row = db.get(PlatformCredential, credential_id)
     if row is None:
         raise HTTPException(status_code=404, detail="Credential not found")
+    platform_id = row.platform_id
+    account_id = row.account_id
     db.delete(row)
     db.commit()
+    audit_event(
+        "deleted",
+        "platform_credential",
+        credential_id=credential_id,
+        platform_id=platform_id,
+        account_id=account_id,
+    )

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -64,5 +64,9 @@ class Settings(BaseSettings):
     backup_dir: str = "data/backups"
     backup_keep_days: int = 14
 
+    # Observability — emit logs as JSON (for aggregators / shipping to a file
+    # sink). Default off so local dev keeps the human-readable format.
+    log_json: bool = False
+
 
 settings = Settings()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -26,6 +26,7 @@ from app.config import settings
 from app.db import init_db
 from app.observability import (
     RequestContextMiddleware,
+    configure_logging,
     register_gauge_sampler,
     render_prometheus,
 )
@@ -40,7 +41,7 @@ register_gauge_sampler(health_samplers.sample_extension_status)
 register_gauge_sampler(health_samplers.sample_backup_age)
 register_gauge_sampler(health_samplers.sample_scheduler_depth)
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(name)s] %(message)s")
+configure_logging(json_output=settings.log_json, level=logging.INFO)
 log = logging.getLogger("main")
 
 

--- a/backend/app/observability.py
+++ b/backend/app/observability.py
@@ -1,7 +1,9 @@
 """Observability helpers — request IDs, access log, Prometheus-ish metrics.
 
-No external deps. Structured logs are pipe-separated key=value pairs; easy to
-grep and still parseable with a small awk script.
+Logs: when `settings.log_json` is set, each record is emitted as one JSON
+object per line (`ts`, `level`, `logger`, `message`, plus any extras like
+`request_id`, `method`, `path`, `status`, `ms`, `event`, `user_action`).
+Default is the human-readable `asctime [logger] message` format for local dev.
 
 `/metrics` returns a Prometheus exposition-format text body. We count:
 - http_requests_total{path,method,status}
@@ -19,10 +21,12 @@ a self-hosted tool.
 """
 from __future__ import annotations
 
+import json
 import logging
 import time
 from collections import defaultdict
 from collections.abc import Callable
+from datetime import UTC, datetime
 from threading import Lock
 
 from fastapi import Request, Response
@@ -31,6 +35,65 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from app.security import new_request_id
 
 log = logging.getLogger("http")
+
+
+# ---------- JSON log formatter ----------
+#
+# Anything a caller passes via `extra={...}` ends up as an attribute on the
+# LogRecord; we scoop those into the JSON payload. `_LOG_RECORD_STD_ATTRS` is
+# the allowlist of stdlib attributes we skip — everything else is
+# caller-provided.
+_LOG_RECORD_STD_ATTRS = frozenset(
+    {
+        "args", "asctime", "created", "exc_info", "exc_text", "filename",
+        "funcName", "levelname", "levelno", "lineno", "message", "module",
+        "msecs", "msg", "name", "pathname", "process", "processName",
+        "relativeCreated", "stack_info", "thread", "threadName", "taskName",
+    }
+)
+
+
+class JsonFormatter(logging.Formatter):
+    """Render a LogRecord as a single-line JSON object."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, object] = {
+            "ts": datetime.fromtimestamp(record.created, UTC).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        for key, value in record.__dict__.items():
+            if key in _LOG_RECORD_STD_ATTRS or key.startswith("_") or key in payload:
+                continue
+            try:
+                json.dumps(value)
+                payload[key] = value
+            except TypeError:
+                payload[key] = repr(value)
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(payload, ensure_ascii=False)
+
+
+def configure_logging(json_output: bool, level: int = logging.INFO) -> None:
+    """Wire up the root logger. Called once from main.py at startup.
+
+    Idempotent: wipes existing handlers so re-running (e.g. uvicorn reload or
+    pytest re-import) doesn't double-emit every line.
+    """
+    root = logging.getLogger()
+    root.setLevel(level)
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+    handler = logging.StreamHandler()
+    if json_output:
+        handler.setFormatter(JsonFormatter())
+    else:
+        handler.setFormatter(
+            logging.Formatter("%(asctime)s [%(name)s] %(message)s")
+        )
+    root.addHandler(handler)
 
 
 # ---------- Counters ----------
@@ -123,28 +186,38 @@ def _escape(v: str) -> str:
 
 
 class RequestContextMiddleware(BaseHTTPMiddleware):
-    """Attaches a request_id to each request/response; logs access line."""
+    """Attaches a request_id to each request/response; logs access line.
+
+    Access records carry structured extras so that when `LOG_JSON=true` each
+    line is machine-parseable without regex: `request_id`, `method`, `path`,
+    `status`, `ms`.
+    """
 
     async def dispatch(self, request: Request, call_next):
         rid = request.headers.get("X-Request-ID") or new_request_id()
         start = time.perf_counter()
         request.state.request_id = rid
+        method = request.method
+        path = request.url.path
         try:
             response: Response = await call_next(request)
         except Exception:
             duration = (time.perf_counter() - start) * 1000
             log.exception(
-                "rid=%s method=%s path=%s status=500 ms=%.1f",
-                rid,
-                request.method,
-                request.url.path,
-                duration,
+                "request failed",
+                extra={
+                    "request_id": rid,
+                    "method": method,
+                    "path": path,
+                    "status": 500,
+                    "ms": round(duration, 1),
+                },
             )
             counter_inc(
                 "http_requests_total",
                 {
-                    "path": _normalize_path(request.url.path),
-                    "method": request.method,
+                    "path": _normalize_path(path),
+                    "method": method,
                     "status": "500",
                 },
             )
@@ -152,18 +225,20 @@ class RequestContextMiddleware(BaseHTTPMiddleware):
         duration = (time.perf_counter() - start) * 1000
         response.headers["X-Request-ID"] = rid
         log.info(
-            "rid=%s method=%s path=%s status=%d ms=%.1f",
-            rid,
-            request.method,
-            request.url.path,
-            response.status_code,
-            duration,
+            "request completed",
+            extra={
+                "request_id": rid,
+                "method": method,
+                "path": path,
+                "status": response.status_code,
+                "ms": round(duration, 1),
+            },
         )
         counter_inc(
             "http_requests_total",
             {
-                "path": _normalize_path(request.url.path),
-                "method": request.method,
+                "path": _normalize_path(path),
+                "method": method,
                 "status": str(response.status_code),
             },
         )

--- a/backend/app/services/audit.py
+++ b/backend/app/services/audit.py
@@ -1,0 +1,41 @@
+"""Audit-log helper.
+
+Security-sensitive mutations emit one line via the `audit` logger. When
+`LOG_JSON=true` these land as structured JSON records — easy to tail, grep, or
+ship to a sink. In human-readable mode they still carry the same fields as
+record extras and render as `<timestamp> [audit] <message>` with the extras
+visible to anything reading LogRecord.__dict__ (e.g., pytest caplog).
+
+Rules:
+- Never include the actual secret (access token, PIN, Fernet key).
+- Keep payloads small — just the identifiers needed to correlate.
+- Use stable action verbs ("created", "updated", "deleted") so downstream
+  consumers can filter on them.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+log = logging.getLogger("audit")
+
+
+def audit_event(action: str, resource: str, **fields: Any) -> None:
+    """Emit an audit record.
+
+    Args:
+        action: "created" | "updated" | "deleted" | custom verb.
+        resource: logical resource name, e.g. "platform_credential".
+        **fields: any additional identifiers (id, platform_id, account_id).
+            MUST NOT contain secrets.
+    """
+    extras: dict[str, Any] = {
+        "event": "audit",
+        "audit_action": action,
+        "audit_resource": resource,
+    }
+    for key, value in fields.items():
+        if value is None:
+            continue
+        extras[key] = value
+    log.info("%s %s", resource, action, extra=extras)

--- a/backend/scripts/encrypt_legacy_tokens.py
+++ b/backend/scripts/encrypt_legacy_tokens.py
@@ -1,0 +1,73 @@
+"""One-shot migration: encrypt any legacy plaintext `PlatformCredential` rows.
+
+Pre-M8 credentials were stored as plaintext in the `access_token` column.
+M8 introduced Fernet-at-rest encryption with a `fernet:v1:` prefix; the
+`PlatformCredential.access_token` property-setter transparently encrypts on
+write. Rows written pre-M8 remain decryptable (the decrypt helper returns
+non-prefixed values as-is), so they keep working — but they stay on disk in
+plaintext until the next update.
+
+Run this script once after upgrading to M8+ to sweep all such rows into the
+encrypted format. Idempotent: skip rows that already carry the prefix.
+
+    cd backend && python -m scripts.encrypt_legacy_tokens
+
+Exit codes:
+    0 — success (count printed; zero is fine)
+    1 — DB init / access error
+"""
+from __future__ import annotations
+
+import logging
+import sys
+
+from app.db import session as db_session
+from app.db.models import PlatformCredential
+from app.security import _FERNET_PREFIX  # internal but stable — used by encrypt_str
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+    log = logging.getLogger("encrypt_legacy_tokens")
+
+    # Late-bind SessionLocal so tests that monkeypatch it are respected.
+    try:
+        db = db_session.SessionLocal()
+    except Exception as exc:  # noqa: BLE001
+        log.error("Could not open DB session: %s", exc)
+        return 1
+
+    try:
+        rows = db.query(PlatformCredential).all()
+        log.info("Scanning %d credential row(s)", len(rows))
+        migrated = 0
+        skipped = 0
+        for row in rows:
+            stored = row.access_token_encrypted
+            if not stored:
+                skipped += 1
+                continue
+            if stored.startswith(_FERNET_PREFIX):
+                skipped += 1
+                continue
+            # Assign through the property to trigger encrypt_str.
+            row.access_token = stored
+            migrated += 1
+        if migrated:
+            db.commit()
+        log.info(
+            "Migration complete: migrated=%d already_encrypted_or_empty=%d",
+            migrated,
+            skipped,
+        )
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        log.exception("Migration failed: %s", exc)
+        db.rollback()
+        return 1
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_phase2_security_ops.py
+++ b/backend/tests/test_phase2_security_ops.py
@@ -1,0 +1,289 @@
+"""Phase 2 security/ops additions.
+
+- JSON log formatter emits parseable records with expected fields.
+- RequestContextMiddleware attaches structured extras (request_id, method,
+  path, status, ms) to its access records.
+- PlatformCredential create / update / delete paths each fire an
+  `audit_event("created"|"updated"|"deleted", ...)` record tagged with
+  platform_id + account_id (never the token value).
+- scripts/encrypt_legacy_tokens.py upgrades plaintext rows in-place without
+  clobbering already-encrypted ones.
+"""
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+from app.db.models import PlatformCredential
+
+
+# ---------- JSON log formatter ----------
+
+
+def test_json_formatter_emits_expected_fields():
+    from app.observability import JsonFormatter
+
+    record = logging.LogRecord(
+        name="http",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="request completed",
+        args=(),
+        exc_info=None,
+    )
+    record.request_id = "abc123"
+    record.method = "GET"
+    record.path = "/api/status"
+    record.status = 200
+    record.ms = 4.2
+
+    line = JsonFormatter().format(record)
+    payload = json.loads(line)
+    assert payload["level"] == "INFO"
+    assert payload["logger"] == "http"
+    assert payload["message"] == "request completed"
+    assert payload["request_id"] == "abc123"
+    assert payload["method"] == "GET"
+    assert payload["path"] == "/api/status"
+    assert payload["status"] == 200
+    assert payload["ms"] == 4.2
+    assert "ts" in payload
+
+
+def test_json_formatter_stringifies_unserialisable_extras():
+    from app.observability import JsonFormatter
+
+    class Unserialisable:
+        def __repr__(self) -> str:
+            return "<Unserialisable>"
+
+    record = logging.LogRecord(
+        name="test", level=logging.INFO, pathname="", lineno=0,
+        msg="hi", args=(), exc_info=None,
+    )
+    record.blob = Unserialisable()
+    payload = json.loads(JsonFormatter().format(record))
+    assert payload["blob"] == "<Unserialisable>"
+
+
+def test_configure_logging_is_idempotent():
+    from app.observability import configure_logging
+
+    configure_logging(json_output=True)
+    configure_logging(json_output=False)
+    configure_logging(json_output=True)
+    root = logging.getLogger()
+    # One handler after repeat calls, not three.
+    assert len(root.handlers) == 1
+
+
+# ---------- Access log extras ----------
+
+
+def test_access_log_carries_structured_extras(client, caplog):
+    caplog.set_level(logging.INFO, logger="http")
+    r = client.get("/api/status")
+    assert r.status_code == 200
+
+    matching = [rec for rec in caplog.records if rec.name == "http" and rec.message == "request completed"]
+    assert matching, "expected an http access record"
+    rec = matching[-1]
+    assert rec.method == "GET"
+    assert rec.path == "/api/status"
+    assert rec.status == 200
+    assert hasattr(rec, "request_id") and rec.request_id
+    assert isinstance(rec.ms, float)
+
+
+# ---------- Credential audit log ----------
+
+
+def _audit_records(caplog):
+    return [rec for rec in caplog.records if rec.name == "audit"]
+
+
+def test_audit_event_has_expected_fields(caplog):
+    caplog.set_level(logging.INFO, logger="audit")
+    from app.services.audit import audit_event
+
+    audit_event(
+        "created",
+        "platform_credential",
+        credential_id=7,
+        platform_id="instagram",
+        account_id="999",
+    )
+    records = _audit_records(caplog)
+    assert len(records) == 1
+    rec = records[0]
+    assert rec.audit_action == "created"
+    assert rec.audit_resource == "platform_credential"
+    assert rec.credential_id == 7
+    assert rec.platform_id == "instagram"
+    assert rec.account_id == "999"
+
+
+def test_delete_credential_emits_audit_event(client, db, caplog):
+    caplog.set_level(logging.INFO, logger="audit")
+
+    row = PlatformCredential(
+        platform_id="instagram",
+        account_id="acc-1",
+        access_token="plain-token",
+    )
+    db.add(row)
+    db.commit()
+    cid = row.id
+
+    r = client.delete(f"/api/platform-credentials/{cid}")
+    assert r.status_code == 204
+
+    records = _audit_records(caplog)
+    assert any(
+        getattr(rec, "audit_action", None) == "deleted"
+        and getattr(rec, "audit_resource", None) == "platform_credential"
+        and getattr(rec, "credential_id", None) == cid
+        and getattr(rec, "platform_id", None) == "instagram"
+        for rec in records
+    )
+    # Never log the token value itself.
+    for rec in records:
+        for value in rec.__dict__.values():
+            assert "plain-token" != value
+
+
+def test_add_manual_credential_emits_audit_event(client, caplog):
+    caplog.set_level(logging.INFO, logger="audit")
+
+    payload = {
+        "platform_id": "instagram",
+        "account_id": "acc-2",
+        "access_token": "secret-xyz",
+        "username": "biz",
+    }
+    r = client.post("/api/meta/credentials", json=payload)
+    assert r.status_code == 200
+
+    records = _audit_records(caplog)
+    created = [rec for rec in records if getattr(rec, "audit_action", None) == "created"]
+    assert created, "expected a created audit record"
+    assert getattr(created[-1], "platform_id", None) == "instagram"
+    assert getattr(created[-1], "account_id", None) == "acc-2"
+    # Token must never appear in any audit record's attributes.
+    for rec in records:
+        for value in rec.__dict__.values():
+            assert value != "secret-xyz"
+
+
+def test_update_credential_reports_changed_fields(client, caplog):
+    caplog.set_level(logging.INFO, logger="audit")
+
+    client.post(
+        "/api/meta/credentials",
+        json={
+            "platform_id": "instagram",
+            "account_id": "acc-3",
+            "access_token": "token-A",
+            "username": "old-name",
+        },
+    )
+    caplog.clear()
+
+    r = client.post(
+        "/api/meta/credentials",
+        json={
+            "platform_id": "instagram",
+            "account_id": "acc-3",
+            "access_token": "token-B",
+            "username": "new-name",
+        },
+    )
+    assert r.status_code == 200
+
+    updates = [
+        rec
+        for rec in _audit_records(caplog)
+        if getattr(rec, "audit_action", None) == "updated"
+    ]
+    assert updates
+    changed = updates[-1].changed_fields
+    assert "access_token" in changed
+    assert "username" in changed
+
+
+# ---------- Legacy-token migration script ----------
+
+
+def test_encrypt_legacy_tokens_migrates_plaintext(db, session_maker, monkeypatch, caplog):
+    from app.db import session as db_session
+    from app.security import _FERNET_PREFIX
+
+    # Two legacy plaintext rows + one already-encrypted row.
+    legacy1 = PlatformCredential(platform_id="instagram", account_id="a1")
+    legacy1.access_token_encrypted = "plaintext-A"
+    legacy2 = PlatformCredential(platform_id="threads", account_id="a2")
+    legacy2.access_token_encrypted = "plaintext-B"
+    already = PlatformCredential(platform_id="instagram", account_id="a3")
+    already.access_token = "safe"  # goes through setter → prefixed
+    db.add_all([legacy1, legacy2, already])
+    db.commit()
+
+    monkeypatch.setattr(db_session, "SessionLocal", session_maker, raising=True)
+
+    from scripts import encrypt_legacy_tokens
+
+    rc = encrypt_legacy_tokens.main()
+    assert rc == 0
+
+    db.expire_all()
+    all_rows = db.query(PlatformCredential).all()
+    for row in all_rows:
+        assert row.access_token_encrypted.startswith(_FERNET_PREFIX)
+    # Decrypt round-trips cleanly.
+    assert {r.access_token for r in all_rows} == {"plaintext-A", "plaintext-B", "safe"}
+
+
+def test_encrypt_legacy_tokens_is_idempotent(db, session_maker, monkeypatch):
+    from app.db import session as db_session
+
+    row = PlatformCredential(platform_id="instagram", account_id="idem")
+    row.access_token_encrypted = "legacy-plain"
+    db.add(row)
+    db.commit()
+
+    monkeypatch.setattr(db_session, "SessionLocal", session_maker, raising=True)
+
+    from scripts import encrypt_legacy_tokens
+
+    assert encrypt_legacy_tokens.main() == 0
+    db.expire_all()
+    first_value = db.query(PlatformCredential).one().access_token_encrypted
+
+    # Second run: nothing changes.
+    assert encrypt_legacy_tokens.main() == 0
+    db.expire_all()
+    assert db.query(PlatformCredential).one().access_token_encrypted == first_value
+
+
+# ---------- Regression: settings has log_json knob ----------
+
+
+def test_log_json_setting_defaults_false():
+    from app.config import settings
+
+    assert settings.log_json is False
+
+
+@pytest.fixture(autouse=True)
+def _restore_logging_after_test():
+    """Tests that touch configure_logging mutate the root logger; restore
+    something sane afterwards so other tests' caplog captures still work.
+    """
+    yield
+    root = logging.getLogger()
+    for h in list(root.handlers):
+        root.removeHandler(h)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(name)s] %(message)s")


### PR DESCRIPTION
## Summary
Implements Phase 2 security and observability enhancements: structured audit logging for credential mutations, JSON log formatting for machine-parseable output, and a migration script for legacy plaintext tokens.

## Key Changes

### Observability & Logging
- **JSON log formatter** (`JsonFormatter` class): Renders log records as single-line JSON objects with ISO timestamps, log level, logger name, message, and any caller-provided extras (request_id, method, path, status, ms, etc.)
- **Configurable logging** (`configure_logging`): Idempotent setup function that wires the root logger with either JSON or human-readable format based on `settings.log_json`
- **Structured access logs**: `RequestContextMiddleware` now attaches request metadata as LogRecord extras (`request_id`, `method`, `path`, `status`, `ms`) instead of formatting them into the message string, enabling clean JSON serialization
- **Settings knob**: Added `log_json` boolean to `Settings` (defaults to `False` for local dev)

### Audit Logging
- **New audit service** (`app/services/audit.py`): `audit_event()` helper that emits security-sensitive mutations to the `audit` logger with structured fields (action, resource, identifiers) while explicitly excluding secrets
- **Credential create/update/delete hooks**: 
  - `_upsert_credential()` in `meta_oauth.py` now fires `audit_event("created"|"updated", ...)` and tracks which fields changed
  - `delete_credential()` in `platform_credentials.py` fires `audit_event("deleted", ...)`
  - All audit records include `platform_id` and `account_id` but never the token value

### Legacy Token Migration
- **New script** (`scripts/encrypt_legacy_tokens.py`): One-shot migration that sweeps pre-M8 plaintext credential rows into Fernet-encrypted format by reading the plaintext value and assigning it back through the property setter (which triggers encryption)
  - Idempotent: skips rows already prefixed with `fernet:v1:`
  - Comprehensive test coverage including round-trip decryption verification

### Security Scanning
- **Gitleaks integration** (`.github/workflows/gitleaks.yml`): GitHub Actions workflow that scans for leaked secrets on PRs and pushes to main
- **Gitleaks config** (`.gitleaks.toml`): Project-specific allowlist for intentional dev placeholders (`.env.example`, docs) and Fernet key examples

## Notable Implementation Details
- `JsonFormatter` gracefully handles non-JSON-serializable values by calling `repr()` on them
- `configure_logging()` is idempotent (removes existing handlers before adding new ones) to support uvicorn reload and pytest re-imports
- Audit records use a dedicated logger (`"audit"`) so they can be filtered/routed separately from application logs
- The encryption migration script uses late-binding of `SessionLocal` to respect test monkeypatching
- All tests include a fixture that restores logging to a sane state after each test to avoid caplog interference

https://claude.ai/code/session_0134AfB5wht644Tdt6Gad7od