### PR TITLE
Phase 5b: A/B split tests for post variants

### DIFF
--- a/backend/alembic/versions/0002_add_ab_arm.py
+++ b/backend/alembic/versions/0002_add_ab_arm.py
@@ -1,0 +1,33 @@
+"""add post_variants.ab_arm
+
+Used by the A/B-split endpoint to tag each variant with the arm it was
+assigned to so metrics can be aggregated by arm afterwards.
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-04-19 21:05:00.000000
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0002"
+down_revision: Union[str, None] = "0001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("post_variants", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("ab_arm", sa.String(length=50), nullable=True))
+        batch_op.create_index(batch_op.f("ix_post_variants_ab_arm"), ["ab_arm"], unique=False)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("post_variants", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_post_variants_ab_arm"))
+        batch_op.drop_column("ab_arm")

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -2,6 +2,7 @@
 from fastapi import APIRouter
 
 from app.api import (
+    ab_tests,
     analytics,
     auth,
     business_profile,
@@ -29,5 +30,6 @@ api_router.include_router(humanizer.router)
 api_router.include_router(analytics.router)
 api_router.include_router(meta_oauth.router)
 api_router.include_router(platform_credentials.router)
+api_router.include_router(ab_tests.router)
 
 __all__ = ["api_router"]

--- a/backend/app/api/ab_tests.py
+++ b/backend/app/api/ab_tests.py
@@ -1,0 +1,232 @@
+"""A/B split testing for posts.
+
+The natural axis is *targets*: you can't A/B within a single Facebook group
+(everyone there sees one post), but you can send arm A to half your groups
+and arm B to the other half. This module provides two endpoints:
+
+- POST /api/posts/{id}/ab-split — take N text arms, assign them round-robin
+  to the post's pending PostVariants, and stamp each variant with its arm
+  label. Only DRAFT / SCHEDULED / PENDING_REVIEW variants are touched —
+  already-posted rows are left alone so a late split can't rewrite history.
+- GET  /api/posts/{id}/ab-results — group the post's variants by ab_arm,
+  aggregate engagement from the best-available PostMetrics window (24h
+  preferred, 1h fallback), and surface a winner arm by average engagement.
+
+The feature lives behind a dedicated router rather than bolting onto the
+/posts router so it stays easy to remove or feature-flag if hobby-scale
+sample sizes turn out not to be useful.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Iterable
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session, selectinload
+
+from app.db import get_session
+from app.db.models import MetricsWindow, Post, PostMetrics, PostStatus, PostVariant
+
+router = APIRouter(prefix="/api/posts", tags=["posts"])
+
+
+# ---------- Schemas ----------
+
+
+class AbArmIn(BaseModel):
+    label: str = Field(min_length=1, max_length=50)
+    text: str = Field(min_length=1)
+
+
+class AbSplitRequest(BaseModel):
+    arms: list[AbArmIn] = Field(min_length=2)
+
+
+class AbArmAssignment(BaseModel):
+    label: str
+    variant_ids: list[int]
+
+
+class AbSplitResponse(BaseModel):
+    post_id: int
+    assignments: list[AbArmAssignment]
+
+
+class AbArmResult(BaseModel):
+    label: str
+    variant_count: int
+    posted_count: int
+    likes: int
+    comments: int
+    shares: int
+    avg_engagement: float
+    # Which metrics window the aggregate was taken from. Null when we have
+    # no data for this arm yet.
+    window: MetricsWindow | None = None
+
+
+class AbResultsResponse(BaseModel):
+    post_id: int
+    arms: list[AbArmResult]
+    # Arm with highest avg_engagement among arms that have posted variants.
+    # Null when no arm has been published + measured yet.
+    winner: str | None
+
+
+# ---------- Split ----------
+
+
+_MUTABLE_STATUSES = {
+    PostStatus.DRAFT,
+    PostStatus.PENDING_REVIEW,
+    PostStatus.SCHEDULED,
+}
+
+
+def _load_post(db: Session, post_id: int) -> Post:
+    post = (
+        db.query(Post)
+        .options(selectinload(Post.variants))
+        .filter(Post.id == post_id)
+        .first()
+    )
+    if post is None:
+        raise HTTPException(status_code=404, detail="Post not found")
+    return post
+
+
+@router.post("/{post_id}/ab-split", response_model=AbSplitResponse)
+def ab_split(
+    post_id: int,
+    payload: AbSplitRequest,
+    db: Session = Depends(get_session),
+) -> AbSplitResponse:
+    # Dedup arm labels — silent duplicates would make the results endpoint
+    # misleading.
+    labels = [arm.label for arm in payload.arms]
+    if len(set(labels)) != len(labels):
+        raise HTTPException(status_code=400, detail="Duplicate arm labels")
+
+    post = _load_post(db, post_id)
+    # Deterministic order so re-splitting with the same arms lands the same
+    # variants on the same arm.
+    mutable = sorted(
+        (v for v in post.variants if v.status in _MUTABLE_STATUSES),
+        key=lambda v: v.id,
+    )
+    if not mutable:
+        raise HTTPException(
+            status_code=409,
+            detail="No pending variants to split — all are posted or failed",
+        )
+
+    buckets: dict[str, list[int]] = {arm.label: [] for arm in payload.arms}
+    for idx, variant in enumerate(mutable):
+        arm = payload.arms[idx % len(payload.arms)]
+        variant.ab_arm = arm.label
+        variant.text = arm.text
+        buckets[arm.label].append(variant.id)
+    db.commit()
+
+    return AbSplitResponse(
+        post_id=post_id,
+        assignments=[
+            AbArmAssignment(label=label, variant_ids=ids)
+            for label, ids in buckets.items()
+        ],
+    )
+
+
+# ---------- Results ----------
+
+
+def _pick_metrics_window(
+    metrics_by_variant: dict[int, list[PostMetrics]],
+) -> MetricsWindow | None:
+    """Across all variants in an arm, pick the most-informative shared
+    window. 24h beats 1h beats 7d (freshest meaningful signal for a hobby
+    tool that mainly cares about recent posts). Returns None if every
+    variant in the arm is pre-measurement.
+    """
+    order = (MetricsWindow.ONE_DAY, MetricsWindow.ONE_HOUR, MetricsWindow.SEVEN_DAY)
+    available = {m.window for rows in metrics_by_variant.values() for m in rows}
+    for w in order:
+        if w in available:
+            return w
+    return None
+
+
+def _aggregate_arm(
+    label: str,
+    variants: Iterable[PostVariant],
+    metrics_by_variant: dict[int, list[PostMetrics]],
+) -> AbArmResult:
+    variants = list(variants)
+    posted = [v for v in variants if v.status == PostStatus.POSTED]
+    window = _pick_metrics_window(
+        {v.id: metrics_by_variant.get(v.id, []) for v in posted}
+    )
+    likes = comments = shares = 0
+    scores: list[float] = []
+    if window is not None:
+        for v in posted:
+            row = next(
+                (m for m in metrics_by_variant.get(v.id, []) if m.window == window),
+                None,
+            )
+            if row is None:
+                continue
+            likes += row.likes
+            comments += row.comments
+            shares += row.shares
+            scores.append(row.engagement_score)
+    avg = sum(scores) / len(scores) if scores else 0.0
+    return AbArmResult(
+        label=label,
+        variant_count=len(variants),
+        posted_count=len(posted),
+        likes=likes,
+        comments=comments,
+        shares=shares,
+        avg_engagement=avg,
+        window=window,
+    )
+
+
+@router.get("/{post_id}/ab-results", response_model=AbResultsResponse)
+def ab_results(
+    post_id: int,
+    db: Session = Depends(get_session),
+) -> AbResultsResponse:
+    post = _load_post(db, post_id)
+    split_variants = [v for v in post.variants if v.ab_arm is not None]
+    if not split_variants:
+        raise HTTPException(
+            status_code=404, detail="Post has no A/B split assigned"
+        )
+
+    variant_ids = [v.id for v in split_variants]
+    rows = (
+        db.query(PostMetrics)
+        .filter(PostMetrics.variant_id.in_(variant_ids))
+        .all()
+    )
+    metrics_by_variant: dict[int, list[PostMetrics]] = defaultdict(list)
+    for row in rows:
+        metrics_by_variant[row.variant_id].append(row)
+
+    by_arm: dict[str, list[PostVariant]] = defaultdict(list)
+    for v in split_variants:
+        by_arm[v.ab_arm].append(v)
+
+    # Iterate in the original arm-assignment order (sorted label preserves
+    # determinism across API reads).
+    results = [
+        _aggregate_arm(label, by_arm[label], metrics_by_variant)
+        for label in sorted(by_arm.keys())
+    ]
+    measurable = [r for r in results if r.posted_count > 0 and r.window is not None]
+    winner = max(measurable, key=lambda r: r.avg_engagement).label if measurable else None
+
+    return AbResultsResponse(post_id=post_id, arms=results, winner=winner)

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -218,6 +218,9 @@ class PostVariant(Base):
     posted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     external_post_id: Mapped[str | None] = mapped_column(String(500), nullable=True)
     error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # A/B test arm label (e.g. "control", "a", "b"). Null when the post isn't
+    # part of a split test. Populated by POST /api/posts/{id}/ab-split.
+    ab_arm: Mapped[str | None] = mapped_column(String(50), nullable=True, index=True)
 
     post: Mapped[Post] = relationship(back_populates="variants")
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -186,6 +186,7 @@ class PostVariantOut(BaseModel):
     posted_at: datetime | None
     external_post_id: str | None
     error: str | None
+    ab_arm: str | None = None
 
 
 class PostOut(BaseModel):

--- a/backend/tests/test_ab_tests.py
+++ b/backend/tests/test_ab_tests.py
@@ -1,0 +1,269 @@
+"""Phase 5b — A/B split tests.
+
+Covers:
+- Split distributes variants round-robin across arms.
+- Arms rewrite variant text and stamp ab_arm.
+- Already-posted variants are left alone (so re-splitting can't rewrite
+  history of what actually went out).
+- Rejects duplicate labels and single-arm splits.
+- /ab-results aggregates engagement per arm and picks a winner from the
+  freshest shared metrics window.
+- Returns 404 if no split has been assigned.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from app.db.models import (
+    MetricsWindow,
+    Post,
+    PostMetrics,
+    PostStatus,
+    PostType,
+    PostVariant,
+    Target,
+)
+
+
+def _seed(db, *, n_variants: int = 4, all_status: PostStatus = PostStatus.SCHEDULED) -> Post:
+    post = Post(post_type=PostType.INFORMATIVE, status=PostStatus.SCHEDULED, text="seed")
+    db.add(post)
+    db.flush()
+    targets = []
+    for i in range(n_variants):
+        t = Target(
+            platform_id="facebook",
+            external_id=f"ext-{i}",
+            name=f"group {i}",
+            tags=[],
+            active=True,
+            source="manual",
+        )
+        db.add(t)
+        db.flush()
+        targets.append(t)
+    for t in targets:
+        db.add(
+            PostVariant(
+                post_id=post.id,
+                target_id=t.id,
+                text=f"original for {t.name}",
+                status=all_status,
+            )
+        )
+    db.commit()
+    db.refresh(post)
+    return post
+
+
+def _metrics_row(
+    variant_id: int,
+    window: MetricsWindow,
+    likes: int,
+    comments: int,
+    shares: int,
+    engagement: float,
+) -> PostMetrics:
+    return PostMetrics(
+        variant_id=variant_id,
+        window=window,
+        likes=likes,
+        comments=comments,
+        shares=shares,
+        engagement_score=engagement,
+        collected_at=datetime.now(UTC),
+    )
+
+
+# ---------- /ab-split ----------
+
+
+def test_split_round_robin_assigns_arms(client, db):
+    post = _seed(db, n_variants=4)
+    r = client.post(
+        f"/api/posts/{post.id}/ab-split",
+        json={
+            "arms": [
+                {"label": "a", "text": "arm-a text"},
+                {"label": "b", "text": "arm-b text"},
+            ]
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    labels = {a["label"]: a["variant_ids"] for a in body["assignments"]}
+    assert set(labels) == {"a", "b"}
+    assert len(labels["a"]) == 2 and len(labels["b"]) == 2
+    # Round-robin in id order: arms receive the 1st and 3rd, 2nd and 4th
+    # variants respectively.
+    all_ids = sorted(labels["a"] + labels["b"])
+    assert labels["a"] == [all_ids[0], all_ids[2]]
+    assert labels["b"] == [all_ids[1], all_ids[3]]
+
+    # Variants now carry ab_arm and the arm's text, not the original.
+    db.expire_all()
+    fresh = db.query(PostVariant).filter(PostVariant.post_id == post.id).all()
+    assert all(v.ab_arm in {"a", "b"} for v in fresh)
+    assert {v.text for v in fresh if v.ab_arm == "a"} == {"arm-a text"}
+    assert {v.text for v in fresh if v.ab_arm == "b"} == {"arm-b text"}
+
+
+def test_split_leaves_posted_variants_alone(client, db):
+    post = _seed(db, n_variants=2, all_status=PostStatus.SCHEDULED)
+    # One variant is already POSTED — rewriting its text would be a lie.
+    posted_variant = post.variants[0]
+    posted_variant.status = PostStatus.POSTED
+    db.commit()
+    original_text = posted_variant.text
+
+    r = client.post(
+        f"/api/posts/{post.id}/ab-split",
+        json={
+            "arms": [
+                {"label": "a", "text": "arm-a text"},
+                {"label": "b", "text": "arm-b text"},
+            ]
+        },
+    )
+    assert r.status_code == 200
+
+    db.expire_all()
+    v0 = db.get(PostVariant, posted_variant.id)
+    assert v0.ab_arm is None
+    assert v0.text == original_text
+
+
+def test_split_rejects_duplicate_labels(client, db):
+    post = _seed(db, n_variants=2)
+    r = client.post(
+        f"/api/posts/{post.id}/ab-split",
+        json={
+            "arms": [
+                {"label": "a", "text": "x"},
+                {"label": "a", "text": "y"},
+            ]
+        },
+    )
+    assert r.status_code == 400
+
+
+def test_split_requires_at_least_two_arms(client, db):
+    post = _seed(db, n_variants=2)
+    r = client.post(
+        f"/api/posts/{post.id}/ab-split",
+        json={"arms": [{"label": "only", "text": "x"}]},
+    )
+    # Pydantic min_length=2 → 422 validation error.
+    assert r.status_code == 422
+
+
+def test_split_returns_409_when_no_pending_variants(client, db):
+    post = _seed(db, n_variants=2, all_status=PostStatus.POSTED)
+    r = client.post(
+        f"/api/posts/{post.id}/ab-split",
+        json={
+            "arms": [
+                {"label": "a", "text": "x"},
+                {"label": "b", "text": "y"},
+            ]
+        },
+    )
+    assert r.status_code == 409
+
+
+def test_split_404_when_post_missing(client):
+    r = client.post(
+        "/api/posts/999/ab-split",
+        json={
+            "arms": [
+                {"label": "a", "text": "x"},
+                {"label": "b", "text": "y"},
+            ]
+        },
+    )
+    assert r.status_code == 404
+
+
+# ---------- /ab-results ----------
+
+
+def test_ab_results_404_when_not_split(client, db):
+    post = _seed(db, n_variants=2)
+    r = client.get(f"/api/posts/{post.id}/ab-results")
+    assert r.status_code == 404
+
+
+def test_ab_results_aggregates_per_arm_and_picks_winner(client, db):
+    post = _seed(db, n_variants=4)
+    variants = sorted(post.variants, key=lambda v: v.id)
+    # Assign arms and mark all posted so metrics are measurable.
+    for i, v in enumerate(variants):
+        v.ab_arm = "a" if i % 2 == 0 else "b"
+        v.status = PostStatus.POSTED
+        v.text = f"arm-{v.ab_arm}"
+    db.commit()
+
+    # Arm A: engagement 1.0 and 2.0 → avg 1.5
+    # Arm B: engagement 5.0 and 9.0 → avg 7.0 (winner)
+    db.add_all(
+        [
+            _metrics_row(variants[0].id, MetricsWindow.ONE_DAY, 1, 0, 0, 1.0),
+            _metrics_row(variants[1].id, MetricsWindow.ONE_DAY, 5, 0, 0, 5.0),
+            _metrics_row(variants[2].id, MetricsWindow.ONE_DAY, 2, 0, 0, 2.0),
+            _metrics_row(variants[3].id, MetricsWindow.ONE_DAY, 9, 0, 0, 9.0),
+        ]
+    )
+    db.commit()
+
+    r = client.get(f"/api/posts/{post.id}/ab-results")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["winner"] == "b"
+    arms = {a["label"]: a for a in body["arms"]}
+    assert arms["a"]["posted_count"] == 2
+    assert arms["a"]["likes"] == 3
+    assert abs(arms["a"]["avg_engagement"] - 1.5) < 1e-6
+    assert arms["b"]["likes"] == 14
+    assert abs(arms["b"]["avg_engagement"] - 7.0) < 1e-6
+    assert arms["a"]["window"] == "24h"
+    assert arms["b"]["window"] == "24h"
+
+
+def test_ab_results_null_winner_when_no_metrics_yet(client, db):
+    post = _seed(db, n_variants=2)
+    for v in post.variants:
+        v.ab_arm = "a" if v == post.variants[0] else "b"
+    db.commit()
+
+    r = client.get(f"/api/posts/{post.id}/ab-results")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["winner"] is None
+    for arm in body["arms"]:
+        assert arm["posted_count"] == 0
+        assert arm["avg_engagement"] == 0.0
+        assert arm["window"] is None
+
+
+def test_ab_results_falls_back_to_1h_when_24h_missing(client, db):
+    post = _seed(db, n_variants=2)
+    variants = list(post.variants)
+    for i, v in enumerate(variants):
+        v.ab_arm = "a" if i == 0 else "b"
+        v.status = PostStatus.POSTED
+    db.commit()
+
+    # Only 1h metrics collected so far.
+    db.add_all(
+        [
+            _metrics_row(variants[0].id, MetricsWindow.ONE_HOUR, 0, 1, 0, 2.0),
+            _metrics_row(variants[1].id, MetricsWindow.ONE_HOUR, 0, 2, 0, 4.0),
+        ]
+    )
+    db.commit()
+
+    r = client.get(f"/api/posts/{post.id}/ab-results")
+    body = r.json()
+    assert body["winner"] == "b"
+    for arm in body["arms"]:
+        assert arm["window"] == "1h"

--- a/backend/tests/test_phase4_alembic.py
+++ b/backend/tests/test_phase4_alembic.py
@@ -12,11 +12,16 @@ a no-op the second time.
 """
 from __future__ import annotations
 
+from alembic.script import ScriptDirectory
 from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.pool import StaticPool
 
 from app.db import session as db_session
 from app.db.models import Base
+
+
+def _head_revision() -> str:
+    return ScriptDirectory.from_config(db_session._alembic_config()).get_current_head()
 
 # Tables the baseline migration 0001 is expected to create. Keep this list
 # explicit so drift in the model layer or a botched autogen gets caught
@@ -66,7 +71,7 @@ def test_init_db_upgrades_fresh_db(monkeypatch):
 
     with eng.connect() as conn:
         row = conn.execute(text("SELECT version_num FROM alembic_version")).fetchone()
-    assert row is not None and row[0] == "0001"
+    assert row is not None and row[0] == _head_revision()
 
 
 def test_init_db_is_idempotent(monkeypatch):
@@ -80,7 +85,7 @@ def test_init_db_is_idempotent(monkeypatch):
 
     with eng.connect() as conn:
         row = conn.execute(text("SELECT version_num FROM alembic_version")).fetchone()
-    assert row[0] == "0001"
+    assert row[0] == _head_revision()
 
 
 def test_init_db_stamps_preexisting_schema(monkeypatch):
@@ -104,7 +109,7 @@ def test_init_db_stamps_preexisting_schema(monkeypatch):
 
     with eng.connect() as conn:
         row = conn.execute(text("SELECT version_num FROM alembic_version")).fetchone()
-    assert row[0] == "0001"
+    assert row[0] == _head_revision()
 
 
 def test_alembic_config_points_at_bundled_ini():


### PR DESCRIPTION
- Alembic migration 0002 adds post_variants.ab_arm (indexed, nullable VARCHAR(50)) so engagement can be aggregated by arm after the fact.
- PostVariant model + PostVariantOut schema expose ab_arm.
- app/api/ab_tests.py:
  - POST /api/posts/{id}/ab-split — round-robin assigns N text arms to the post's pending variants (DRAFT / PENDING_REVIEW / SCHEDULED only), so a split after publication can't rewrite what already went out. Rejects duplicate labels; Pydantic enforces min 2 arms.
  - GET /api/posts/{id}/ab-results — aggregates likes/comments/shares and average engagement per arm from the most-informative shared metrics window (24h > 1h > 7d). Reports a winner when at least one arm has posted + measured variants, otherwise winner is null.
- tests/test_ab_tests.py: 10 tests covering round-robin, posted-variant protection, 400/409/422/404 paths, 24h aggregation, no-metrics fallback, 1h fallback window.
- tests/test_phase4_alembic.py: replace hardcoded "0001" revision asserts with a dynamic head lookup so future migrations don't break it.