### PR TITLE
Add LinkedIn platform support with OAuth and REST API integration

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -8,6 +8,7 @@ from app.api import (
     feedback,
     health,
     humanizer,
+    linkedin_oauth,
     media,
     meta_oauth,
     plans,
@@ -28,6 +29,7 @@ api_router.include_router(media.router)
 api_router.include_router(humanizer.router)
 api_router.include_router(analytics.router)
 api_router.include_router(meta_oauth.router)
+api_router.include_router(linkedin_oauth.router)
 api_router.include_router(platform_credentials.router)
 
 __all__ = ["api_router"]

--- a/backend/app/api/linkedin_oauth.py
+++ b/backend/app/api/linkedin_oauth.py
@@ -1,0 +1,198 @@
+"""LinkedIn OAuth endpoints.
+
+Three-legged OIDC flow:
+1. Dashboard hits `GET /api/linkedin/oauth/url` → returns the authorization
+   URL plus a `state` nonce to round-trip.
+2. User signs in at linkedin.com, accepts scopes, LinkedIn redirects back
+   to `GET /api/linkedin/oauth/callback?code=...&state=...`.
+3. We exchange the code for an access token, pull the OIDC `userinfo` to
+   discover the person id, and upsert a PlatformCredential row with
+   `platform_id="linkedin"`.
+
+Scopes requested: `openid profile email w_member_social`. `openid`/`profile`
+unlock `/v2/userinfo`; `w_member_social` unlocks `/rest/posts` to the
+member's own feed.
+"""
+from __future__ import annotations
+
+import logging
+import secrets
+from urllib.parse import urlencode
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.db import get_session
+from app.db.models import PlatformCredential
+from app.platforms import linkedin_api
+from app.schemas import PlatformCredentialOut
+from app.services.audit import audit_event
+
+log = logging.getLogger("api.linkedin_oauth")
+
+router = APIRouter(prefix="/api/linkedin", tags=["linkedin"])
+
+
+LINKEDIN_SCOPES = ["openid", "profile", "email", "w_member_social"]
+
+
+class LinkedInOAuthUrlOut(BaseModel):
+    url: str
+    state: str
+
+
+class LinkedInOAuthCompleteOut(BaseModel):
+    credential: PlatformCredentialOut | None = None
+    message: str
+
+
+class LinkedInManualCredentialIn(BaseModel):
+    """Paste-a-token escape hatch. CLI users who already have a valid token
+    (e.g. from the LinkedIn API console) can skip the redirect dance.
+    """
+
+    account_id: str  # LinkedIn person id (OIDC `sub`).
+    access_token: str
+    username: str | None = None
+
+
+def _upsert_credential(
+    db: Session,
+    *,
+    account_id: str,
+    access_token: str,
+    username: str | None = None,
+    extra: dict | None = None,
+) -> PlatformCredential:
+    row = (
+        db.query(PlatformCredential)
+        .filter(
+            PlatformCredential.platform_id == "linkedin",
+            PlatformCredential.account_id == account_id,
+        )
+        .one_or_none()
+    )
+    is_new = row is None
+    changed: list[str] = []
+    if is_new:
+        row = PlatformCredential(
+            platform_id="linkedin",
+            account_id=account_id,
+            username=username,
+            access_token=access_token,
+            extra=extra or {},
+        )
+        db.add(row)
+    else:
+        if row.access_token_encrypted != access_token:
+            row.access_token = access_token
+            changed.append("access_token")
+        if username and row.username != username:
+            row.username = username
+            changed.append("username")
+        if extra is not None and row.extra != extra:
+            row.extra = extra
+            changed.append("extra")
+    db.commit()
+    db.refresh(row)
+    audit_event(
+        "created" if is_new else "updated",
+        "platform_credential",
+        credential_id=row.id,
+        platform_id="linkedin",
+        account_id=account_id,
+        changed_fields=None if is_new else changed,
+    )
+    return row
+
+
+@router.get("/oauth/url", response_model=LinkedInOAuthUrlOut)
+def oauth_url() -> LinkedInOAuthUrlOut:
+    if not settings.linkedin_client_id:
+        raise HTTPException(
+            status_code=400,
+            detail="LINKEDIN_CLIENT_ID is not configured in .env",
+        )
+    state = secrets.token_urlsafe(24)
+    params = {
+        "response_type": "code",
+        "client_id": settings.linkedin_client_id,
+        "redirect_uri": settings.linkedin_redirect_uri,
+        "state": state,
+        "scope": " ".join(LINKEDIN_SCOPES),
+    }
+    return LinkedInOAuthUrlOut(
+        url=f"{linkedin_api.OAUTH_AUTH_URL}?{urlencode(params)}",
+        state=state,
+    )
+
+
+@router.get("/oauth/callback", response_model=LinkedInOAuthCompleteOut)
+def oauth_callback(
+    code: str = Query(..., description="Authorization code from LinkedIn"),
+    state: str | None = Query(None),
+    db: Session = Depends(get_session),
+) -> LinkedInOAuthCompleteOut:
+    """Complete the OAuth dance. Called by LinkedIn's redirect.
+
+    Same state-verification caveat as Meta: single-user localhost tool, no
+    real CSRF surface, we trust the redirect.
+    """
+    if not settings.linkedin_client_id or not settings.linkedin_client_secret:
+        raise HTTPException(status_code=400, detail="LinkedIn app credentials missing")
+    try:
+        token_resp = linkedin_api.exchange_code_for_token(
+            client_id=settings.linkedin_client_id,
+            client_secret=settings.linkedin_client_secret,
+            redirect_uri=settings.linkedin_redirect_uri,
+            code=code,
+        )
+    except linkedin_api.LinkedInError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    access_token = token_resp.get("access_token")
+    if not access_token:
+        raise HTTPException(status_code=400, detail="LinkedIn did not return an access_token")
+
+    try:
+        userinfo = linkedin_api.get_userinfo(access_token)
+    except linkedin_api.LinkedInError as exc:
+        raise HTTPException(status_code=400, detail=f"userinfo failed: {exc}") from exc
+
+    sub = userinfo.get("sub")
+    if not sub:
+        raise HTTPException(
+            status_code=400,
+            detail="LinkedIn userinfo missing `sub` — cannot derive person URN",
+        )
+
+    row = _upsert_credential(
+        db,
+        account_id=sub,
+        access_token=access_token,
+        username=userinfo.get("name"),
+        extra={
+            "email": userinfo.get("email"),
+            "locale": userinfo.get("locale"),
+        },
+    )
+    return LinkedInOAuthCompleteOut(
+        credential=PlatformCredentialOut.model_validate(row),
+        message=f"LinkedIn account {sub} connected",
+    )
+
+
+@router.post("/credentials", response_model=PlatformCredentialOut)
+def add_credential(
+    payload: LinkedInManualCredentialIn,
+    db: Session = Depends(get_session),
+) -> PlatformCredentialOut:
+    row = _upsert_credential(
+        db,
+        account_id=payload.account_id,
+        access_token=payload.access_token,
+        username=payload.username,
+    )
+    return PlatformCredentialOut.model_validate(row)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -51,6 +51,14 @@ class Settings(BaseSettings):
     # The Threads user id (numeric).
     threads_user_id: str = ""
 
+    # Phase 5d — LinkedIn OAuth.
+    # Values come from https://www.linkedin.com/developers/apps. Scopes we
+    # request: `openid profile email w_member_social`. For company-page
+    # posting, add `w_organization_social` and wire target URN separately.
+    linkedin_client_id: str = ""
+    linkedin_client_secret: str = ""
+    linkedin_redirect_uri: str = "http://localhost:8787/api/linkedin/oauth/callback"
+
     # M8 — Security
     # Empty = auth disabled (single-user localhost default). Set to any
     # 4–32 char string to require `X-Dashboard-Pin` or a `/api/auth/login`

--- a/backend/app/platforms/linkedin.py
+++ b/backend/app/platforms/linkedin.py
@@ -1,0 +1,175 @@
+"""LinkedIn platform (via the official REST API, no browser automation).
+
+Scope of v1:
+- Person (`urn:li:person:*`) posts. Company pages come later — the OAuth
+  scope `w_organization_social` would need to be added.
+- Text-only posts and text + single image.
+- Reads one PlatformCredential row with `platform_id="linkedin"`. The
+  `account_id` is the LinkedIn person id (OIDC `sub`), stored as the raw
+  id so we can build the URN at publish time.
+
+Posting flow:
+  1. If an `image_url` is attached, fetch the bytes → register upload →
+     PUT the bytes → we get back an image URN.
+  2. POST /rest/posts with commentary + (optional) image URN.
+
+Metrics: LinkedIn's `socialActions` endpoint gives likes/comments; a full
+insights surface needs Marketing-scope tokens we don't ask for. Return
+None for now and let the metrics service fill zeros.
+"""
+from __future__ import annotations
+
+import logging
+from typing import ClassVar
+
+import httpx
+from sqlalchemy.orm import Session
+
+from app.db.models import Post, Target
+from app.platforms import linkedin_api
+from app.platforms.base import Platform, PublishResult
+
+log = logging.getLogger("platforms.linkedin")
+
+
+# LinkedIn's hard cap on commentary is ~3000 chars; we mirror that.
+LINKEDIN_MAX = 3000
+
+
+def _get_credential(db: Session):
+    from app.db.models import PlatformCredential
+
+    return (
+        db.query(PlatformCredential)
+        .filter(PlatformCredential.platform_id == "linkedin")
+        .order_by(PlatformCredential.updated_at.desc())
+        .first()
+    )
+
+
+def _person_urn(account_id: str) -> str:
+    """Build the author URN from the raw person id."""
+    if account_id.startswith("urn:li:"):
+        return account_id
+    return f"urn:li:person:{account_id}"
+
+
+def _fetch_image_bytes(url: str) -> bytes:
+    """Download an image by URL. LinkedIn's `/rest/images` endpoint wants
+    the raw binary; we can't pass it a URL like IG does.
+    """
+    with httpx.Client(timeout=60, follow_redirects=True) as c:
+        resp = c.get(url)
+    if resp.status_code >= 400:
+        raise RuntimeError(f"Could not fetch image {url}: HTTP {resp.status_code}")
+    return resp.content
+
+
+class LinkedInPlatform(Platform):
+    id: ClassVar[str] = "linkedin"
+    name: ClassVar[str] = "LinkedIn"
+    max_length: ClassVar[int | None] = LINKEDIN_MAX
+    supports_images: ClassVar[bool] = True
+    supports_first_comment: ClassVar[bool] = False
+
+    def __init__(self, db: Session | None = None) -> None:
+        self._db = db
+
+    # ------- Content adaptation -------
+
+    def adapt_content(self, text: str) -> str:
+        """LinkedIn tolerates hashtags liberally and has a soft 3000-char cap."""
+        text = text.strip()
+        if self.max_length and len(text) > self.max_length:
+            cutoff = self.max_length - 1
+            slice_ = text[:cutoff]
+            last_space = slice_.rfind(" ")
+            if last_space > cutoff - 80:
+                slice_ = slice_[:last_space]
+            text = slice_ + "\u2026"
+        return text
+
+    # ------- Targets -------
+
+    async def list_targets(self, db: Session | None = None) -> list[dict]:
+        session = db or self._db
+        if session is None:
+            return []
+        cred = _get_credential(session)
+        if cred is None:
+            return []
+        return [
+            {
+                "external_id": cred.account_id,
+                "name": cred.username or f"LinkedIn ({cred.account_id})",
+                "meta": {"source": "linkedin_oauth"},
+            }
+        ]
+
+    # ------- Publishing -------
+
+    async def publish(
+        self,
+        post: Post,
+        target: Target,
+        humanizer: dict | None = None,
+        db: Session | None = None,
+    ) -> PublishResult:
+        session = db or self._db
+        if session is None:
+            return PublishResult(ok=False, error="No DB session for LinkedIn publish")
+        cred = _get_credential(session)
+        if cred is None:
+            return PublishResult(ok=False, error="No LinkedIn credential configured")
+
+        author_urn = _person_urn(target.external_id)
+        text = self.adapt_content(post.text)
+
+        image_urn: str | None = None
+        if post.image_url and post.image_url.startswith(("http://", "https://")):
+            try:
+                init = linkedin_api.register_image_upload(
+                    access_token=cred.access_token, author_urn=author_urn
+                )
+                image_bytes = _fetch_image_bytes(post.image_url)
+                linkedin_api.upload_image_binary(
+                    upload_url=init["upload_url"], image_bytes=image_bytes
+                )
+                image_urn = init["image_urn"]
+            except linkedin_api.LinkedInError as exc:
+                return PublishResult(ok=False, error=f"Image upload failed: {exc}")
+            except Exception as exc:
+                log.exception("Unexpected LinkedIn image upload failure")
+                return PublishResult(ok=False, error=f"Image upload: {exc}")
+        elif post.image_url:
+            # Non-public URL (localhost / file://) — drop rather than fail so
+            # the text still gets out.
+            log.info("Dropping non-public image_url for LinkedIn: %s", post.image_url)
+
+        try:
+            urn = linkedin_api.create_text_post(
+                access_token=cred.access_token,
+                author_urn=author_urn,
+                text=text,
+                image_urn=image_urn,
+            )
+        except linkedin_api.LinkedInError as exc:
+            return PublishResult(ok=False, error=str(exc))
+        except Exception as exc:
+            log.exception("Unexpected LinkedIn publish failure")
+            return PublishResult(ok=False, error=f"Unexpected: {exc}")
+
+        return PublishResult(
+            ok=True,
+            external_post_id=urn,
+            raw={"post_urn": urn, "image_urn": image_urn},
+        )
+
+    # ------- Metrics -------
+
+    async def fetch_metrics(
+        self, external_post_id: str, db: Session | None = None
+    ) -> dict | None:
+        # Full insights need Marketing-scoped tokens. Return None so the
+        # metrics service leaves the row alone instead of writing zeros.
+        return None

--- a/backend/app/platforms/linkedin_api.py
+++ b/backend/app/platforms/linkedin_api.py
@@ -1,0 +1,221 @@
+"""Thin wrapper around the LinkedIn REST + OAuth APIs.
+
+Scope of v1: publish text-only and text+image posts to the authenticated
+person's feed. Company-page posting is out of scope — the OAuth scopes below
+only cover `w_member_social`. Adding `w_organization_social` later is a
+one-line scope change.
+
+Endpoints we rely on:
+
+OAuth (3-legged, OIDC flavour):
+- GET  https://www.linkedin.com/oauth/v2/authorization  (redirect URL)
+- POST https://www.linkedin.com/oauth/v2/accessToken    (code → token)
+- GET  https://api.linkedin.com/v2/userinfo             (OIDC `sub` = person id)
+
+Posting (current `/rest/posts` endpoint, versioned header required):
+- POST https://api.linkedin.com/rest/posts              → created post URN
+
+The old `/v2/ugcPosts` endpoint still works for legacy apps but LinkedIn
+points every new app at `/rest/posts`, so that's what we target.
+
+Every function is a single HTTP call with the token passed in — nothing
+stateful, which keeps the platform layer trivially mockable.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import httpx
+
+log = logging.getLogger("platforms.linkedin")
+
+
+OAUTH_AUTH_URL = "https://www.linkedin.com/oauth/v2/authorization"
+OAUTH_TOKEN_URL = "https://www.linkedin.com/oauth/v2/accessToken"
+API_BASE = "https://api.linkedin.com"
+# LinkedIn pins every `/rest/*` endpoint to a monthly version header. We
+# target the November 2024 release — posts API hasn't changed meaningfully
+# since mid-2023, and LinkedIn promises 12 months of rolling support.
+REST_VERSION = "202411"
+
+
+@dataclass
+class LinkedInError(Exception):
+    status: int
+    code: str
+    message: str
+
+    def __str__(self) -> str:
+        return f"[{self.status}/{self.code}] {self.message}"
+
+
+def _raise_if_error(resp: httpx.Response) -> dict:
+    if resp.status_code >= 400:
+        try:
+            data = resp.json()
+        except ValueError:
+            data = {}
+        raise LinkedInError(
+            status=resp.status_code,
+            code=str(data.get("serviceErrorCode") or data.get("code") or "http_error"),
+            message=data.get("message") or resp.text[:300],
+        )
+    try:
+        return resp.json()
+    except ValueError:
+        # Some 2xx responses come back empty (e.g. /rest/posts returns the
+        # URN in a header, not a body). An empty dict is the right shape.
+        return {}
+
+
+# ---------- OAuth ----------
+
+
+def exchange_code_for_token(
+    *, client_id: str, client_secret: str, redirect_uri: str, code: str
+) -> dict:
+    """Exchange an authorization code for an access token.
+
+    LinkedIn tokens last 60 days; refresh tokens are 365 days but only issued
+    to apps explicitly enrolled in the refresh-token program. For v1 we just
+    persist the access token and let the user re-auth when it expires.
+    """
+    with httpx.Client(timeout=30) as c:
+        resp = c.post(
+            OAUTH_TOKEN_URL,
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": redirect_uri,
+                "client_id": client_id,
+                "client_secret": client_secret,
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+    return _raise_if_error(resp)
+
+
+def get_userinfo(access_token: str) -> dict:
+    """OIDC userinfo — returns `sub` (the person id), name, email.
+
+    The `sub` is what we use to build the author URN (`urn:li:person:{sub}`).
+    """
+    with httpx.Client(timeout=30) as c:
+        resp = c.get(
+            f"{API_BASE}/v2/userinfo",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+    return _raise_if_error(resp)
+
+
+# ---------- Publishing ----------
+
+
+def _build_post_payload(
+    *, author_urn: str, text: str, image_urn: str | None
+) -> dict:
+    """Shape the `/rest/posts` JSON body.
+
+    Keep visibility = PUBLIC and lifecycle = PUBLISHED. The `content` block
+    is only present for image posts; plain-text posts omit it entirely.
+    """
+    body: dict = {
+        "author": author_urn,
+        "commentary": text,
+        "visibility": "PUBLIC",
+        "distribution": {
+            "feedDistribution": "MAIN_FEED",
+            "targetEntities": [],
+            "thirdPartyDistributionChannels": [],
+        },
+        "lifecycleState": "PUBLISHED",
+        "isReshareDisabledByAuthor": False,
+    }
+    if image_urn:
+        body["content"] = {"media": {"id": image_urn}}
+    return body
+
+
+def create_text_post(
+    *, access_token: str, author_urn: str, text: str, image_urn: str | None = None
+) -> str:
+    """Publish a post. Returns the created post's URN (x-restli-id header)."""
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json",
+        "LinkedIn-Version": REST_VERSION,
+        "X-Restli-Protocol-Version": "2.0.0",
+    }
+    with httpx.Client(timeout=60) as c:
+        resp = c.post(
+            f"{API_BASE}/rest/posts",
+            json=_build_post_payload(
+                author_urn=author_urn, text=text, image_urn=image_urn
+            ),
+            headers=headers,
+        )
+    # LinkedIn returns 201 with the new URN in `x-restli-id` and an empty body.
+    if resp.status_code >= 400:
+        _raise_if_error(resp)
+    urn = resp.headers.get("x-restli-id") or resp.headers.get("X-RestLi-Id")
+    if not urn:
+        # Fallback — some proxies strip headers. Parse the response body.
+        try:
+            data = resp.json()
+        except ValueError:
+            data = {}
+        urn = data.get("id") or ""
+    if not urn:
+        raise LinkedInError(
+            status=resp.status_code,
+            code="missing_urn",
+            message="LinkedIn accepted the post but didn't return a URN",
+        )
+    return urn
+
+
+# ---------- Image upload (register + PUT) ----------
+
+
+def register_image_upload(*, access_token: str, author_urn: str) -> dict:
+    """Step 1 of the image upload dance.
+
+    Returns `{uploadUrl, image (URN)}`. The caller PUTs the binary to
+    `uploadUrl`, then passes the URN into `create_text_post(image_urn=...)`.
+    """
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json",
+        "LinkedIn-Version": REST_VERSION,
+        "X-Restli-Protocol-Version": "2.0.0",
+    }
+    with httpx.Client(timeout=30) as c:
+        resp = c.post(
+            f"{API_BASE}/rest/images?action=initializeUpload",
+            json={"initializeUploadRequest": {"owner": author_urn}},
+            headers=headers,
+        )
+    data = _raise_if_error(resp)
+    body = data.get("value") or {}
+    upload_url = body.get("uploadUrl")
+    image_urn = body.get("image")
+    if not upload_url or not image_urn:
+        raise LinkedInError(
+            status=resp.status_code,
+            code="bad_init",
+            message="initializeUpload missing uploadUrl/image URN",
+        )
+    return {"upload_url": upload_url, "image_urn": image_urn}
+
+
+def upload_image_binary(*, upload_url: str, image_bytes: bytes) -> None:
+    """Step 2 — PUT the raw bytes. The upload URL is presigned, no auth header."""
+    with httpx.Client(timeout=120) as c:
+        resp = c.put(upload_url, content=image_bytes)
+    if resp.status_code >= 400:
+        raise LinkedInError(
+            status=resp.status_code,
+            code="upload_failed",
+            message=resp.text[:300],
+        )

--- a/backend/app/platforms/registry.py
+++ b/backend/app/platforms/registry.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 from app.platforms.base import Platform
 from app.platforms.facebook import FacebookPlatform
 from app.platforms.instagram import InstagramPlatform
+from app.platforms.linkedin import LinkedInPlatform
 from app.platforms.threads import ThreadsPlatform
 
 
@@ -21,6 +22,7 @@ PLATFORMS: dict[str, type[Platform]] = {
     "facebook": FacebookPlatform,
     "instagram": InstagramPlatform,
     "threads": ThreadsPlatform,
+    "linkedin": LinkedInPlatform,
 }
 
 

--- a/backend/tests/test_linkedin.py
+++ b/backend/tests/test_linkedin.py
@@ -1,0 +1,377 @@
+"""Phase 5d — LinkedIn platform adapter.
+
+Covers:
+- linkedin_api._build_post_payload shapes the /rest/posts body correctly
+  (PUBLIC visibility, PUBLISHED lifecycle, `content.media` only when an
+  image URN is attached).
+- linkedin_api.create_text_post dispatches a POST, extracts the URN from
+  `x-restli-id`, and surfaces a LinkedInError on 4xx.
+- LinkedInPlatform.adapt_content truncates on a word boundary.
+- LinkedInPlatform.publish dispatches create_text_post with the right
+  author URN, bails cleanly when no credential is configured, and uploads
+  the image via the two-step register → PUT dance when an image_url is
+  attached.
+- Registry returns the right class.
+- /api/linkedin/oauth/url refuses without a client_id and returns a
+  well-formed URL with all expected scopes when configured.
+- /api/linkedin/oauth/callback persists a PlatformCredential.
+- /api/linkedin/credentials paste-a-token endpoint works.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from app.config import settings
+from app.db.models import (
+    PlatformCredential,
+    Post,
+    PostStatus,
+    PostType,
+    Target,
+)
+from app.platforms import linkedin_api
+from app.platforms.linkedin import LINKEDIN_MAX, LinkedInPlatform, _person_urn
+from app.platforms.registry import PLATFORMS, get_platform
+
+
+# ---------- linkedin_api pure functions ----------
+
+
+def test_build_post_payload_text_only():
+    body = linkedin_api._build_post_payload(
+        author_urn="urn:li:person:ABC", text="hi there", image_urn=None
+    )
+    assert body["author"] == "urn:li:person:ABC"
+    assert body["commentary"] == "hi there"
+    assert body["visibility"] == "PUBLIC"
+    assert body["lifecycleState"] == "PUBLISHED"
+    # No content block for text-only posts.
+    assert "content" not in body
+
+
+def test_build_post_payload_with_image():
+    body = linkedin_api._build_post_payload(
+        author_urn="urn:li:person:ABC",
+        text="hi",
+        image_urn="urn:li:image:XYZ",
+    )
+    assert body["content"] == {"media": {"id": "urn:li:image:XYZ"}}
+
+
+# ---------- linkedin_api HTTP wrapper (httpx mocked) ----------
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, headers=None, payload=None, text=""):
+        self.status_code = status_code
+        self.headers = headers or {}
+        self._payload = payload
+        self.text = text
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("no json")
+        return self._payload
+
+
+class _FakeClient:
+    def __init__(self, response: _FakeResponse, captured: list[dict]):
+        self._response = response
+        self._captured = captured
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def post(self, url, json=None, data=None, headers=None):
+        self._captured.append({"method": "POST", "url": url, "json": json, "data": data, "headers": headers})
+        return self._response
+
+    def get(self, url, headers=None, params=None):
+        self._captured.append({"method": "GET", "url": url, "headers": headers, "params": params})
+        return self._response
+
+    def put(self, url, content=None):
+        self._captured.append({"method": "PUT", "url": url, "content": content})
+        return self._response
+
+
+def test_create_text_post_extracts_urn_from_restli_header(monkeypatch):
+    captured: list[dict] = []
+    resp = _FakeResponse(
+        status_code=201,
+        headers={"x-restli-id": "urn:li:share:7123"},
+        text="",
+    )
+    monkeypatch.setattr(
+        linkedin_api.httpx,
+        "Client",
+        lambda **kw: _FakeClient(resp, captured),
+    )
+    urn = linkedin_api.create_text_post(
+        access_token="TOK",
+        author_urn="urn:li:person:ABC",
+        text="hello",
+    )
+    assert urn == "urn:li:share:7123"
+    # Verify we set the version + restli protocol headers.
+    call = captured[0]
+    assert call["headers"]["LinkedIn-Version"] == linkedin_api.REST_VERSION
+    assert call["headers"]["X-Restli-Protocol-Version"] == "2.0.0"
+    assert call["headers"]["Authorization"] == "Bearer TOK"
+
+
+def test_create_text_post_raises_on_4xx(monkeypatch):
+    captured: list[dict] = []
+    resp = _FakeResponse(
+        status_code=401,
+        payload={"serviceErrorCode": 65600, "message": "Invalid access token"},
+        text='{"message":"Invalid access token"}',
+    )
+    monkeypatch.setattr(
+        linkedin_api.httpx,
+        "Client",
+        lambda **kw: _FakeClient(resp, captured),
+    )
+    with pytest.raises(linkedin_api.LinkedInError) as ei:
+        linkedin_api.create_text_post(
+            access_token="BAD",
+            author_urn="urn:li:person:ABC",
+            text="hi",
+        )
+    assert ei.value.status == 401
+    assert "Invalid access token" in str(ei.value)
+
+
+def test_exchange_code_for_token_posts_form(monkeypatch):
+    captured: list[dict] = []
+    resp = _FakeResponse(
+        status_code=200,
+        payload={"access_token": "TOK", "expires_in": 5184000},
+    )
+    monkeypatch.setattr(
+        linkedin_api.httpx,
+        "Client",
+        lambda **kw: _FakeClient(resp, captured),
+    )
+    out = linkedin_api.exchange_code_for_token(
+        client_id="cid", client_secret="sec", redirect_uri="http://x/y", code="AUTHCODE"
+    )
+    assert out["access_token"] == "TOK"
+    assert captured[0]["url"] == linkedin_api.OAUTH_TOKEN_URL
+    assert captured[0]["data"]["code"] == "AUTHCODE"
+    assert captured[0]["data"]["grant_type"] == "authorization_code"
+
+
+# ---------- LinkedInPlatform ----------
+
+
+def test_person_urn_builds_from_bare_id():
+    assert _person_urn("abc123") == "urn:li:person:abc123"
+    # Already a URN — returned as-is.
+    assert _person_urn("urn:li:person:xyz") == "urn:li:person:xyz"
+
+
+def test_adapt_content_truncates_on_word_boundary():
+    plat = LinkedInPlatform()
+    text = ("hello world " * 400).strip()  # well over 3000 chars
+    out = plat.adapt_content(text)
+    assert len(out) <= LINKEDIN_MAX
+    assert out.endswith("\u2026")
+    # Word boundary: shouldn't end with a partial word like "hel…"
+    assert "  " not in out
+
+
+def test_adapt_content_leaves_short_text_alone():
+    assert LinkedInPlatform().adapt_content("quick note") == "quick note"
+
+
+def test_registry_returns_linkedin_platform():
+    assert "linkedin" in PLATFORMS
+    assert get_platform("linkedin").__class__.__name__ == "LinkedInPlatform"
+
+
+def _make_linkedin_cred(db, account_id="ABC123"):
+    row = PlatformCredential(
+        platform_id="linkedin",
+        account_id=account_id,
+        username="Some Person",
+        access_token="LI_TOK",
+    )
+    db.add(row)
+    db.commit()
+    return row
+
+
+def _make_target(db, external_id="ABC123"):
+    t = Target(platform_id="linkedin", external_id=external_id, name="My feed")
+    db.add(t)
+    db.commit()
+    return t
+
+
+@pytest.mark.asyncio
+async def test_publish_text_only(db):
+    _make_linkedin_cred(db)
+    target = _make_target(db)
+    post = Post(
+        post_type=PostType.INFORMATIVE,
+        status=PostStatus.DRAFT,
+        text="Sharing a quick thought",
+        image_url=None,
+    )
+
+    with patch("app.platforms.linkedin.linkedin_api.create_text_post") as create_mock:
+        create_mock.return_value = "urn:li:share:99"
+        result = await LinkedInPlatform(db=db).publish(post, target)
+
+    assert result.ok
+    assert result.external_post_id == "urn:li:share:99"
+    kwargs = create_mock.call_args.kwargs
+    assert kwargs["author_urn"] == "urn:li:person:ABC123"
+    assert kwargs["access_token"] == "LI_TOK"
+    assert kwargs["image_urn"] is None
+
+
+@pytest.mark.asyncio
+async def test_publish_with_image_registers_and_uploads(db):
+    _make_linkedin_cred(db)
+    target = _make_target(db)
+    post = Post(
+        post_type=PostType.INFORMATIVE,
+        status=PostStatus.DRAFT,
+        text="Image post",
+        image_url="https://cdn.example.com/pic.jpg",
+    )
+
+    with patch(
+        "app.platforms.linkedin.linkedin_api.register_image_upload"
+    ) as reg_mock, patch(
+        "app.platforms.linkedin.linkedin_api.upload_image_binary"
+    ) as upload_mock, patch(
+        "app.platforms.linkedin._fetch_image_bytes"
+    ) as fetch_mock, patch(
+        "app.platforms.linkedin.linkedin_api.create_text_post"
+    ) as create_mock:
+        reg_mock.return_value = {
+            "upload_url": "https://li-upload.example/presigned",
+            "image_urn": "urn:li:image:IMG_X",
+        }
+        fetch_mock.return_value = b"\xff\xd8\xff\xe0stub"
+        create_mock.return_value = "urn:li:share:42"
+
+        result = await LinkedInPlatform(db=db).publish(post, target)
+
+    assert result.ok
+    assert result.external_post_id == "urn:li:share:42"
+    upload_mock.assert_called_once_with(
+        upload_url="https://li-upload.example/presigned",
+        image_bytes=b"\xff\xd8\xff\xe0stub",
+    )
+    assert create_mock.call_args.kwargs["image_urn"] == "urn:li:image:IMG_X"
+
+
+@pytest.mark.asyncio
+async def test_publish_drops_non_public_image(db):
+    _make_linkedin_cred(db)
+    target = _make_target(db)
+    post = Post(
+        post_type=PostType.INFORMATIVE,
+        status=PostStatus.DRAFT,
+        text="Local file attempt",
+        image_url="/static/images/uploads/foo.jpg",
+    )
+
+    with patch(
+        "app.platforms.linkedin.linkedin_api.register_image_upload"
+    ) as reg_mock, patch(
+        "app.platforms.linkedin.linkedin_api.create_text_post"
+    ) as create_mock:
+        create_mock.return_value = "urn:li:share:text-only"
+        result = await LinkedInPlatform(db=db).publish(post, target)
+
+    assert result.ok
+    # We didn't try to register an image.
+    reg_mock.assert_not_called()
+    assert create_mock.call_args.kwargs["image_urn"] is None
+
+
+@pytest.mark.asyncio
+async def test_publish_without_credential_fails(db):
+    target = _make_target(db)
+    post = Post(
+        post_type=PostType.INFORMATIVE,
+        status=PostStatus.DRAFT,
+        text="no cred",
+        image_url=None,
+    )
+    result = await LinkedInPlatform(db=db).publish(post, target)
+    assert not result.ok
+    assert "credential" in result.error.lower()
+
+
+# ---------- OAuth endpoints ----------
+
+
+def test_oauth_url_requires_client_id(client, monkeypatch):
+    monkeypatch.setattr(settings, "linkedin_client_id", "", raising=True)
+    r = client.get("/api/linkedin/oauth/url")
+    assert r.status_code == 400
+    assert "LINKEDIN_CLIENT_ID" in r.json()["detail"]
+
+
+def test_oauth_url_includes_scopes(client, monkeypatch):
+    monkeypatch.setattr(settings, "linkedin_client_id", "cid-123", raising=True)
+    r = client.get("/api/linkedin/oauth/url")
+    assert r.status_code == 200
+    body = r.json()
+    assert "state" in body and body["state"]
+    url = body["url"]
+    assert url.startswith(linkedin_api.OAUTH_AUTH_URL)
+    assert "w_member_social" in url
+    assert "openid" in url
+    assert "client_id=cid-123" in url
+
+
+def test_oauth_callback_persists_credential(client, db, monkeypatch):
+    monkeypatch.setattr(settings, "linkedin_client_id", "cid", raising=True)
+    monkeypatch.setattr(settings, "linkedin_client_secret", "sec", raising=True)
+
+    def _fake_exchange(**kwargs):
+        return {"access_token": "LI_TOK", "expires_in": 5184000}
+
+    def _fake_userinfo(token):
+        return {
+            "sub": "XYZ_PERSON",
+            "name": "Test Person",
+            "email": "t@example.com",
+        }
+
+    monkeypatch.setattr(linkedin_api, "exchange_code_for_token", _fake_exchange)
+    monkeypatch.setattr(linkedin_api, "get_userinfo", _fake_userinfo)
+
+    r = client.get("/api/linkedin/oauth/callback?code=AUTH&state=abc")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["credential"]["account_id"] == "XYZ_PERSON"
+    assert body["credential"]["username"] == "Test Person"
+
+    rows = db.query(PlatformCredential).filter_by(platform_id="linkedin").all()
+    assert len(rows) == 1
+    assert rows[0].access_token == "LI_TOK"
+
+
+def test_manual_credential_endpoint(client, db):
+    r = client.post(
+        "/api/linkedin/credentials",
+        json={"account_id": "MANUAL_1", "access_token": "TOK1", "username": "Me"},
+    )
+    assert r.status_code == 200
+    rows = db.query(PlatformCredential).filter_by(platform_id="linkedin").all()
+    assert len(rows) == 1
+    assert rows[0].account_id == "MANUAL_1"
+    assert rows[0].access_token == "TOK1"

--- a/backend/tests/test_meta_platforms.py
+++ b/backend/tests/test_meta_platforms.py
@@ -79,8 +79,8 @@ def test_threads_adapt_leaves_hashtags_alone():
 # ---------- Registry ----------
 
 
-def test_registry_has_three_platforms():
-    assert set(PLATFORMS.keys()) == {"facebook", "instagram", "threads"}
+def test_registry_has_four_platforms():
+    assert set(PLATFORMS.keys()) == {"facebook", "instagram", "threads", "linkedin"}
 
 
 def test_get_platform_returns_correct_subclass():


### PR DESCRIPTION
## Summary
Implements full LinkedIn platform support including OAuth authentication, credential management, and post publishing via the official LinkedIn REST API.

## Key Changes

### New Platform Implementation
- **`app/platforms/linkedin.py`**: Core LinkedIn platform adapter implementing the `Platform` interface
  - Text and image post publishing to authenticated user's feed
  - Content adaptation with word-boundary truncation at 3000 character limit
  - Image upload via two-step register → PUT flow
  - Credential lookup and author URN construction

### LinkedIn API Wrapper
- **`app/platforms/linkedin_api.py`**: Thin HTTP wrapper around LinkedIn's REST and OAuth endpoints
  - OAuth token exchange and OIDC userinfo retrieval
  - Post creation via `/rest/posts` endpoint with proper versioning headers
  - Image registration and binary upload for the presigned upload URL flow
  - Structured error handling with `LinkedInError` exception class

### OAuth Integration
- **`app/api/linkedin_oauth.py`**: Three-legged OIDC flow endpoints
  - `GET /api/linkedin/oauth/url`: Returns authorization URL with state nonce
  - `GET /api/linkedin/oauth/callback`: Exchanges code for token, retrieves userinfo, persists credential
  - `POST /api/linkedin/credentials`: Manual token paste endpoint for CLI users
  - Credential upsert logic with audit logging

### Configuration
- **`app/config.py`**: Added LinkedIn OAuth settings
  - `linkedin_client_id`, `linkedin_client_secret`, `linkedin_redirect_uri`

### Registry & Routing
- **`app/platforms/registry.py`**: Registered `LinkedInPlatform` in platform registry
- **`app/api/__init__.py`**: Mounted LinkedIn OAuth router

### Testing
- **`tests/test_linkedin.py`**: Comprehensive test suite (377 lines)
  - Pure function tests for payload building and URN extraction
  - HTTP wrapper tests with mocked httpx client
  - Platform adapter tests for content adaptation, publishing, and image handling
  - OAuth endpoint tests for URL generation, callback flow, and credential persistence
  - Registry and manual credential endpoint tests

## Notable Implementation Details

- **Versioning**: Targets LinkedIn's November 2024 REST API version with rolling 12-month support guarantee
- **Scopes**: Requests `openid profile email w_member_social` for member feed posting; company pages deferred
- **Image Handling**: Drops non-public URLs (localhost/file://) gracefully to allow text-only fallback
- **Token Management**: Persists access tokens (60-day expiry); refresh token support deferred
- **Error Handling**: Structured `LinkedInError` with status code, service error code, and message
- **Metrics**: Returns `None` for now; full insights require Marketing-scoped tokens

https://claude.ai/code/session_0134AfB5wht644Tdt6Gad7od