### PR TITLE
Phase 5a: iCalendar feed of scheduled + posted posts

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -6,6 +6,7 @@ from app.api import (
     analytics,
     auth,
     business_profile,
+    calendar_ics,
     feedback,
     followers,
     health,
@@ -35,5 +36,6 @@ api_router.include_router(linkedin_oauth.router)
 api_router.include_router(platform_credentials.router)
 api_router.include_router(ab_tests.router)
 api_router.include_router(followers.router)
+api_router.include_router(calendar_ics.router)
 
 __all__ = ["api_router"]

--- a/backend/app/api/calendar_ics.py
+++ b/backend/app/api/calendar_ics.py
@@ -1,0 +1,203 @@
+"""iCalendar feed of scheduled + posted posts.
+
+Lets the user subscribe to the posting queue from Google Calendar / Apple
+Calendar / Outlook. Each Post with `scheduled_for` or `posted_at` becomes a
+VEVENT; the VCALENDAR wrapper is refreshed on every request (no caching —
+volume is tiny).
+
+## Auth
+
+The normal dashboard-PIN cookie/header doesn't reach third-party calendar
+clients — they do a plain anonymous GET every ~30 min. So `.ics` uses a
+token derived from the PIN via HMAC: stable across restarts, impossible to
+guess without the PIN, invalidated automatically if the PIN is rotated.
+
+- `GET /api/calendar.ics?token=<t>` — the feed itself. Public path (exempt
+  from DashboardAuthMiddleware) but rejects with 401 if the token is wrong.
+- `GET /api/calendar/subscribe-url` — returns the full URL with token baked
+  in so the dashboard can show a "copy subscription link" button. Sits
+  behind the normal PIN auth.
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac as _hmac
+from datetime import UTC, datetime, timedelta
+from typing import Iterable
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from sqlalchemy.orm import Session, selectinload
+
+from app.config import settings
+from app.db import get_session
+from app.db.models import Post, PostStatus, Target
+
+router = APIRouter(prefix="/api/calendar", tags=["calendar"])
+
+
+# ---------- Token ----------
+#
+# Context string is versioned so rotating the scheme (e.g. switching to a
+# per-feed secret) later won't silently keep old tokens working.
+_TOKEN_CONTEXT = b"calendar-ics-v1"
+
+
+def make_calendar_token(pin: str) -> str:
+    mac = _hmac.new(pin.encode("utf-8"), _TOKEN_CONTEXT, hashlib.sha256).digest()
+    return mac.hex()
+
+
+def _verify_token(token: str, pin: str) -> bool:
+    return _hmac.compare_digest(token or "", make_calendar_token(pin))
+
+
+def _check_token(token: str) -> None:
+    pin = settings.dashboard_pin.strip()
+    if not pin:
+        return  # auth disabled entirely — dev mode
+    if not _verify_token(token, pin):
+        raise HTTPException(status_code=401, detail="Invalid calendar token")
+
+
+# ---------- iCal serialization ----------
+#
+# Hand-rolled to avoid a dep for ~60 lines of code. Compliant with the subset
+# of RFC 5545 that calendar clients actually care about: CRLF line endings,
+# TEXT-value escaping, conservative line folding.
+
+_CAL_STATUS = {
+    PostStatus.POSTED: "CONFIRMED",
+    PostStatus.FAILED: "CANCELLED",
+    PostStatus.SKIPPED: "CANCELLED",
+}
+# DRAFT / PENDING_REVIEW / SCHEDULED / POSTING — not committed yet.
+_DEFAULT_CAL_STATUS = "TENTATIVE"
+
+# Arbitrary event length — posts are instantaneous, but calendars need a
+# duration to render a visible block.
+_EVENT_DURATION = timedelta(minutes=15)
+
+# 73 chars leaves room for the leading space on folded continuation lines
+# and keeps us well under the 75-octet RFC 5545 cap even for multi-byte UTF-8.
+_FOLD_WIDTH = 73
+
+
+def _escape(text: str) -> str:
+    """RFC 5545 TEXT-value escaping. Order matters — backslash first."""
+    return (
+        text.replace("\\", "\\\\")
+        .replace("\r\n", "\\n")
+        .replace("\n", "\\n")
+        .replace("\r", "")
+        .replace(",", "\\,")
+        .replace(";", "\\;")
+    )
+
+
+def _fold(line: str) -> str:
+    if len(line) <= _FOLD_WIDTH:
+        return line
+    chunks = [line[i : i + _FOLD_WIDTH] for i in range(0, len(line), _FOLD_WIDTH)]
+    return "\r\n ".join(chunks)
+
+
+def _fmt_dt(dt: datetime) -> str:
+    """iCal UTC format, e.g. 20260419T203000Z."""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _event_lines(post: Post, target_names: list[str]) -> list[str]:
+    # Prefer scheduled_for; fall back to posted_at for already-published posts
+    # so the calendar shows history too.
+    start = post.scheduled_for or post.posted_at
+    if start is None:
+        return []
+    end = start + _EVENT_DURATION
+    snippet = post.text.strip().splitlines()[0] if post.text else ""
+    summary = f"[{post.post_type.value}] {snippet[:80]}"
+    description = "\n".join(
+        [
+            f"Status: {post.status.value}",
+            f"Targets: {', '.join(target_names) if target_names else '—'}",
+            "",
+            post.text,
+        ]
+    )
+    status = _CAL_STATUS.get(post.status, _DEFAULT_CAL_STATUS)
+    dtstamp = _fmt_dt(post.created_at or datetime.now(UTC))
+    return [
+        "BEGIN:VEVENT",
+        _fold(f"UID:autoposter-post-{post.id}@autoposter"),
+        _fold(f"DTSTAMP:{dtstamp}"),
+        _fold(f"DTSTART:{_fmt_dt(start)}"),
+        _fold(f"DTEND:{_fmt_dt(end)}"),
+        _fold(f"SUMMARY:{_escape(summary)}"),
+        _fold(f"DESCRIPTION:{_escape(description)}"),
+        f"STATUS:{status}",
+        # Show the slot as "free" on the subscriber's calendar — they're not
+        # actually busy, it's just an informational entry.
+        "TRANSP:TRANSPARENT",
+        "END:VEVENT",
+    ]
+
+
+def _render_calendar(posts: Iterable[Post], target_map: dict[int, str]) -> str:
+    lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//autoposter-AI//Calendar//EN",
+        "CALSCALE:GREGORIAN",
+        "METHOD:PUBLISH",
+        _fold("X-WR-CALNAME:autoposter-AI — Scheduled Posts"),
+        _fold("X-WR-CALDESC:Live feed of scheduled and posted content."),
+    ]
+    for post in posts:
+        names = sorted(
+            {target_map.get(v.target_id, "") for v in post.variants} - {""}
+        )
+        lines.extend(_event_lines(post, names))
+    lines.append("END:VCALENDAR")
+    # iCal spec is CRLF-terminated, including after the final END line.
+    return "\r\n".join(lines) + "\r\n"
+
+
+# ---------- Endpoints ----------
+
+
+@router.get(".ics")
+def calendar_feed(
+    token: str = Query(default=""),
+    db: Session = Depends(get_session),
+) -> Response:
+    _check_token(token)
+    posts = (
+        db.query(Post)
+        .options(selectinload(Post.variants))
+        .filter(
+            (Post.scheduled_for.isnot(None)) | (Post.posted_at.isnot(None))
+        )
+        .order_by(Post.scheduled_for.asc().nullslast())
+        .all()
+    )
+    target_ids = {v.target_id for p in posts for v in p.variants}
+    if target_ids:
+        targets = db.query(Target).filter(Target.id.in_(target_ids)).all()
+        target_map = {t.id: t.name for t in targets}
+    else:
+        target_map = {}
+    body = _render_calendar(posts, target_map)
+    return Response(content=body, media_type="text/calendar; charset=utf-8")
+
+
+@router.get("/subscribe-url")
+def subscribe_url() -> dict:
+    """Return the URL the user pastes into their calendar app."""
+    pin = settings.dashboard_pin.strip()
+    if not pin:
+        return {"url": "/api/calendar.ics", "auth_required": False}
+    return {
+        "url": f"/api/calendar.ics?token={make_calendar_token(pin)}",
+        "auth_required": True,
+    }

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -117,6 +117,9 @@ _PUBLIC_PATHS = {
     "/api/auth/login",
     "/api/auth/status",
     "/api/meta/oauth/callback",  # Meta redirects hit this directly
+    # iCal feed — calendar apps can't send PIN cookies/headers, so this
+    # endpoint enforces its own HMAC-derived token check instead.
+    "/api/calendar.ics",
 }
 
 # Path prefixes that bypass auth.

--- a/backend/tests/test_calendar_ics.py
+++ b/backend/tests/test_calendar_ics.py
@@ -1,0 +1,239 @@
+"""Phase 5a — iCalendar feed.
+
+Covers:
+- Empty DB returns a well-formed (but eventless) VCALENDAR.
+- A scheduled post renders a VEVENT with matching DTSTART / SUMMARY.
+- Wrong / missing token is rejected with 401 when a PIN is configured.
+- No-PIN dev mode skips token enforcement.
+- /subscribe-url returns the URL the dashboard should show.
+- RFC 5545 TEXT-escaping survives commas, semicolons, backslashes, newlines.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.api import calendar_ics
+from app.db.models import Post, PostStatus, PostType, PostVariant, Target
+
+
+# ---------- Helpers ----------
+
+
+def _seed_post(
+    db,
+    *,
+    scheduled_for: datetime | None = None,
+    posted_at: datetime | None = None,
+    text: str = "Hello, world.",
+    post_type: PostType = PostType.INFORMATIVE,
+    status: PostStatus = PostStatus.SCHEDULED,
+) -> Post:
+    target = Target(
+        platform_id="facebook",
+        external_id=f"https://fb/group/{text[:8]}",
+        name="Test Group",
+        tags=[],
+        active=True,
+        source="manual",
+    )
+    db.add(target)
+    db.flush()
+    post = Post(
+        post_type=post_type,
+        status=status,
+        text=text,
+        scheduled_for=scheduled_for,
+        posted_at=posted_at,
+    )
+    db.add(post)
+    db.flush()
+    db.add(
+        PostVariant(
+            post_id=post.id,
+            target_id=target.id,
+            text=text,
+            status=status,
+            scheduled_for=scheduled_for,
+        )
+    )
+    db.commit()
+    db.refresh(post)
+    return post
+
+
+def _ics_header_ok(body: str) -> None:
+    assert body.startswith("BEGIN:VCALENDAR\r\n")
+    assert body.rstrip("\r\n").endswith("END:VCALENDAR")
+    assert "VERSION:2.0" in body
+    assert "PRODID:" in body
+    # All newlines must be CRLF.
+    assert "\r\n" in body
+    stripped = body.replace("\r\n", "")
+    assert "\n" not in stripped
+
+
+# ---------- Token ----------
+
+
+def test_token_is_stable_for_same_pin():
+    a = calendar_ics.make_calendar_token("1234")
+    b = calendar_ics.make_calendar_token("1234")
+    assert a == b
+    assert len(a) == 64  # sha256 hex
+
+
+def test_token_changes_with_pin():
+    assert calendar_ics.make_calendar_token("1234") != calendar_ics.make_calendar_token(
+        "4321"
+    )
+
+
+# ---------- Serialization ----------
+
+
+def test_render_empty_calendar():
+    body = calendar_ics._render_calendar([], {})
+    _ics_header_ok(body)
+    assert "BEGIN:VEVENT" not in body
+
+
+def test_render_single_event_fields():
+    start = datetime(2026, 5, 1, 14, 30, tzinfo=UTC)
+    post = Post(
+        id=42,
+        post_type=PostType.INFORMATIVE,
+        status=PostStatus.SCHEDULED,
+        text="Launch day!",
+        scheduled_for=start,
+        created_at=datetime(2026, 4, 20, 10, 0, tzinfo=UTC),
+    )
+    post.variants = []
+    body = calendar_ics._render_calendar([post], {})
+    _ics_header_ok(body)
+    assert "BEGIN:VEVENT" in body
+    assert "UID:autoposter-post-42@autoposter" in body
+    assert "DTSTART:20260501T143000Z" in body
+    # +15 min default duration.
+    assert "DTEND:20260501T144500Z" in body
+    assert "SUMMARY:[informative] Launch day!" in body
+    assert "STATUS:TENTATIVE" in body
+    assert "TRANSP:TRANSPARENT" in body
+
+
+def test_render_posted_event_uses_posted_at_and_confirmed():
+    posted = datetime(2026, 4, 1, 9, 0, tzinfo=UTC)
+    post = Post(
+        id=1,
+        post_type=PostType.HARD_SELL,
+        status=PostStatus.POSTED,
+        text="shipped",
+        posted_at=posted,
+        created_at=posted,
+    )
+    post.variants = []
+    body = calendar_ics._render_calendar([post], {})
+    assert "DTSTART:20260401T090000Z" in body
+    assert "STATUS:CONFIRMED" in body
+
+
+def test_escape_handles_ical_special_chars():
+    assert calendar_ics._escape("a,b;c\\d\ne") == "a\\,b\\;c\\\\d\\ne"
+
+
+def test_fold_long_line():
+    long = "x" * 200
+    folded = calendar_ics._fold(long)
+    # Continuation lines begin with a single space, and no physical line
+    # exceeds the fold width.
+    for phys in folded.split("\r\n"):
+        assert len(phys) <= calendar_ics._FOLD_WIDTH + 1  # +1 for leading space
+
+
+# ---------- HTTP surface ----------
+
+
+@pytest.fixture()
+def _no_pin(monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "dashboard_pin", "", raising=False)
+
+
+@pytest.fixture()
+def _with_pin(monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "dashboard_pin", "test-pin", raising=False)
+
+
+def test_calendar_ics_empty_db_no_pin(client, _no_pin):
+    r = client.get("/api/calendar.ics")
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("text/calendar")
+    _ics_header_ok(r.text)
+    assert "BEGIN:VEVENT" not in r.text
+
+
+def test_calendar_ics_includes_scheduled_post(client, db, _no_pin):
+    when = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+    post = _seed_post(db, scheduled_for=when, text="Big announcement; exciting!")
+    r = client.get("/api/calendar.ics")
+    assert r.status_code == 200
+    body = r.text
+    assert f"UID:autoposter-post-{post.id}@autoposter" in body
+    assert "DTSTART:20260601T120000Z" in body
+    # Semicolon must be escaped in SUMMARY.
+    assert "Big announcement\\; exciting!" in body
+
+
+def test_calendar_ics_requires_token_when_pin_set(client, _with_pin):
+    r = client.get("/api/calendar.ics")
+    assert r.status_code == 401
+
+
+def test_calendar_ics_rejects_wrong_token(client, _with_pin):
+    r = client.get("/api/calendar.ics?token=deadbeef")
+    assert r.status_code == 401
+
+
+def test_calendar_ics_accepts_correct_token(client, _with_pin):
+    token = calendar_ics.make_calendar_token("test-pin")
+    r = client.get(f"/api/calendar.ics?token={token}")
+    assert r.status_code == 200
+    _ics_header_ok(r.text)
+
+
+def test_subscribe_url_no_pin(client, _no_pin):
+    r = client.get("/api/calendar/subscribe-url")
+    assert r.status_code == 200
+    body = r.json()
+    assert body == {"url": "/api/calendar.ics", "auth_required": False}
+
+
+def test_subscribe_url_with_pin_includes_token(client, _with_pin):
+    r = client.get(
+        "/api/calendar/subscribe-url",
+        headers={"X-Dashboard-Pin": "test-pin"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["auth_required"] is True
+    token = calendar_ics.make_calendar_token("test-pin")
+    assert body["url"] == f"/api/calendar.ics?token={token}"
+
+
+def test_posts_without_scheduling_are_skipped(client, db, _no_pin):
+    # Draft with no scheduled_for and no posted_at shouldn't appear.
+    _seed_post(db, text="draft-only", status=PostStatus.DRAFT)
+    r = client.get("/api/calendar.ics")
+    assert r.status_code == 200
+    assert "BEGIN:VEVENT" not in r.text
+
+
+def test_event_includes_target_names(client, db, _no_pin):
+    when = datetime.now(UTC) + timedelta(days=1)
+    _seed_post(db, scheduled_for=when, text="targeted post")
+    r = client.get("/api/calendar.ics")
+    assert "Targets: Test Group" in r.text


### PR DESCRIPTION
- app/api/calendar_ics.py: GET /api/calendar.ics serves an RFC 5545 feed (handful of dependency-free serialization helpers) so Google / Apple / Outlook calendars can subscribe to the posting queue. Each Post with scheduled_for or posted_at becomes a 15-min VEVENT; POSTED maps to STATUS:CONFIRMED, FAILED/SKIPPED to CANCELLED, everything else to TENTATIVE. GET /api/calendar/subscribe-url returns the URL the dashboard can render as a "copy subscription link" button.
- security.py: expose /api/calendar.ics as a public path so calendar clients (which can't attach the dashboard cookie) can reach it; the endpoint itself enforces an HMAC-derived token tied to the PIN.
- tests/test_calendar_ics.py: 16 tests covering token stability, empty feeds, field serialization, status mapping, RFC 5545 escaping and folding, public/protected paths, and target-name rendering.