### PR TITLE
Phase 5c: follower-count time series via Meta Graph

### DIFF
--- a/backend/alembic/versions/0002_add_ab_arm.py
+++ b/backend/alembic/versions/0002_add_ab_arm.py
@@ -1,0 +1,33 @@
+"""add post_variants.ab_arm
+
+Used by the A/B-split endpoint to tag each variant with the arm it was
+assigned to so metrics can be aggregated by arm afterwards.
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-04-19 21:05:00.000000
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0002"
+down_revision: Union[str, None] = "0001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("post_variants", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("ab_arm", sa.String(length=50), nullable=True))
+        batch_op.create_index(batch_op.f("ix_post_variants_ab_arm"), ["ab_arm"], unique=False)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("post_variants", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_post_variants_ab_arm"))
+        batch_op.drop_column("ab_arm")

--- a/backend/alembic/versions/0002_follower_snapshots.py
+++ b/backend/alembic/versions/0002_follower_snapshots.py
@@ -1,0 +1,62 @@
+"""add follower_snapshots
+
+Stores the daily follower-count time series per connected platform account.
+Writes are append-only: one row per collection tick per credential.
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-04-19 21:35:00.000000
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0002"
+down_revision: Union[str, None] = "0001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "follower_snapshots",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("platform_id", sa.String(length=50), nullable=False),
+        sa.Column("account_id", sa.String(length=100), nullable=False),
+        sa.Column("followers", sa.Integer(), nullable=False),
+        sa.Column(
+            "collected_at",
+            sa.DateTime(),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    with op.batch_alter_table("follower_snapshots", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_follower_snapshots_platform_id"),
+            ["platform_id"],
+            unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f("ix_follower_snapshots_account_id"),
+            ["account_id"],
+            unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f("ix_follower_snapshots_collected_at"),
+            ["collected_at"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("follower_snapshots", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_follower_snapshots_collected_at"))
+        batch_op.drop_index(batch_op.f("ix_follower_snapshots_account_id"))
+        batch_op.drop_index(batch_op.f("ix_follower_snapshots_platform_id"))
+    op.drop_table("follower_snapshots")

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -2,6 +2,7 @@
 from fastapi import APIRouter
 
 from app.api import (
+    ab_tests,
     analytics,
     auth,
     business_profile,
@@ -29,5 +30,6 @@ api_router.include_router(humanizer.router)
 api_router.include_router(analytics.router)
 api_router.include_router(meta_oauth.router)
 api_router.include_router(platform_credentials.router)
+api_router.include_router(ab_tests.router)
 
 __all__ = ["api_router"]

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -6,6 +6,7 @@ from app.api import (
     auth,
     business_profile,
     feedback,
+    followers,
     health,
     humanizer,
     media,
@@ -29,5 +30,6 @@ api_router.include_router(humanizer.router)
 api_router.include_router(analytics.router)
 api_router.include_router(meta_oauth.router)
 api_router.include_router(platform_credentials.router)
+api_router.include_router(followers.router)
 
 __all__ = ["api_router"]

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -8,6 +8,7 @@ from app.api import (
     feedback,
     health,
     humanizer,
+    linkedin_oauth,
     media,
     meta_oauth,
     plans,
@@ -28,6 +29,7 @@ api_router.include_router(media.router)
 api_router.include_router(humanizer.router)
 api_router.include_router(analytics.router)
 api_router.include_router(meta_oauth.router)
+api_router.include_router(linkedin_oauth.router)
 api_router.include_router(platform_credentials.router)
 
 __all__ = ["api_router"]

--- a/backend/app/api/ab_tests.py
+++ b/backend/app/api/ab_tests.py
@@ -1,0 +1,232 @@
+"""A/B split testing for posts.
+
+The natural axis is *targets*: you can't A/B within a single Facebook group
+(everyone there sees one post), but you can send arm A to half your groups
+and arm B to the other half. This module provides two endpoints:
+
+- POST /api/posts/{id}/ab-split — take N text arms, assign them round-robin
+  to the post's pending PostVariants, and stamp each variant with its arm
+  label. Only DRAFT / SCHEDULED / PENDING_REVIEW variants are touched —
+  already-posted rows are left alone so a late split can't rewrite history.
+- GET  /api/posts/{id}/ab-results — group the post's variants by ab_arm,
+  aggregate engagement from the best-available PostMetrics window (24h
+  preferred, 1h fallback), and surface a winner arm by average engagement.
+
+The feature lives behind a dedicated router rather than bolting onto the
+/posts router so it stays easy to remove or feature-flag if hobby-scale
+sample sizes turn out not to be useful.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Iterable
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session, selectinload
+
+from app.db import get_session
+from app.db.models import MetricsWindow, Post, PostMetrics, PostStatus, PostVariant
+
+router = APIRouter(prefix="/api/posts", tags=["posts"])
+
+
+# ---------- Schemas ----------
+
+
+class AbArmIn(BaseModel):
+    label: str = Field(min_length=1, max_length=50)
+    text: str = Field(min_length=1)
+
+
+class AbSplitRequest(BaseModel):
+    arms: list[AbArmIn] = Field(min_length=2)
+
+
+class AbArmAssignment(BaseModel):
+    label: str
+    variant_ids: list[int]
+
+
+class AbSplitResponse(BaseModel):
+    post_id: int
+    assignments: list[AbArmAssignment]
+
+
+class AbArmResult(BaseModel):
+    label: str
+    variant_count: int
+    posted_count: int
+    likes: int
+    comments: int
+    shares: int
+    avg_engagement: float
+    # Which metrics window the aggregate was taken from. Null when we have
+    # no data for this arm yet.
+    window: MetricsWindow | None = None
+
+
+class AbResultsResponse(BaseModel):
+    post_id: int
+    arms: list[AbArmResult]
+    # Arm with highest avg_engagement among arms that have posted variants.
+    # Null when no arm has been published + measured yet.
+    winner: str | None
+
+
+# ---------- Split ----------
+
+
+_MUTABLE_STATUSES = {
+    PostStatus.DRAFT,
+    PostStatus.PENDING_REVIEW,
+    PostStatus.SCHEDULED,
+}
+
+
+def _load_post(db: Session, post_id: int) -> Post:
+    post = (
+        db.query(Post)
+        .options(selectinload(Post.variants))
+        .filter(Post.id == post_id)
+        .first()
+    )
+    if post is None:
+        raise HTTPException(status_code=404, detail="Post not found")
+    return post
+
+
+@router.post("/{post_id}/ab-split", response_model=AbSplitResponse)
+def ab_split(
+    post_id: int,
+    payload: AbSplitRequest,
+    db: Session = Depends(get_session),
+) -> AbSplitResponse:
+    # Dedup arm labels — silent duplicates would make the results endpoint
+    # misleading.
+    labels = [arm.label for arm in payload.arms]
+    if len(set(labels)) != len(labels):
+        raise HTTPException(status_code=400, detail="Duplicate arm labels")
+
+    post = _load_post(db, post_id)
+    # Deterministic order so re-splitting with the same arms lands the same
+    # variants on the same arm.
+    mutable = sorted(
+        (v for v in post.variants if v.status in _MUTABLE_STATUSES),
+        key=lambda v: v.id,
+    )
+    if not mutable:
+        raise HTTPException(
+            status_code=409,
+            detail="No pending variants to split — all are posted or failed",
+        )
+
+    buckets: dict[str, list[int]] = {arm.label: [] for arm in payload.arms}
+    for idx, variant in enumerate(mutable):
+        arm = payload.arms[idx % len(payload.arms)]
+        variant.ab_arm = arm.label
+        variant.text = arm.text
+        buckets[arm.label].append(variant.id)
+    db.commit()
+
+    return AbSplitResponse(
+        post_id=post_id,
+        assignments=[
+            AbArmAssignment(label=label, variant_ids=ids)
+            for label, ids in buckets.items()
+        ],
+    )
+
+
+# ---------- Results ----------
+
+
+def _pick_metrics_window(
+    metrics_by_variant: dict[int, list[PostMetrics]],
+) -> MetricsWindow | None:
+    """Across all variants in an arm, pick the most-informative shared
+    window. 24h beats 1h beats 7d (freshest meaningful signal for a hobby
+    tool that mainly cares about recent posts). Returns None if every
+    variant in the arm is pre-measurement.
+    """
+    order = (MetricsWindow.ONE_DAY, MetricsWindow.ONE_HOUR, MetricsWindow.SEVEN_DAY)
+    available = {m.window for rows in metrics_by_variant.values() for m in rows}
+    for w in order:
+        if w in available:
+            return w
+    return None
+
+
+def _aggregate_arm(
+    label: str,
+    variants: Iterable[PostVariant],
+    metrics_by_variant: dict[int, list[PostMetrics]],
+) -> AbArmResult:
+    variants = list(variants)
+    posted = [v for v in variants if v.status == PostStatus.POSTED]
+    window = _pick_metrics_window(
+        {v.id: metrics_by_variant.get(v.id, []) for v in posted}
+    )
+    likes = comments = shares = 0
+    scores: list[float] = []
+    if window is not None:
+        for v in posted:
+            row = next(
+                (m for m in metrics_by_variant.get(v.id, []) if m.window == window),
+                None,
+            )
+            if row is None:
+                continue
+            likes += row.likes
+            comments += row.comments
+            shares += row.shares
+            scores.append(row.engagement_score)
+    avg = sum(scores) / len(scores) if scores else 0.0
+    return AbArmResult(
+        label=label,
+        variant_count=len(variants),
+        posted_count=len(posted),
+        likes=likes,
+        comments=comments,
+        shares=shares,
+        avg_engagement=avg,
+        window=window,
+    )
+
+
+@router.get("/{post_id}/ab-results", response_model=AbResultsResponse)
+def ab_results(
+    post_id: int,
+    db: Session = Depends(get_session),
+) -> AbResultsResponse:
+    post = _load_post(db, post_id)
+    split_variants = [v for v in post.variants if v.ab_arm is not None]
+    if not split_variants:
+        raise HTTPException(
+            status_code=404, detail="Post has no A/B split assigned"
+        )
+
+    variant_ids = [v.id for v in split_variants]
+    rows = (
+        db.query(PostMetrics)
+        .filter(PostMetrics.variant_id.in_(variant_ids))
+        .all()
+    )
+    metrics_by_variant: dict[int, list[PostMetrics]] = defaultdict(list)
+    for row in rows:
+        metrics_by_variant[row.variant_id].append(row)
+
+    by_arm: dict[str, list[PostVariant]] = defaultdict(list)
+    for v in split_variants:
+        by_arm[v.ab_arm].append(v)
+
+    # Iterate in the original arm-assignment order (sorted label preserves
+    # determinism across API reads).
+    results = [
+        _aggregate_arm(label, by_arm[label], metrics_by_variant)
+        for label in sorted(by_arm.keys())
+    ]
+    measurable = [r for r in results if r.posted_count > 0 and r.window is not None]
+    winner = max(measurable, key=lambda r: r.avg_engagement).label if measurable else None
+
+    return AbResultsResponse(post_id=post_id, arms=results, winner=winner)

--- a/backend/app/api/followers.py
+++ b/backend/app/api/followers.py
@@ -1,0 +1,88 @@
+"""Follower-count time series endpoints.
+
+- GET /api/followers — per-account trailing time series with 7d/30d deltas.
+  Feeds the dashboard growth chart.
+- POST /api/followers/collect — manual trigger. Normally the scheduler
+  hits this code path at 02:00 UTC; the endpoint exists so the user can
+  pull an ad-hoc snapshot without waiting for the next tick.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.db import get_session
+from app.db.models import PlatformCredential
+from app.services import followers as followers_service
+
+router = APIRouter(prefix="/api/followers", tags=["followers"])
+
+
+class FollowerSnapshotOut(BaseModel):
+    collected_at: datetime
+    followers: int
+
+
+class FollowerSeriesOut(BaseModel):
+    platform_id: str
+    account_id: str
+    username: str | None
+    current: int
+    # Oldest first — the dashboard plots left-to-right.
+    series: list[FollowerSnapshotOut]
+    # Null when the window doesn't yet have a baseline snapshot
+    # (e.g. a brand-new connection).
+    growth_7d: int | None
+    growth_30d: int | None
+
+
+class CollectFollowersResult(BaseModel):
+    collected: int
+    failed: int
+    skipped: int
+
+
+@router.get("", response_model=list[FollowerSeriesOut])
+def list_followers(
+    days: int = Query(default=30, ge=1, le=365),
+    db: Session = Depends(get_session),
+) -> list[FollowerSeriesOut]:
+    series = followers_service.read_follower_series(db, days=days)
+    # Pull usernames from credentials in one query so the dashboard can label
+    # accounts with something human-readable instead of raw IDs.
+    creds = {
+        (c.platform_id, c.account_id): c.username
+        for c in db.query(PlatformCredential).all()
+    }
+    return [
+        FollowerSeriesOut(
+            platform_id=s.platform_id,
+            account_id=s.account_id,
+            username=creds.get((s.platform_id, s.account_id)),
+            current=s.current,
+            series=[
+                FollowerSnapshotOut(collected_at=dt, followers=f)
+                for dt, f in s.series
+            ],
+            growth_7d=s.growth_7d,
+            growth_30d=s.growth_30d,
+        )
+        for s in series
+    ]
+
+
+@router.post("/collect", response_model=CollectFollowersResult)
+async def collect_now(db: Session = Depends(get_session)) -> CollectFollowersResult:
+    try:
+        result = await asyncio.to_thread(
+            followers_service.collect_follower_snapshots, db
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    return CollectFollowersResult(
+        collected=result.collected, failed=result.failed, skipped=result.skipped
+    )

--- a/backend/app/api/linkedin_oauth.py
+++ b/backend/app/api/linkedin_oauth.py
@@ -1,0 +1,198 @@
+"""LinkedIn OAuth endpoints.
+
+Three-legged OIDC flow:
+1. Dashboard hits `GET /api/linkedin/oauth/url` → returns the authorization
+   URL plus a `state` nonce to round-trip.
+2. User signs in at linkedin.com, accepts scopes, LinkedIn redirects back
+   to `GET /api/linkedin/oauth/callback?code=...&state=...`.
+3. We exchange the code for an access token, pull the OIDC `userinfo` to
+   discover the person id, and upsert a PlatformCredential row with
+   `platform_id="linkedin"`.
+
+Scopes requested: `openid profile email w_member_social`. `openid`/`profile`
+unlock `/v2/userinfo`; `w_member_social` unlocks `/rest/posts` to the
+member's own feed.
+"""
+from __future__ import annotations
+
+import logging
+import secrets
+from urllib.parse import urlencode
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.db import get_session
+from app.db.models import PlatformCredential
+from app.platforms import linkedin_api
+from app.schemas import PlatformCredentialOut
+from app.services.audit import audit_event
+
+log = logging.getLogger("api.linkedin_oauth")
+
+router = APIRouter(prefix="/api/linkedin", tags=["linkedin"])
+
+
+LINKEDIN_SCOPES = ["openid", "profile", "email", "w_member_social"]
+
+
+class LinkedInOAuthUrlOut(BaseModel):
+    url: str
+    state: str
+
+
+class LinkedInOAuthCompleteOut(BaseModel):
+    credential: PlatformCredentialOut | None = None
+    message: str
+
+
+class LinkedInManualCredentialIn(BaseModel):
+    """Paste-a-token escape hatch. CLI users who already have a valid token
+    (e.g. from the LinkedIn API console) can skip the redirect dance.
+    """
+
+    account_id: str  # LinkedIn person id (OIDC `sub`).
+    access_token: str
+    username: str | None = None
+
+
+def _upsert_credential(
+    db: Session,
+    *,
+    account_id: str,
+    access_token: str,
+    username: str | None = None,
+    extra: dict | None = None,
+) -> PlatformCredential:
+    row = (
+        db.query(PlatformCredential)
+        .filter(
+            PlatformCredential.platform_id == "linkedin",
+            PlatformCredential.account_id == account_id,
+        )
+        .one_or_none()
+    )
+    is_new = row is None
+    changed: list[str] = []
+    if is_new:
+        row = PlatformCredential(
+            platform_id="linkedin",
+            account_id=account_id,
+            username=username,
+            access_token=access_token,
+            extra=extra or {},
+        )
+        db.add(row)
+    else:
+        if row.access_token_encrypted != access_token:
+            row.access_token = access_token
+            changed.append("access_token")
+        if username and row.username != username:
+            row.username = username
+            changed.append("username")
+        if extra is not None and row.extra != extra:
+            row.extra = extra
+            changed.append("extra")
+    db.commit()
+    db.refresh(row)
+    audit_event(
+        "created" if is_new else "updated",
+        "platform_credential",
+        credential_id=row.id,
+        platform_id="linkedin",
+        account_id=account_id,
+        changed_fields=None if is_new else changed,
+    )
+    return row
+
+
+@router.get("/oauth/url", response_model=LinkedInOAuthUrlOut)
+def oauth_url() -> LinkedInOAuthUrlOut:
+    if not settings.linkedin_client_id:
+        raise HTTPException(
+            status_code=400,
+            detail="LINKEDIN_CLIENT_ID is not configured in .env",
+        )
+    state = secrets.token_urlsafe(24)
+    params = {
+        "response_type": "code",
+        "client_id": settings.linkedin_client_id,
+        "redirect_uri": settings.linkedin_redirect_uri,
+        "state": state,
+        "scope": " ".join(LINKEDIN_SCOPES),
+    }
+    return LinkedInOAuthUrlOut(
+        url=f"{linkedin_api.OAUTH_AUTH_URL}?{urlencode(params)}",
+        state=state,
+    )
+
+
+@router.get("/oauth/callback", response_model=LinkedInOAuthCompleteOut)
+def oauth_callback(
+    code: str = Query(..., description="Authorization code from LinkedIn"),
+    state: str | None = Query(None),
+    db: Session = Depends(get_session),
+) -> LinkedInOAuthCompleteOut:
+    """Complete the OAuth dance. Called by LinkedIn's redirect.
+
+    Same state-verification caveat as Meta: single-user localhost tool, no
+    real CSRF surface, we trust the redirect.
+    """
+    if not settings.linkedin_client_id or not settings.linkedin_client_secret:
+        raise HTTPException(status_code=400, detail="LinkedIn app credentials missing")
+    try:
+        token_resp = linkedin_api.exchange_code_for_token(
+            client_id=settings.linkedin_client_id,
+            client_secret=settings.linkedin_client_secret,
+            redirect_uri=settings.linkedin_redirect_uri,
+            code=code,
+        )
+    except linkedin_api.LinkedInError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    access_token = token_resp.get("access_token")
+    if not access_token:
+        raise HTTPException(status_code=400, detail="LinkedIn did not return an access_token")
+
+    try:
+        userinfo = linkedin_api.get_userinfo(access_token)
+    except linkedin_api.LinkedInError as exc:
+        raise HTTPException(status_code=400, detail=f"userinfo failed: {exc}") from exc
+
+    sub = userinfo.get("sub")
+    if not sub:
+        raise HTTPException(
+            status_code=400,
+            detail="LinkedIn userinfo missing `sub` — cannot derive person URN",
+        )
+
+    row = _upsert_credential(
+        db,
+        account_id=sub,
+        access_token=access_token,
+        username=userinfo.get("name"),
+        extra={
+            "email": userinfo.get("email"),
+            "locale": userinfo.get("locale"),
+        },
+    )
+    return LinkedInOAuthCompleteOut(
+        credential=PlatformCredentialOut.model_validate(row),
+        message=f"LinkedIn account {sub} connected",
+    )
+
+
+@router.post("/credentials", response_model=PlatformCredentialOut)
+def add_credential(
+    payload: LinkedInManualCredentialIn,
+    db: Session = Depends(get_session),
+) -> PlatformCredentialOut:
+    row = _upsert_credential(
+        db,
+        account_id=payload.account_id,
+        access_token=payload.access_token,
+        username=payload.username,
+    )
+    return PlatformCredentialOut.model_validate(row)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -51,6 +51,14 @@ class Settings(BaseSettings):
     # The Threads user id (numeric).
     threads_user_id: str = ""
 
+    # Phase 5d — LinkedIn OAuth.
+    # Values come from https://www.linkedin.com/developers/apps. Scopes we
+    # request: `openid profile email w_member_social`. For company-page
+    # posting, add `w_organization_social` and wire target URN separately.
+    linkedin_client_id: str = ""
+    linkedin_client_secret: str = ""
+    linkedin_redirect_uri: str = "http://localhost:8787/api/linkedin/oauth/callback"
+
     # M8 — Security
     # Empty = auth disabled (single-user localhost default). Set to any
     # 4–32 char string to require `X-Dashboard-Pin` or a `/api/auth/login`

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -591,3 +591,20 @@ class FewShotExample(Base):
     text: Mapped[str] = mapped_column(Text)
     engagement_score: Mapped[float] = mapped_column(Float, default=0.0)
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+
+
+class FollowerSnapshot(Base):
+    """Daily follower count per connected platform account. A time series —
+    we never update a row, we insert a new one. Growth deltas are computed
+    on read.
+    """
+
+    __tablename__ = "follower_snapshots"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    platform_id: Mapped[str] = mapped_column(String(50), index=True)
+    account_id: Mapped[str] = mapped_column(String(100), index=True)
+    followers: Mapped[int] = mapped_column(Integer)
+    collected_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), index=True
+    )

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -218,6 +218,9 @@ class PostVariant(Base):
     posted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     external_post_id: Mapped[str | None] = mapped_column(String(500), nullable=True)
     error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # A/B test arm label (e.g. "control", "a", "b"). Null when the post isn't
+    # part of a split test. Populated by POST /api/posts/{id}/ab-split.
+    ab_arm: Mapped[str | None] = mapped_column(String(50), nullable=True, index=True)
 
     post: Mapped[Post] = relationship(back_populates="variants")
 

--- a/backend/app/platforms/linkedin.py
+++ b/backend/app/platforms/linkedin.py
@@ -1,0 +1,175 @@
+"""LinkedIn platform (via the official REST API, no browser automation).
+
+Scope of v1:
+- Person (`urn:li:person:*`) posts. Company pages come later — the OAuth
+  scope `w_organization_social` would need to be added.
+- Text-only posts and text + single image.
+- Reads one PlatformCredential row with `platform_id="linkedin"`. The
+  `account_id` is the LinkedIn person id (OIDC `sub`), stored as the raw
+  id so we can build the URN at publish time.
+
+Posting flow:
+  1. If an `image_url` is attached, fetch the bytes → register upload →
+     PUT the bytes → we get back an image URN.
+  2. POST /rest/posts with commentary + (optional) image URN.
+
+Metrics: LinkedIn's `socialActions` endpoint gives likes/comments; a full
+insights surface needs Marketing-scope tokens we don't ask for. Return
+None for now and let the metrics service fill zeros.
+"""
+from __future__ import annotations
+
+import logging
+from typing import ClassVar
+
+import httpx
+from sqlalchemy.orm import Session
+
+from app.db.models import Post, Target
+from app.platforms import linkedin_api
+from app.platforms.base import Platform, PublishResult
+
+log = logging.getLogger("platforms.linkedin")
+
+
+# LinkedIn's hard cap on commentary is ~3000 chars; we mirror that.
+LINKEDIN_MAX = 3000
+
+
+def _get_credential(db: Session):
+    from app.db.models import PlatformCredential
+
+    return (
+        db.query(PlatformCredential)
+        .filter(PlatformCredential.platform_id == "linkedin")
+        .order_by(PlatformCredential.updated_at.desc())
+        .first()
+    )
+
+
+def _person_urn(account_id: str) -> str:
+    """Build the author URN from the raw person id."""
+    if account_id.startswith("urn:li:"):
+        return account_id
+    return f"urn:li:person:{account_id}"
+
+
+def _fetch_image_bytes(url: str) -> bytes:
+    """Download an image by URL. LinkedIn's `/rest/images` endpoint wants
+    the raw binary; we can't pass it a URL like IG does.
+    """
+    with httpx.Client(timeout=60, follow_redirects=True) as c:
+        resp = c.get(url)
+    if resp.status_code >= 400:
+        raise RuntimeError(f"Could not fetch image {url}: HTTP {resp.status_code}")
+    return resp.content
+
+
+class LinkedInPlatform(Platform):
+    id: ClassVar[str] = "linkedin"
+    name: ClassVar[str] = "LinkedIn"
+    max_length: ClassVar[int | None] = LINKEDIN_MAX
+    supports_images: ClassVar[bool] = True
+    supports_first_comment: ClassVar[bool] = False
+
+    def __init__(self, db: Session | None = None) -> None:
+        self._db = db
+
+    # ------- Content adaptation -------
+
+    def adapt_content(self, text: str) -> str:
+        """LinkedIn tolerates hashtags liberally and has a soft 3000-char cap."""
+        text = text.strip()
+        if self.max_length and len(text) > self.max_length:
+            cutoff = self.max_length - 1
+            slice_ = text[:cutoff]
+            last_space = slice_.rfind(" ")
+            if last_space > cutoff - 80:
+                slice_ = slice_[:last_space]
+            text = slice_ + "\u2026"
+        return text
+
+    # ------- Targets -------
+
+    async def list_targets(self, db: Session | None = None) -> list[dict]:
+        session = db or self._db
+        if session is None:
+            return []
+        cred = _get_credential(session)
+        if cred is None:
+            return []
+        return [
+            {
+                "external_id": cred.account_id,
+                "name": cred.username or f"LinkedIn ({cred.account_id})",
+                "meta": {"source": "linkedin_oauth"},
+            }
+        ]
+
+    # ------- Publishing -------
+
+    async def publish(
+        self,
+        post: Post,
+        target: Target,
+        humanizer: dict | None = None,
+        db: Session | None = None,
+    ) -> PublishResult:
+        session = db or self._db
+        if session is None:
+            return PublishResult(ok=False, error="No DB session for LinkedIn publish")
+        cred = _get_credential(session)
+        if cred is None:
+            return PublishResult(ok=False, error="No LinkedIn credential configured")
+
+        author_urn = _person_urn(target.external_id)
+        text = self.adapt_content(post.text)
+
+        image_urn: str | None = None
+        if post.image_url and post.image_url.startswith(("http://", "https://")):
+            try:
+                init = linkedin_api.register_image_upload(
+                    access_token=cred.access_token, author_urn=author_urn
+                )
+                image_bytes = _fetch_image_bytes(post.image_url)
+                linkedin_api.upload_image_binary(
+                    upload_url=init["upload_url"], image_bytes=image_bytes
+                )
+                image_urn = init["image_urn"]
+            except linkedin_api.LinkedInError as exc:
+                return PublishResult(ok=False, error=f"Image upload failed: {exc}")
+            except Exception as exc:
+                log.exception("Unexpected LinkedIn image upload failure")
+                return PublishResult(ok=False, error=f"Image upload: {exc}")
+        elif post.image_url:
+            # Non-public URL (localhost / file://) — drop rather than fail so
+            # the text still gets out.
+            log.info("Dropping non-public image_url for LinkedIn: %s", post.image_url)
+
+        try:
+            urn = linkedin_api.create_text_post(
+                access_token=cred.access_token,
+                author_urn=author_urn,
+                text=text,
+                image_urn=image_urn,
+            )
+        except linkedin_api.LinkedInError as exc:
+            return PublishResult(ok=False, error=str(exc))
+        except Exception as exc:
+            log.exception("Unexpected LinkedIn publish failure")
+            return PublishResult(ok=False, error=f"Unexpected: {exc}")
+
+        return PublishResult(
+            ok=True,
+            external_post_id=urn,
+            raw={"post_urn": urn, "image_urn": image_urn},
+        )
+
+    # ------- Metrics -------
+
+    async def fetch_metrics(
+        self, external_post_id: str, db: Session | None = None
+    ) -> dict | None:
+        # Full insights need Marketing-scoped tokens. Return None so the
+        # metrics service leaves the row alone instead of writing zeros.
+        return None

--- a/backend/app/platforms/linkedin_api.py
+++ b/backend/app/platforms/linkedin_api.py
@@ -1,0 +1,221 @@
+"""Thin wrapper around the LinkedIn REST + OAuth APIs.
+
+Scope of v1: publish text-only and text+image posts to the authenticated
+person's feed. Company-page posting is out of scope — the OAuth scopes below
+only cover `w_member_social`. Adding `w_organization_social` later is a
+one-line scope change.
+
+Endpoints we rely on:
+
+OAuth (3-legged, OIDC flavour):
+- GET  https://www.linkedin.com/oauth/v2/authorization  (redirect URL)
+- POST https://www.linkedin.com/oauth/v2/accessToken    (code → token)
+- GET  https://api.linkedin.com/v2/userinfo             (OIDC `sub` = person id)
+
+Posting (current `/rest/posts` endpoint, versioned header required):
+- POST https://api.linkedin.com/rest/posts              → created post URN
+
+The old `/v2/ugcPosts` endpoint still works for legacy apps but LinkedIn
+points every new app at `/rest/posts`, so that's what we target.
+
+Every function is a single HTTP call with the token passed in — nothing
+stateful, which keeps the platform layer trivially mockable.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import httpx
+
+log = logging.getLogger("platforms.linkedin")
+
+
+OAUTH_AUTH_URL = "https://www.linkedin.com/oauth/v2/authorization"
+OAUTH_TOKEN_URL = "https://www.linkedin.com/oauth/v2/accessToken"
+API_BASE = "https://api.linkedin.com"
+# LinkedIn pins every `/rest/*` endpoint to a monthly version header. We
+# target the November 2024 release — posts API hasn't changed meaningfully
+# since mid-2023, and LinkedIn promises 12 months of rolling support.
+REST_VERSION = "202411"
+
+
+@dataclass
+class LinkedInError(Exception):
+    status: int
+    code: str
+    message: str
+
+    def __str__(self) -> str:
+        return f"[{self.status}/{self.code}] {self.message}"
+
+
+def _raise_if_error(resp: httpx.Response) -> dict:
+    if resp.status_code >= 400:
+        try:
+            data = resp.json()
+        except ValueError:
+            data = {}
+        raise LinkedInError(
+            status=resp.status_code,
+            code=str(data.get("serviceErrorCode") or data.get("code") or "http_error"),
+            message=data.get("message") or resp.text[:300],
+        )
+    try:
+        return resp.json()
+    except ValueError:
+        # Some 2xx responses come back empty (e.g. /rest/posts returns the
+        # URN in a header, not a body). An empty dict is the right shape.
+        return {}
+
+
+# ---------- OAuth ----------
+
+
+def exchange_code_for_token(
+    *, client_id: str, client_secret: str, redirect_uri: str, code: str
+) -> dict:
+    """Exchange an authorization code for an access token.
+
+    LinkedIn tokens last 60 days; refresh tokens are 365 days but only issued
+    to apps explicitly enrolled in the refresh-token program. For v1 we just
+    persist the access token and let the user re-auth when it expires.
+    """
+    with httpx.Client(timeout=30) as c:
+        resp = c.post(
+            OAUTH_TOKEN_URL,
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": redirect_uri,
+                "client_id": client_id,
+                "client_secret": client_secret,
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+    return _raise_if_error(resp)
+
+
+def get_userinfo(access_token: str) -> dict:
+    """OIDC userinfo — returns `sub` (the person id), name, email.
+
+    The `sub` is what we use to build the author URN (`urn:li:person:{sub}`).
+    """
+    with httpx.Client(timeout=30) as c:
+        resp = c.get(
+            f"{API_BASE}/v2/userinfo",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+    return _raise_if_error(resp)
+
+
+# ---------- Publishing ----------
+
+
+def _build_post_payload(
+    *, author_urn: str, text: str, image_urn: str | None
+) -> dict:
+    """Shape the `/rest/posts` JSON body.
+
+    Keep visibility = PUBLIC and lifecycle = PUBLISHED. The `content` block
+    is only present for image posts; plain-text posts omit it entirely.
+    """
+    body: dict = {
+        "author": author_urn,
+        "commentary": text,
+        "visibility": "PUBLIC",
+        "distribution": {
+            "feedDistribution": "MAIN_FEED",
+            "targetEntities": [],
+            "thirdPartyDistributionChannels": [],
+        },
+        "lifecycleState": "PUBLISHED",
+        "isReshareDisabledByAuthor": False,
+    }
+    if image_urn:
+        body["content"] = {"media": {"id": image_urn}}
+    return body
+
+
+def create_text_post(
+    *, access_token: str, author_urn: str, text: str, image_urn: str | None = None
+) -> str:
+    """Publish a post. Returns the created post's URN (x-restli-id header)."""
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json",
+        "LinkedIn-Version": REST_VERSION,
+        "X-Restli-Protocol-Version": "2.0.0",
+    }
+    with httpx.Client(timeout=60) as c:
+        resp = c.post(
+            f"{API_BASE}/rest/posts",
+            json=_build_post_payload(
+                author_urn=author_urn, text=text, image_urn=image_urn
+            ),
+            headers=headers,
+        )
+    # LinkedIn returns 201 with the new URN in `x-restli-id` and an empty body.
+    if resp.status_code >= 400:
+        _raise_if_error(resp)
+    urn = resp.headers.get("x-restli-id") or resp.headers.get("X-RestLi-Id")
+    if not urn:
+        # Fallback — some proxies strip headers. Parse the response body.
+        try:
+            data = resp.json()
+        except ValueError:
+            data = {}
+        urn = data.get("id") or ""
+    if not urn:
+        raise LinkedInError(
+            status=resp.status_code,
+            code="missing_urn",
+            message="LinkedIn accepted the post but didn't return a URN",
+        )
+    return urn
+
+
+# ---------- Image upload (register + PUT) ----------
+
+
+def register_image_upload(*, access_token: str, author_urn: str) -> dict:
+    """Step 1 of the image upload dance.
+
+    Returns `{uploadUrl, image (URN)}`. The caller PUTs the binary to
+    `uploadUrl`, then passes the URN into `create_text_post(image_urn=...)`.
+    """
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json",
+        "LinkedIn-Version": REST_VERSION,
+        "X-Restli-Protocol-Version": "2.0.0",
+    }
+    with httpx.Client(timeout=30) as c:
+        resp = c.post(
+            f"{API_BASE}/rest/images?action=initializeUpload",
+            json={"initializeUploadRequest": {"owner": author_urn}},
+            headers=headers,
+        )
+    data = _raise_if_error(resp)
+    body = data.get("value") or {}
+    upload_url = body.get("uploadUrl")
+    image_urn = body.get("image")
+    if not upload_url or not image_urn:
+        raise LinkedInError(
+            status=resp.status_code,
+            code="bad_init",
+            message="initializeUpload missing uploadUrl/image URN",
+        )
+    return {"upload_url": upload_url, "image_urn": image_urn}
+
+
+def upload_image_binary(*, upload_url: str, image_bytes: bytes) -> None:
+    """Step 2 — PUT the raw bytes. The upload URL is presigned, no auth header."""
+    with httpx.Client(timeout=120) as c:
+        resp = c.put(upload_url, content=image_bytes)
+    if resp.status_code >= 400:
+        raise LinkedInError(
+            status=resp.status_code,
+            code="upload_failed",
+            message=resp.text[:300],
+        )

--- a/backend/app/platforms/meta_graph.py
+++ b/backend/app/platforms/meta_graph.py
@@ -232,6 +232,27 @@ def threads_publish_container(
     return data["id"]
 
 
+def get_followers_count(account_id: str, access_token: str, *, is_threads: bool = False) -> int:
+    """Current follower count for a Page, IG Business account, or Threads user.
+
+    - FB Page / IG Business → ``followers_count`` via graph.facebook.com.
+    - Threads user → ``followers_count`` via graph.threads.net.
+
+    Raises `MetaError` on API failure; we deliberately don't swallow here
+    so the scheduler can log and skip, and retries happen at the job level.
+    """
+    base = THREADS_BASE if is_threads else GRAPH_BASE
+    with httpx.Client(timeout=30) as c:
+        resp = c.get(
+            f"{base}/{account_id}",
+            params={"fields": "followers_count", "access_token": access_token},
+        )
+    data = _raise_if_error(resp)
+    # Meta returns the field as a plain int; fall through to 0 if missing so
+    # we record a deliberate "we asked, got nothing" rather than crashing.
+    return int(data.get("followers_count") or 0)
+
+
 def threads_insights(media_id: str, access_token: str) -> dict:
     with httpx.Client(timeout=30) as c:
         resp = c.get(

--- a/backend/app/platforms/registry.py
+++ b/backend/app/platforms/registry.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 from app.platforms.base import Platform
 from app.platforms.facebook import FacebookPlatform
 from app.platforms.instagram import InstagramPlatform
+from app.platforms.linkedin import LinkedInPlatform
 from app.platforms.threads import ThreadsPlatform
 
 
@@ -21,6 +22,7 @@ PLATFORMS: dict[str, type[Platform]] = {
     "facebook": FacebookPlatform,
     "instagram": InstagramPlatform,
     "threads": ThreadsPlatform,
+    "linkedin": LinkedInPlatform,
 }
 
 

--- a/backend/app/scheduler/__init__.py
+++ b/backend/app/scheduler/__init__.py
@@ -30,6 +30,7 @@ class SchedulerSingleton:
             return
         # Late import: jobs.py imports models, which require db init first.
         from app.scheduler.jobs import (
+            collect_follower_snapshots_tick,
             collect_metrics_tick,
             daily_backup_tick,
             publish_due_posts,
@@ -77,9 +78,21 @@ class SchedulerSingleton:
             coalesce=True,
             max_instances=1,
         )
+        # Daily follower-count snapshot — 02:00 UTC, before the backup so
+        # the snapshot is included in the archive that day.
+        self._impl.add_job(
+            collect_follower_snapshots_tick,
+            trigger="cron",
+            hour=2,
+            minute=0,
+            id="collect_followers",
+            coalesce=True,
+            max_instances=1,
+        )
         self._impl.start()
         log.info(
-            "Scheduler started (publish 30s, metrics 1h, analyst Sun 21:00, backup 03:00)"
+            "Scheduler started (publish 30s, metrics 1h, analyst Sun 21:00, "
+            "followers 02:00, backup 03:00)"
         )
 
     def shutdown(self, wait: bool = False) -> None:

--- a/backend/app/scheduler/jobs.py
+++ b/backend/app/scheduler/jobs.py
@@ -221,6 +221,26 @@ async def daily_backup_tick() -> None:
         log.exception("daily_backup_tick crashed")
 
 
+async def collect_follower_snapshots_tick() -> None:
+    """Daily. One follower-count snapshot per connected Meta credential."""
+    from app.services import followers
+
+    db = SessionLocal()
+    try:
+        result = await asyncio.to_thread(followers.collect_follower_snapshots, db)
+        if result.collected or result.failed:
+            log.info(
+                "follower snapshot tick: collected=%d failed=%d skipped=%d",
+                result.collected,
+                result.failed,
+                result.skipped,
+            )
+    except Exception:
+        log.exception("collect_follower_snapshots_tick crashed")
+    finally:
+        db.close()
+
+
 async def weekly_analyst_tick() -> None:
     """Weekly Analyst run. No-op if profile or fresh metrics are missing."""
     from datetime import timedelta

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -186,6 +186,7 @@ class PostVariantOut(BaseModel):
     posted_at: datetime | None
     external_post_id: str | None
     error: str | None
+    ab_arm: str | None = None
 
 
 class PostOut(BaseModel):

--- a/backend/app/services/followers.py
+++ b/backend/app/services/followers.py
@@ -1,0 +1,171 @@
+"""Follower-count time series.
+
+One daily snapshot per `PlatformCredential` on Meta platforms. The
+scheduler calls `collect_follower_snapshots` at 02:00 UTC; the analytics
+endpoint reads snapshots back and computes growth deltas over the common
+7/30-day windows.
+
+We only talk to Meta for now — LinkedIn follower counts land in a later
+phase (behind its own adapter). Unknown platforms are skipped silently so
+adding one later doesn't require editing this file.
+"""
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy.orm import Session
+
+from app.db.models import FollowerSnapshot, PlatformCredential
+from app.platforms import meta_graph
+
+log = logging.getLogger("services.followers")
+
+# Credential platform_ids we know how to fetch for.
+_META_PLATFORM_IDS = {"facebook", "instagram", "threads"}
+
+
+@dataclass
+class CollectResult:
+    collected: int
+    failed: int
+    skipped: int
+
+
+def fetch_followers_for_credential(cred: PlatformCredential) -> int:
+    """Return current follower count for one credential.
+
+    Delegates to `meta_graph.get_followers_count`. `is_threads=True` for
+    Threads so we hit the right API base.
+    """
+    if cred.platform_id not in _META_PLATFORM_IDS:
+        raise ValueError(f"Unsupported platform: {cred.platform_id}")
+    return meta_graph.get_followers_count(
+        cred.account_id,
+        cred.access_token,
+        is_threads=cred.platform_id == "threads",
+    )
+
+
+def collect_follower_snapshots(db: Session, *, now: datetime | None = None) -> CollectResult:
+    """Walk credentials; one snapshot per success. Failures are logged but
+    don't break the tick — a single dead token shouldn't lose snapshots
+    for every other platform.
+    """
+    when = now or datetime.now(UTC)
+    result = CollectResult(collected=0, failed=0, skipped=0)
+    creds = db.query(PlatformCredential).all()
+    for cred in creds:
+        if cred.platform_id not in _META_PLATFORM_IDS:
+            result.skipped += 1
+            continue
+        try:
+            count = fetch_followers_for_credential(cred)
+        except Exception as exc:  # noqa: BLE001
+            log.warning(
+                "follower fetch failed for %s/%s: %s",
+                cred.platform_id,
+                cred.account_id,
+                exc,
+            )
+            result.failed += 1
+            continue
+        db.add(
+            FollowerSnapshot(
+                platform_id=cred.platform_id,
+                account_id=cred.account_id,
+                followers=count,
+                collected_at=when,
+            )
+        )
+        result.collected += 1
+    if result.collected:
+        db.commit()
+    return result
+
+
+# ---------- Read side ----------
+
+
+@dataclass
+class AccountSeries:
+    """Time series + derived growth deltas for one (platform, account)."""
+
+    platform_id: str
+    account_id: str
+    current: int
+    # (collected_at, followers) pairs, oldest first.
+    series: list[tuple[datetime, int]]
+    growth_7d: int | None
+    growth_30d: int | None
+
+
+def _as_naive_utc(dt: datetime) -> datetime:
+    """SQLite stores timezone-naive datetimes. Normalise so comparisons with
+    DB-loaded values don't raise."""
+    if dt.tzinfo is None:
+        return dt
+    return dt.astimezone(UTC).replace(tzinfo=None)
+
+
+def _growth_over(
+    series: list[tuple[datetime, int]], days: int, now: datetime
+) -> int | None:
+    """Change in followers between the oldest snapshot older than `days` ago
+    and `current`. None if the window has no baseline yet.
+    """
+    if not series:
+        return None
+    cutoff = now - timedelta(days=days)
+    baseline = None
+    for collected_at, followers in series:
+        if _as_naive_utc(collected_at) <= _as_naive_utc(cutoff):
+            baseline = followers
+        else:
+            break
+    if baseline is None:
+        return None
+    return series[-1][1] - baseline
+
+
+def read_follower_series(
+    db: Session,
+    *,
+    days: int = 30,
+    now: datetime | None = None,
+) -> list[AccountSeries]:
+    """Per-account time series over the trailing N days, plus growth deltas
+    over 7 and 30 day windows.
+    """
+    when = now or datetime.now(UTC)
+    cutoff = _as_naive_utc(when - timedelta(days=days))
+    rows = (
+        db.query(FollowerSnapshot)
+        .filter(FollowerSnapshot.collected_at >= cutoff)
+        .order_by(
+            FollowerSnapshot.platform_id.asc(),
+            FollowerSnapshot.account_id.asc(),
+            FollowerSnapshot.collected_at.asc(),
+        )
+        .all()
+    )
+    grouped: dict[tuple[str, str], list[FollowerSnapshot]] = defaultdict(list)
+    for r in rows:
+        grouped[(r.platform_id, r.account_id)].append(r)
+
+    out: list[AccountSeries] = []
+    for (platform_id, account_id), snaps in grouped.items():
+        pairs = [(s.collected_at, s.followers) for s in snaps]
+        out.append(
+            AccountSeries(
+                platform_id=platform_id,
+                account_id=account_id,
+                current=pairs[-1][1],
+                series=pairs,
+                growth_7d=_growth_over(pairs, 7, when),
+                growth_30d=_growth_over(pairs, 30, when),
+            )
+        )
+    return out

--- a/backend/tests/test_ab_tests.py
+++ b/backend/tests/test_ab_tests.py
@@ -1,0 +1,269 @@
+"""Phase 5b — A/B split tests.
+
+Covers:
+- Split distributes variants round-robin across arms.
+- Arms rewrite variant text and stamp ab_arm.
+- Already-posted variants are left alone (so re-splitting can't rewrite
+  history of what actually went out).
+- Rejects duplicate labels and single-arm splits.
+- /ab-results aggregates engagement per arm and picks a winner from the
+  freshest shared metrics window.
+- Returns 404 if no split has been assigned.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from app.db.models import (
+    MetricsWindow,
+    Post,
+    PostMetrics,
+    PostStatus,
+    PostType,
+    PostVariant,
+    Target,
+)
+
+
+def _seed(db, *, n_variants: int = 4, all_status: PostStatus = PostStatus.SCHEDULED) -> Post:
+    post = Post(post_type=PostType.INFORMATIVE, status=PostStatus.SCHEDULED, text="seed")
+    db.add(post)
+    db.flush()
+    targets = []
+    for i in range(n_variants):
+        t = Target(
+            platform_id="facebook",
+            external_id=f"ext-{i}",
+            name=f"group {i}",
+            tags=[],
+            active=True,
+            source="manual",
+        )
+        db.add(t)
+        db.flush()
+        targets.append(t)
+    for t in targets:
+        db.add(
+            PostVariant(
+                post_id=post.id,
+                target_id=t.id,
+                text=f"original for {t.name}",
+                status=all_status,
+            )
+        )
+    db.commit()
+    db.refresh(post)
+    return post
+
+
+def _metrics_row(
+    variant_id: int,
+    window: MetricsWindow,
+    likes: int,
+    comments: int,
+    shares: int,
+    engagement: float,
+) -> PostMetrics:
+    return PostMetrics(
+        variant_id=variant_id,
+        window=window,
+        likes=likes,
+        comments=comments,
+        shares=shares,
+        engagement_score=engagement,
+        collected_at=datetime.now(UTC),
+    )
+
+
+# ---------- /ab-split ----------
+
+
+def test_split_round_robin_assigns_arms(client, db):
+    post = _seed(db, n_variants=4)
+    r = client.post(
+        f"/api/posts/{post.id}/ab-split",
+        json={
+            "arms": [
+                {"label": "a", "text": "arm-a text"},
+                {"label": "b", "text": "arm-b text"},
+            ]
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    labels = {a["label"]: a["variant_ids"] for a in body["assignments"]}
+    assert set(labels) == {"a", "b"}
+    assert len(labels["a"]) == 2 and len(labels["b"]) == 2
+    # Round-robin in id order: arms receive the 1st and 3rd, 2nd and 4th
+    # variants respectively.
+    all_ids = sorted(labels["a"] + labels["b"])
+    assert labels["a"] == [all_ids[0], all_ids[2]]
+    assert labels["b"] == [all_ids[1], all_ids[3]]
+
+    # Variants now carry ab_arm and the arm's text, not the original.
+    db.expire_all()
+    fresh = db.query(PostVariant).filter(PostVariant.post_id == post.id).all()
+    assert all(v.ab_arm in {"a", "b"} for v in fresh)
+    assert {v.text for v in fresh if v.ab_arm == "a"} == {"arm-a text"}
+    assert {v.text for v in fresh if v.ab_arm == "b"} == {"arm-b text"}
+
+
+def test_split_leaves_posted_variants_alone(client, db):
+    post = _seed(db, n_variants=2, all_status=PostStatus.SCHEDULED)
+    # One variant is already POSTED — rewriting its text would be a lie.
+    posted_variant = post.variants[0]
+    posted_variant.status = PostStatus.POSTED
+    db.commit()
+    original_text = posted_variant.text
+
+    r = client.post(
+        f"/api/posts/{post.id}/ab-split",
+        json={
+            "arms": [
+                {"label": "a", "text": "arm-a text"},
+                {"label": "b", "text": "arm-b text"},
+            ]
+        },
+    )
+    assert r.status_code == 200
+
+    db.expire_all()
+    v0 = db.get(PostVariant, posted_variant.id)
+    assert v0.ab_arm is None
+    assert v0.text == original_text
+
+
+def test_split_rejects_duplicate_labels(client, db):
+    post = _seed(db, n_variants=2)
+    r = client.post(
+        f"/api/posts/{post.id}/ab-split",
+        json={
+            "arms": [
+                {"label": "a", "text": "x"},
+                {"label": "a", "text": "y"},
+            ]
+        },
+    )
+    assert r.status_code == 400
+
+
+def test_split_requires_at_least_two_arms(client, db):
+    post = _seed(db, n_variants=2)
+    r = client.post(
+        f"/api/posts/{post.id}/ab-split",
+        json={"arms": [{"label": "only", "text": "x"}]},
+    )
+    # Pydantic min_length=2 → 422 validation error.
+    assert r.status_code == 422
+
+
+def test_split_returns_409_when_no_pending_variants(client, db):
+    post = _seed(db, n_variants=2, all_status=PostStatus.POSTED)
+    r = client.post(
+        f"/api/posts/{post.id}/ab-split",
+        json={
+            "arms": [
+                {"label": "a", "text": "x"},
+                {"label": "b", "text": "y"},
+            ]
+        },
+    )
+    assert r.status_code == 409
+
+
+def test_split_404_when_post_missing(client):
+    r = client.post(
+        "/api/posts/999/ab-split",
+        json={
+            "arms": [
+                {"label": "a", "text": "x"},
+                {"label": "b", "text": "y"},
+            ]
+        },
+    )
+    assert r.status_code == 404
+
+
+# ---------- /ab-results ----------
+
+
+def test_ab_results_404_when_not_split(client, db):
+    post = _seed(db, n_variants=2)
+    r = client.get(f"/api/posts/{post.id}/ab-results")
+    assert r.status_code == 404
+
+
+def test_ab_results_aggregates_per_arm_and_picks_winner(client, db):
+    post = _seed(db, n_variants=4)
+    variants = sorted(post.variants, key=lambda v: v.id)
+    # Assign arms and mark all posted so metrics are measurable.
+    for i, v in enumerate(variants):
+        v.ab_arm = "a" if i % 2 == 0 else "b"
+        v.status = PostStatus.POSTED
+        v.text = f"arm-{v.ab_arm}"
+    db.commit()
+
+    # Arm A: engagement 1.0 and 2.0 → avg 1.5
+    # Arm B: engagement 5.0 and 9.0 → avg 7.0 (winner)
+    db.add_all(
+        [
+            _metrics_row(variants[0].id, MetricsWindow.ONE_DAY, 1, 0, 0, 1.0),
+            _metrics_row(variants[1].id, MetricsWindow.ONE_DAY, 5, 0, 0, 5.0),
+            _metrics_row(variants[2].id, MetricsWindow.ONE_DAY, 2, 0, 0, 2.0),
+            _metrics_row(variants[3].id, MetricsWindow.ONE_DAY, 9, 0, 0, 9.0),
+        ]
+    )
+    db.commit()
+
+    r = client.get(f"/api/posts/{post.id}/ab-results")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["winner"] == "b"
+    arms = {a["label"]: a for a in body["arms"]}
+    assert arms["a"]["posted_count"] == 2
+    assert arms["a"]["likes"] == 3
+    assert abs(arms["a"]["avg_engagement"] - 1.5) < 1e-6
+    assert arms["b"]["likes"] == 14
+    assert abs(arms["b"]["avg_engagement"] - 7.0) < 1e-6
+    assert arms["a"]["window"] == "24h"
+    assert arms["b"]["window"] == "24h"
+
+
+def test_ab_results_null_winner_when_no_metrics_yet(client, db):
+    post = _seed(db, n_variants=2)
+    for v in post.variants:
+        v.ab_arm = "a" if v == post.variants[0] else "b"
+    db.commit()
+
+    r = client.get(f"/api/posts/{post.id}/ab-results")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["winner"] is None
+    for arm in body["arms"]:
+        assert arm["posted_count"] == 0
+        assert arm["avg_engagement"] == 0.0
+        assert arm["window"] is None
+
+
+def test_ab_results_falls_back_to_1h_when_24h_missing(client, db):
+    post = _seed(db, n_variants=2)
+    variants = list(post.variants)
+    for i, v in enumerate(variants):
+        v.ab_arm = "a" if i == 0 else "b"
+        v.status = PostStatus.POSTED
+    db.commit()
+
+    # Only 1h metrics collected so far.
+    db.add_all(
+        [
+            _metrics_row(variants[0].id, MetricsWindow.ONE_HOUR, 0, 1, 0, 2.0),
+            _metrics_row(variants[1].id, MetricsWindow.ONE_HOUR, 0, 2, 0, 4.0),
+        ]
+    )
+    db.commit()
+
+    r = client.get(f"/api/posts/{post.id}/ab-results")
+    body = r.json()
+    assert body["winner"] == "b"
+    for arm in body["arms"]:
+        assert arm["window"] == "1h"

--- a/backend/tests/test_followers.py
+++ b/backend/tests/test_followers.py
@@ -1,0 +1,244 @@
+"""Phase 5c — follower-count time series.
+
+Covers:
+- meta_graph.get_followers_count hits the right API base (graph vs
+  threads) and returns the int field.
+- collect_follower_snapshots writes rows for supported platforms, skips
+  unsupported ones, and swallows individual fetch failures so one dead
+  token doesn't break the whole tick.
+- read_follower_series groups by (platform, account), orders oldest-first,
+  and computes 7/30-day deltas only when a baseline exists.
+- GET /api/followers returns the series + username labels; /collect
+  triggers the sync path.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.db.models import FollowerSnapshot, PlatformCredential
+from app.platforms import meta_graph
+from app.services import followers as followers_service
+
+
+# ---------- meta_graph ----------
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: dict):
+        self.status_code = status_code
+        self._payload = payload
+        self.headers: dict[str, str] = {}
+        self.text = ""
+
+    def json(self):
+        return self._payload
+
+
+class _FakeClient:
+    def __init__(self, payload: dict, captured_url: list[str]):
+        self._payload = payload
+        self._captured = captured_url
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def get(self, url, params=None):
+        self._captured.append(url)
+        return _FakeResponse(200, self._payload)
+
+
+def test_get_followers_count_graph(monkeypatch):
+    captured: list[str] = []
+    monkeypatch.setattr(
+        meta_graph.httpx,
+        "Client",
+        lambda **kw: _FakeClient({"followers_count": 42}, captured),
+    )
+    n = meta_graph.get_followers_count("17841000", "token")
+    assert n == 42
+    assert captured[0].startswith(meta_graph.GRAPH_BASE + "/17841000")
+
+
+def test_get_followers_count_threads(monkeypatch):
+    captured: list[str] = []
+    monkeypatch.setattr(
+        meta_graph.httpx,
+        "Client",
+        lambda **kw: _FakeClient({"followers_count": 7}, captured),
+    )
+    n = meta_graph.get_followers_count("999", "token", is_threads=True)
+    assert n == 7
+    assert captured[0].startswith(meta_graph.THREADS_BASE + "/999")
+
+
+def test_get_followers_count_missing_field_returns_zero(monkeypatch):
+    captured: list[str] = []
+    monkeypatch.setattr(
+        meta_graph.httpx,
+        "Client",
+        lambda **kw: _FakeClient({"id": "1"}, captured),
+    )
+    assert meta_graph.get_followers_count("1", "t") == 0
+
+
+# ---------- service ----------
+
+
+def _seed_cred(db, *, platform_id: str, account_id: str, username: str | None = None) -> PlatformCredential:
+    c = PlatformCredential(
+        platform_id=platform_id,
+        account_id=account_id,
+        username=username,
+    )
+    c.access_token = "fake-token"
+    db.add(c)
+    db.commit()
+    db.refresh(c)
+    return c
+
+
+def test_collect_writes_snapshot_per_supported_credential(db, monkeypatch):
+    _seed_cred(db, platform_id="instagram", account_id="ig-1")
+    _seed_cred(db, platform_id="threads", account_id="th-1")
+    _seed_cred(db, platform_id="unknown", account_id="u-1")
+
+    counts = iter([100, 200])
+    monkeypatch.setattr(
+        followers_service,
+        "fetch_followers_for_credential",
+        lambda cred: next(counts),
+    )
+
+    result = followers_service.collect_follower_snapshots(db)
+    assert result.collected == 2
+    assert result.skipped == 1
+    assert result.failed == 0
+
+    rows = db.query(FollowerSnapshot).all()
+    by_platform = {r.platform_id: r.followers for r in rows}
+    assert by_platform == {"instagram": 100, "threads": 200}
+
+
+def test_collect_isolates_fetch_failures(db, monkeypatch):
+    _seed_cred(db, platform_id="instagram", account_id="ig-1")
+    _seed_cred(db, platform_id="facebook", account_id="fb-1")
+
+    def fake(cred):
+        if cred.platform_id == "instagram":
+            raise RuntimeError("token expired")
+        return 500
+
+    monkeypatch.setattr(followers_service, "fetch_followers_for_credential", fake)
+    result = followers_service.collect_follower_snapshots(db)
+    assert result.collected == 1
+    assert result.failed == 1
+    # Only the successful fetch was persisted.
+    rows = db.query(FollowerSnapshot).all()
+    assert [(r.platform_id, r.followers) for r in rows] == [("facebook", 500)]
+
+
+# ---------- read side ----------
+
+
+def _seed_snap(
+    db, platform_id: str, account_id: str, when: datetime, followers: int
+) -> None:
+    db.add(
+        FollowerSnapshot(
+            platform_id=platform_id,
+            account_id=account_id,
+            followers=followers,
+            collected_at=when,
+        )
+    )
+
+
+def test_read_series_groups_and_computes_growth(db):
+    now = datetime(2026, 4, 30, tzinfo=UTC)
+    _seed_snap(db, "instagram", "ig-1", now - timedelta(days=31), 900)
+    _seed_snap(db, "instagram", "ig-1", now - timedelta(days=8), 950)
+    _seed_snap(db, "instagram", "ig-1", now - timedelta(days=1), 1000)
+    db.commit()
+
+    series = followers_service.read_follower_series(db, days=60, now=now)
+    assert len(series) == 1
+    s = series[0]
+    assert s.platform_id == "instagram"
+    assert s.account_id == "ig-1"
+    assert s.current == 1000
+    assert [f for _, f in s.series] == [900, 950, 1000]
+    # 7d baseline = 950 (-8d snapshot is the most recent one older than 7d ago) → 1000 - 950 = 50
+    assert s.growth_7d == 50
+    # 30d baseline = 900 → 1000 - 900 = 100
+    assert s.growth_30d == 100
+
+
+def test_read_series_growth_null_without_baseline(db):
+    now = datetime(2026, 4, 30, tzinfo=UTC)
+    # Only a single snapshot within the 7-day window — no baseline yet.
+    _seed_snap(db, "threads", "th-1", now - timedelta(hours=3), 100)
+    db.commit()
+
+    series = followers_service.read_follower_series(db, days=60, now=now)
+    assert len(series) == 1
+    assert series[0].growth_7d is None
+    assert series[0].growth_30d is None
+
+
+def test_read_series_respects_days_cutoff(db):
+    now = datetime(2026, 4, 30, tzinfo=UTC)
+    _seed_snap(db, "instagram", "ig-1", now - timedelta(days=40), 800)
+    _seed_snap(db, "instagram", "ig-1", now - timedelta(days=1), 900)
+    db.commit()
+
+    series = followers_service.read_follower_series(db, days=10, now=now)
+    assert len(series) == 1
+    # Only the -1d snapshot is within the window.
+    assert [f for _, f in series[0].series] == [900]
+
+
+# ---------- HTTP surface ----------
+
+
+@pytest.fixture()
+def _mute_fetch(monkeypatch):
+    monkeypatch.setattr(
+        followers_service,
+        "fetch_followers_for_credential",
+        lambda cred: 1234,
+    )
+
+
+def test_api_list_followers_includes_username(client, db):
+    _seed_cred(db, platform_id="instagram", account_id="ig-1", username="acme")
+    _seed_snap(db, "instagram", "ig-1", datetime.now(UTC), 500)
+    db.commit()
+
+    r = client.get("/api/followers?days=30")
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body) == 1
+    assert body[0]["username"] == "acme"
+    assert body[0]["current"] == 500
+
+
+def test_api_list_followers_validates_days(client):
+    r = client.get("/api/followers?days=0")
+    assert r.status_code == 422
+    r = client.get("/api/followers?days=400")
+    assert r.status_code == 422
+
+
+def test_api_collect_now_runs_service(client, db, _mute_fetch):
+    _seed_cred(db, platform_id="facebook", account_id="fb-1")
+    r = client.post("/api/followers/collect")
+    assert r.status_code == 200
+    body = r.json()
+    assert body == {"collected": 1, "failed": 0, "skipped": 0}
+    # Persisted.
+    assert db.query(FollowerSnapshot).count() == 1

--- a/backend/tests/test_linkedin.py
+++ b/backend/tests/test_linkedin.py
@@ -1,0 +1,377 @@
+"""Phase 5d — LinkedIn platform adapter.
+
+Covers:
+- linkedin_api._build_post_payload shapes the /rest/posts body correctly
+  (PUBLIC visibility, PUBLISHED lifecycle, `content.media` only when an
+  image URN is attached).
+- linkedin_api.create_text_post dispatches a POST, extracts the URN from
+  `x-restli-id`, and surfaces a LinkedInError on 4xx.
+- LinkedInPlatform.adapt_content truncates on a word boundary.
+- LinkedInPlatform.publish dispatches create_text_post with the right
+  author URN, bails cleanly when no credential is configured, and uploads
+  the image via the two-step register → PUT dance when an image_url is
+  attached.
+- Registry returns the right class.
+- /api/linkedin/oauth/url refuses without a client_id and returns a
+  well-formed URL with all expected scopes when configured.
+- /api/linkedin/oauth/callback persists a PlatformCredential.
+- /api/linkedin/credentials paste-a-token endpoint works.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from app.config import settings
+from app.db.models import (
+    PlatformCredential,
+    Post,
+    PostStatus,
+    PostType,
+    Target,
+)
+from app.platforms import linkedin_api
+from app.platforms.linkedin import LINKEDIN_MAX, LinkedInPlatform, _person_urn
+from app.platforms.registry import PLATFORMS, get_platform
+
+
+# ---------- linkedin_api pure functions ----------
+
+
+def test_build_post_payload_text_only():
+    body = linkedin_api._build_post_payload(
+        author_urn="urn:li:person:ABC", text="hi there", image_urn=None
+    )
+    assert body["author"] == "urn:li:person:ABC"
+    assert body["commentary"] == "hi there"
+    assert body["visibility"] == "PUBLIC"
+    assert body["lifecycleState"] == "PUBLISHED"
+    # No content block for text-only posts.
+    assert "content" not in body
+
+
+def test_build_post_payload_with_image():
+    body = linkedin_api._build_post_payload(
+        author_urn="urn:li:person:ABC",
+        text="hi",
+        image_urn="urn:li:image:XYZ",
+    )
+    assert body["content"] == {"media": {"id": "urn:li:image:XYZ"}}
+
+
+# ---------- linkedin_api HTTP wrapper (httpx mocked) ----------
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, headers=None, payload=None, text=""):
+        self.status_code = status_code
+        self.headers = headers or {}
+        self._payload = payload
+        self.text = text
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("no json")
+        return self._payload
+
+
+class _FakeClient:
+    def __init__(self, response: _FakeResponse, captured: list[dict]):
+        self._response = response
+        self._captured = captured
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def post(self, url, json=None, data=None, headers=None):
+        self._captured.append({"method": "POST", "url": url, "json": json, "data": data, "headers": headers})
+        return self._response
+
+    def get(self, url, headers=None, params=None):
+        self._captured.append({"method": "GET", "url": url, "headers": headers, "params": params})
+        return self._response
+
+    def put(self, url, content=None):
+        self._captured.append({"method": "PUT", "url": url, "content": content})
+        return self._response
+
+
+def test_create_text_post_extracts_urn_from_restli_header(monkeypatch):
+    captured: list[dict] = []
+    resp = _FakeResponse(
+        status_code=201,
+        headers={"x-restli-id": "urn:li:share:7123"},
+        text="",
+    )
+    monkeypatch.setattr(
+        linkedin_api.httpx,
+        "Client",
+        lambda **kw: _FakeClient(resp, captured),
+    )
+    urn = linkedin_api.create_text_post(
+        access_token="TOK",
+        author_urn="urn:li:person:ABC",
+        text="hello",
+    )
+    assert urn == "urn:li:share:7123"
+    # Verify we set the version + restli protocol headers.
+    call = captured[0]
+    assert call["headers"]["LinkedIn-Version"] == linkedin_api.REST_VERSION
+    assert call["headers"]["X-Restli-Protocol-Version"] == "2.0.0"
+    assert call["headers"]["Authorization"] == "Bearer TOK"
+
+
+def test_create_text_post_raises_on_4xx(monkeypatch):
+    captured: list[dict] = []
+    resp = _FakeResponse(
+        status_code=401,
+        payload={"serviceErrorCode": 65600, "message": "Invalid access token"},
+        text='{"message":"Invalid access token"}',
+    )
+    monkeypatch.setattr(
+        linkedin_api.httpx,
+        "Client",
+        lambda **kw: _FakeClient(resp, captured),
+    )
+    with pytest.raises(linkedin_api.LinkedInError) as ei:
+        linkedin_api.create_text_post(
+            access_token="BAD",
+            author_urn="urn:li:person:ABC",
+            text="hi",
+        )
+    assert ei.value.status == 401
+    assert "Invalid access token" in str(ei.value)
+
+
+def test_exchange_code_for_token_posts_form(monkeypatch):
+    captured: list[dict] = []
+    resp = _FakeResponse(
+        status_code=200,
+        payload={"access_token": "TOK", "expires_in": 5184000},
+    )
+    monkeypatch.setattr(
+        linkedin_api.httpx,
+        "Client",
+        lambda **kw: _FakeClient(resp, captured),
+    )
+    out = linkedin_api.exchange_code_for_token(
+        client_id="cid", client_secret="sec", redirect_uri="http://x/y", code="AUTHCODE"
+    )
+    assert out["access_token"] == "TOK"
+    assert captured[0]["url"] == linkedin_api.OAUTH_TOKEN_URL
+    assert captured[0]["data"]["code"] == "AUTHCODE"
+    assert captured[0]["data"]["grant_type"] == "authorization_code"
+
+
+# ---------- LinkedInPlatform ----------
+
+
+def test_person_urn_builds_from_bare_id():
+    assert _person_urn("abc123") == "urn:li:person:abc123"
+    # Already a URN — returned as-is.
+    assert _person_urn("urn:li:person:xyz") == "urn:li:person:xyz"
+
+
+def test_adapt_content_truncates_on_word_boundary():
+    plat = LinkedInPlatform()
+    text = ("hello world " * 400).strip()  # well over 3000 chars
+    out = plat.adapt_content(text)
+    assert len(out) <= LINKEDIN_MAX
+    assert out.endswith("\u2026")
+    # Word boundary: shouldn't end with a partial word like "hel…"
+    assert "  " not in out
+
+
+def test_adapt_content_leaves_short_text_alone():
+    assert LinkedInPlatform().adapt_content("quick note") == "quick note"
+
+
+def test_registry_returns_linkedin_platform():
+    assert "linkedin" in PLATFORMS
+    assert get_platform("linkedin").__class__.__name__ == "LinkedInPlatform"
+
+
+def _make_linkedin_cred(db, account_id="ABC123"):
+    row = PlatformCredential(
+        platform_id="linkedin",
+        account_id=account_id,
+        username="Some Person",
+        access_token="LI_TOK",
+    )
+    db.add(row)
+    db.commit()
+    return row
+
+
+def _make_target(db, external_id="ABC123"):
+    t = Target(platform_id="linkedin", external_id=external_id, name="My feed")
+    db.add(t)
+    db.commit()
+    return t
+
+
+@pytest.mark.asyncio
+async def test_publish_text_only(db):
+    _make_linkedin_cred(db)
+    target = _make_target(db)
+    post = Post(
+        post_type=PostType.INFORMATIVE,
+        status=PostStatus.DRAFT,
+        text="Sharing a quick thought",
+        image_url=None,
+    )
+
+    with patch("app.platforms.linkedin.linkedin_api.create_text_post") as create_mock:
+        create_mock.return_value = "urn:li:share:99"
+        result = await LinkedInPlatform(db=db).publish(post, target)
+
+    assert result.ok
+    assert result.external_post_id == "urn:li:share:99"
+    kwargs = create_mock.call_args.kwargs
+    assert kwargs["author_urn"] == "urn:li:person:ABC123"
+    assert kwargs["access_token"] == "LI_TOK"
+    assert kwargs["image_urn"] is None
+
+
+@pytest.mark.asyncio
+async def test_publish_with_image_registers_and_uploads(db):
+    _make_linkedin_cred(db)
+    target = _make_target(db)
+    post = Post(
+        post_type=PostType.INFORMATIVE,
+        status=PostStatus.DRAFT,
+        text="Image post",
+        image_url="https://cdn.example.com/pic.jpg",
+    )
+
+    with patch(
+        "app.platforms.linkedin.linkedin_api.register_image_upload"
+    ) as reg_mock, patch(
+        "app.platforms.linkedin.linkedin_api.upload_image_binary"
+    ) as upload_mock, patch(
+        "app.platforms.linkedin._fetch_image_bytes"
+    ) as fetch_mock, patch(
+        "app.platforms.linkedin.linkedin_api.create_text_post"
+    ) as create_mock:
+        reg_mock.return_value = {
+            "upload_url": "https://li-upload.example/presigned",
+            "image_urn": "urn:li:image:IMG_X",
+        }
+        fetch_mock.return_value = b"\xff\xd8\xff\xe0stub"
+        create_mock.return_value = "urn:li:share:42"
+
+        result = await LinkedInPlatform(db=db).publish(post, target)
+
+    assert result.ok
+    assert result.external_post_id == "urn:li:share:42"
+    upload_mock.assert_called_once_with(
+        upload_url="https://li-upload.example/presigned",
+        image_bytes=b"\xff\xd8\xff\xe0stub",
+    )
+    assert create_mock.call_args.kwargs["image_urn"] == "urn:li:image:IMG_X"
+
+
+@pytest.mark.asyncio
+async def test_publish_drops_non_public_image(db):
+    _make_linkedin_cred(db)
+    target = _make_target(db)
+    post = Post(
+        post_type=PostType.INFORMATIVE,
+        status=PostStatus.DRAFT,
+        text="Local file attempt",
+        image_url="/static/images/uploads/foo.jpg",
+    )
+
+    with patch(
+        "app.platforms.linkedin.linkedin_api.register_image_upload"
+    ) as reg_mock, patch(
+        "app.platforms.linkedin.linkedin_api.create_text_post"
+    ) as create_mock:
+        create_mock.return_value = "urn:li:share:text-only"
+        result = await LinkedInPlatform(db=db).publish(post, target)
+
+    assert result.ok
+    # We didn't try to register an image.
+    reg_mock.assert_not_called()
+    assert create_mock.call_args.kwargs["image_urn"] is None
+
+
+@pytest.mark.asyncio
+async def test_publish_without_credential_fails(db):
+    target = _make_target(db)
+    post = Post(
+        post_type=PostType.INFORMATIVE,
+        status=PostStatus.DRAFT,
+        text="no cred",
+        image_url=None,
+    )
+    result = await LinkedInPlatform(db=db).publish(post, target)
+    assert not result.ok
+    assert "credential" in result.error.lower()
+
+
+# ---------- OAuth endpoints ----------
+
+
+def test_oauth_url_requires_client_id(client, monkeypatch):
+    monkeypatch.setattr(settings, "linkedin_client_id", "", raising=True)
+    r = client.get("/api/linkedin/oauth/url")
+    assert r.status_code == 400
+    assert "LINKEDIN_CLIENT_ID" in r.json()["detail"]
+
+
+def test_oauth_url_includes_scopes(client, monkeypatch):
+    monkeypatch.setattr(settings, "linkedin_client_id", "cid-123", raising=True)
+    r = client.get("/api/linkedin/oauth/url")
+    assert r.status_code == 200
+    body = r.json()
+    assert "state" in body and body["state"]
+    url = body["url"]
+    assert url.startswith(linkedin_api.OAUTH_AUTH_URL)
+    assert "w_member_social" in url
+    assert "openid" in url
+    assert "client_id=cid-123" in url
+
+
+def test_oauth_callback_persists_credential(client, db, monkeypatch):
+    monkeypatch.setattr(settings, "linkedin_client_id", "cid", raising=True)
+    monkeypatch.setattr(settings, "linkedin_client_secret", "sec", raising=True)
+
+    def _fake_exchange(**kwargs):
+        return {"access_token": "LI_TOK", "expires_in": 5184000}
+
+    def _fake_userinfo(token):
+        return {
+            "sub": "XYZ_PERSON",
+            "name": "Test Person",
+            "email": "t@example.com",
+        }
+
+    monkeypatch.setattr(linkedin_api, "exchange_code_for_token", _fake_exchange)
+    monkeypatch.setattr(linkedin_api, "get_userinfo", _fake_userinfo)
+
+    r = client.get("/api/linkedin/oauth/callback?code=AUTH&state=abc")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["credential"]["account_id"] == "XYZ_PERSON"
+    assert body["credential"]["username"] == "Test Person"
+
+    rows = db.query(PlatformCredential).filter_by(platform_id="linkedin").all()
+    assert len(rows) == 1
+    assert rows[0].access_token == "LI_TOK"
+
+
+def test_manual_credential_endpoint(client, db):
+    r = client.post(
+        "/api/linkedin/credentials",
+        json={"account_id": "MANUAL_1", "access_token": "TOK1", "username": "Me"},
+    )
+    assert r.status_code == 200
+    rows = db.query(PlatformCredential).filter_by(platform_id="linkedin").all()
+    assert len(rows) == 1
+    assert rows[0].account_id == "MANUAL_1"
+    assert rows[0].access_token == "TOK1"

--- a/backend/tests/test_meta_platforms.py
+++ b/backend/tests/test_meta_platforms.py
@@ -79,8 +79,8 @@ def test_threads_adapt_leaves_hashtags_alone():
 # ---------- Registry ----------
 
 
-def test_registry_has_three_platforms():
-    assert set(PLATFORMS.keys()) == {"facebook", "instagram", "threads"}
+def test_registry_has_four_platforms():
+    assert set(PLATFORMS.keys()) == {"facebook", "instagram", "threads", "linkedin"}
 
 
 def test_get_platform_returns_correct_subclass():

--- a/backend/tests/test_phase4_alembic.py
+++ b/backend/tests/test_phase4_alembic.py
@@ -12,11 +12,18 @@ a no-op the second time.
 """
 from __future__ import annotations
 
+from alembic.script import ScriptDirectory
 from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.pool import StaticPool
 
 from app.db import session as db_session
 from app.db.models import Base
+
+
+def _head_revision() -> str:
+    """Ask Alembic what `head` currently is instead of hard-coding a revision
+    id that drifts every time we add a migration."""
+    return ScriptDirectory.from_config(db_session._alembic_config()).get_current_head()
 
 # Tables the baseline migration 0001 is expected to create. Keep this list
 # explicit so drift in the model layer or a botched autogen gets caught
@@ -66,7 +73,7 @@ def test_init_db_upgrades_fresh_db(monkeypatch):
 
     with eng.connect() as conn:
         row = conn.execute(text("SELECT version_num FROM alembic_version")).fetchone()
-    assert row is not None and row[0] == "0001"
+    assert row is not None and row[0] == _head_revision()
 
 
 def test_init_db_is_idempotent(monkeypatch):
@@ -80,7 +87,7 @@ def test_init_db_is_idempotent(monkeypatch):
 
     with eng.connect() as conn:
         row = conn.execute(text("SELECT version_num FROM alembic_version")).fetchone()
-    assert row[0] == "0001"
+    assert row[0] == _head_revision()
 
 
 def test_init_db_stamps_preexisting_schema(monkeypatch):
@@ -104,7 +111,7 @@ def test_init_db_stamps_preexisting_schema(monkeypatch):
 
     with eng.connect() as conn:
         row = conn.execute(text("SELECT version_num FROM alembic_version")).fetchone()
-    assert row[0] == "0001"
+    assert row[0] == _head_revision()
 
 
 def test_alembic_config_points_at_bundled_ini():

--- a/backend/tests/test_phase4_alembic.py
+++ b/backend/tests/test_phase4_alembic.py
@@ -12,11 +12,16 @@ a no-op the second time.
 """
 from __future__ import annotations
 
+from alembic.script import ScriptDirectory
 from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.pool import StaticPool
 
 from app.db import session as db_session
 from app.db.models import Base
+
+
+def _head_revision() -> str:
+    return ScriptDirectory.from_config(db_session._alembic_config()).get_current_head()
 
 # Tables the baseline migration 0001 is expected to create. Keep this list
 # explicit so drift in the model layer or a botched autogen gets caught
@@ -66,7 +71,7 @@ def test_init_db_upgrades_fresh_db(monkeypatch):
 
     with eng.connect() as conn:
         row = conn.execute(text("SELECT version_num FROM alembic_version")).fetchone()
-    assert row is not None and row[0] == "0001"
+    assert row is not None and row[0] == _head_revision()
 
 
 def test_init_db_is_idempotent(monkeypatch):
@@ -80,7 +85,7 @@ def test_init_db_is_idempotent(monkeypatch):
 
     with eng.connect() as conn:
         row = conn.execute(text("SELECT version_num FROM alembic_version")).fetchone()
-    assert row[0] == "0001"
+    assert row[0] == _head_revision()
 
 
 def test_init_db_stamps_preexisting_schema(monkeypatch):
@@ -104,7 +109,7 @@ def test_init_db_stamps_preexisting_schema(monkeypatch):
 
     with eng.connect() as conn:
         row = conn.execute(text("SELECT version_num FROM alembic_version")).fetchone()
-    assert row[0] == "0001"
+    assert row[0] == _head_revision()
 
 
 def test_alembic_config_points_at_bundled_ini():


### PR DESCRIPTION
Daily 02:00 UTC snapshot per Meta credential (FB/IG/Threads). Append-only `follower_snapshots` table; growth deltas (7d/30d) computed on read. GET /api/followers returns labelled time series for the dashboard chart; POST /api/followers/collect runs the tick on demand.

- Meta Graph `followers_count` field routed through graph/threads bases.
- Per-credential fetch failures isolated so one dead token doesn't kill the whole tick.
- Phase 4 test dehardcodes migration id (now reads head from Alembic).