### PR TITLE
Phase 6a: fix 5 broken audit/access-log tests

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -11,8 +11,6 @@ produces ops that silently no-op on SQLite.
 """
 from __future__ import annotations
 
-from logging.config import fileConfig
-
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 
@@ -21,8 +19,10 @@ from app.db.models import Base
 
 config = context.config
 
-if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+# Intentionally do NOT call logging.config.fileConfig on alembic.ini — our
+# app configures the root logger at startup (see app.observability.configure_logging),
+# and fileConfig would overwrite root level to the ini's WARNING, silently
+# dropping every INFO-level access/audit line the app emits.
 
 # Inject the URL at runtime. .env (via pydantic-settings) is the source of truth.
 config.set_main_option("sqlalchemy.url", settings.db_url)

--- a/backend/app/observability.py
+++ b/backend/app/observability.py
@@ -76,17 +76,27 @@ class JsonFormatter(logging.Formatter):
         return json.dumps(payload, ensure_ascii=False)
 
 
+# Attribute we stamp on handlers we install so we can distinguish ours from
+# handlers added by other tooling (e.g. pytest's LogCaptureHandler).
+_OUR_HANDLER_MARKER = "_autoposter_configured"
+
+
 def configure_logging(json_output: bool, level: int = logging.INFO) -> None:
     """Wire up the root logger. Called once from main.py at startup.
 
-    Idempotent: wipes existing handlers so re-running (e.g. uvicorn reload or
-    pytest re-import) doesn't double-emit every line.
+    Idempotent: removes any handler *we* previously installed before adding
+    a fresh one, so re-running (uvicorn reload, pytest re-import) doesn't
+    double-emit every line. Handlers attached by other tooling — notably
+    pytest's `LogCaptureHandler`, which drives `caplog` — are left alone
+    so test instrumentation survives app import.
     """
     root = logging.getLogger()
     root.setLevel(level)
     for handler in list(root.handlers):
-        root.removeHandler(handler)
+        if getattr(handler, _OUR_HANDLER_MARKER, False):
+            root.removeHandler(handler)
     handler = logging.StreamHandler()
+    setattr(handler, _OUR_HANDLER_MARKER, True)
     if json_output:
         handler.setFormatter(JsonFormatter())
     else:

--- a/backend/tests/test_phase2_security_ops.py
+++ b/backend/tests/test_phase2_security_ops.py
@@ -14,8 +14,6 @@ from __future__ import annotations
 import json
 import logging
 
-import pytest
-
 from app.db.models import PlatformCredential
 
 
@@ -70,14 +68,16 @@ def test_json_formatter_stringifies_unserialisable_extras():
 
 
 def test_configure_logging_is_idempotent():
-    from app.observability import configure_logging
+    from app.observability import _OUR_HANDLER_MARKER, configure_logging
 
     configure_logging(json_output=True)
     configure_logging(json_output=False)
     configure_logging(json_output=True)
     root = logging.getLogger()
-    # One handler after repeat calls, not three.
-    assert len(root.handlers) == 1
+    # Exactly one of the handlers *we* installed, regardless of any foreign
+    # handlers (pytest caplog, uvicorn, etc.) that happen to be attached.
+    ours = [h for h in root.handlers if getattr(h, _OUR_HANDLER_MARKER, False)]
+    assert len(ours) == 1
 
 
 # ---------- Access log extras ----------
@@ -275,15 +275,3 @@ def test_log_json_setting_defaults_false():
     from app.config import settings
 
     assert settings.log_json is False
-
-
-@pytest.fixture(autouse=True)
-def _restore_logging_after_test():
-    """Tests that touch configure_logging mutate the root logger; restore
-    something sane afterwards so other tests' caplog captures still work.
-    """
-    yield
-    root = logging.getLogger()
-    for h in list(root.handlers):
-        root.removeHandler(h)
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(name)s] %(message)s")


### PR DESCRIPTION
## Summary

Pre-existing test failures in `test_phase2_security_ops.py` traced back to two separate bugs in logging setup.

**Root cause 1:** `alembic/env.py` called `logging.config.fileConfig(config.config_file_name)` on every `init_db()`. The bundled `alembic.ini` pins `[logger_root] level = WARNING`, which silently clobbered the root logger our app had just set to INFO. Result: every access-log + audit record emitted at INFO level was dropped before reaching caplog. **Fix:** drop the `fileConfig` call — `app.observability.configure_logging` is the sole source of truth for app logging; alembic's own messages still appear via the root handler.

**Root cause 2:** `configure_logging` unconditionally wiped every handler on root, including pytest's `LogCaptureHandler` (the thing that powers `caplog`). **Fix:** stamp a marker attribute on handlers we install and only remove ours on re-invocation.

**Cleanup:** dropped the `_restore_logging_after_test` autouse fixture — it was a workaround for the broken configure_logging; with the marker-based preservation it's now counterproductive (it strips `LogCaptureHandler` between tests).

## Files touched
- `backend/alembic/env.py` — drop `fileConfig`, keep comment explaining why
- `backend/app/observability.py` — `_OUR_HANDLER_MARKER` + selective cleanup
- `backend/tests/test_phase2_security_ops.py` — update idempotency assertion, remove stale autouse fixture, unused `pytest` import

## Test plan
- [x] `pytest tests/test_phase2_security_ops.py` — all 11 green (previously 5 failing)
- [x] full suite: `pytest` — 205 passed, 0 failed
- [x] no regressions in alembic migration behavior (`test_phase4_alembic.py` still green)

https://claude.ai/code/session_0134AfB5wht644Tdt6Gad7od