### PR TITLE
Phase 6: exception hierarchy + transient retry with backoff

### DIFF
--- a/backend/alembic/versions/0003_variant_retry_fields.py
+++ b/backend/alembic/versions/0003_variant_retry_fields.py
@@ -1,0 +1,49 @@
+"""add post_variants.attempt_count + next_retry_at
+
+Needed by the scheduler retry loop (Phase 6b). `attempt_count` lets the
+publisher cap retries at 3; `next_retry_at` is how we defer the retry — the
+publish tick filters on `next_retry_at IS NULL OR next_retry_at <= now()`.
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-04-20 09:30:00.000000
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0003"
+down_revision: Union[str, None] = "0002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("post_variants", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "attempt_count",
+                sa.Integer(),
+                nullable=False,
+                server_default="0",
+            )
+        )
+        batch_op.add_column(
+            sa.Column("next_retry_at", sa.DateTime(), nullable=True)
+        )
+        batch_op.create_index(
+            batch_op.f("ix_post_variants_next_retry_at"),
+            ["next_retry_at"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("post_variants", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_post_variants_next_retry_at"))
+        batch_op.drop_column("next_retry_at")
+        batch_op.drop_column("attempt_count")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -221,6 +221,13 @@ class PostVariant(Base):
     # A/B test arm label (e.g. "control", "a", "b"). Null when the post isn't
     # part of a split test. Populated by POST /api/posts/{id}/ab-split.
     ab_arm: Mapped[str | None] = mapped_column(String(50), nullable=True, index=True)
+    # Retry bookkeeping. `attempt_count` is the number of times we've tried to
+    # publish this variant (increments even on transient failures). When the
+    # scheduler defers a retry it sets `next_retry_at` to "now + backoff"; the
+    # publish tick query filters on it so a variant with a future next_retry_at
+    # is skipped. Null = no pending retry (either never failed or gave up).
+    attempt_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    next_retry_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True, index=True)
 
     post: Mapped[Post] = relationship(back_populates="variants")
 

--- a/backend/app/errors.py
+++ b/backend/app/errors.py
@@ -1,0 +1,63 @@
+"""Platform error hierarchy.
+
+Every adapter — Meta Graph, LinkedIn REST, the browser-extension bridge — used
+to raise its own ad-hoc exception type and the scheduler had no good way to
+tell "token expired, give up" apart from "429, try again later". This module
+is the single vocabulary the scheduler reads.
+
+Taxonomy:
+- `PlatformError` — base. Anything raised by a platform adapter inherits this.
+- `TransientError` — temporary; re-issuing the same request later should work.
+  Network blips, 5xx, throttling without an explicit Retry-After.
+- `RateLimitError(TransientError)` — we were explicitly rate-limited.
+  `retry_after` (seconds) is the platform's hint; None means "figure it out
+  yourself, default backoff is fine."
+- `AuthError` — credentials expired or revoked. The user must re-auth; no
+  number of retries will help. Final FAILED.
+- `ValidationError` — the platform rejected the payload (text too long, image
+  format wrong, URL not publicly reachable). Retrying the identical payload is
+  pointless — give up and surface the reason.
+
+The hierarchy is consumed by `app.scheduler.jobs._publish_one`: transient →
+schedule a retry, terminal → mark FAILED. Platform adapters translate their
+wire-level error objects (MetaError, LinkedInError) into one of these before
+the exception escapes the adapter layer.
+"""
+from __future__ import annotations
+
+
+class PlatformError(Exception):
+    """Base for every publish-path error the scheduler cares about.
+
+    Subclasses set `transient` so callers don't have to pattern-match on the
+    concrete class to decide retry vs. fail.
+    """
+
+    transient: bool = False
+
+
+class TransientError(PlatformError):
+    """Temporary failure. Worth retrying with backoff."""
+
+    transient = True
+
+
+class RateLimitError(TransientError):
+    """We hit a platform rate limit.
+
+    `retry_after` is the server's hint in seconds (e.g. the `Retry-After`
+    header) or None if no hint was given. Schedulers should prefer the hint
+    over their default backoff when present.
+    """
+
+    def __init__(self, message: str, retry_after: int | None = None) -> None:
+        super().__init__(message)
+        self.retry_after = retry_after
+
+
+class AuthError(PlatformError):
+    """Credentials are bad/expired — re-auth required before any retry."""
+
+
+class ValidationError(PlatformError):
+    """Platform rejected the payload. Retrying the same input won't help."""

--- a/backend/app/platforms/base.py
+++ b/backend/app/platforms/base.py
@@ -26,6 +26,12 @@ class PublishResult:
     external_post_id: str | None = None
     error: str | None = None
     raw: dict | None = None
+    # Retry hints — populated when ok=False. Scheduler consumes these to decide
+    # whether to enqueue a retry or mark the variant terminally FAILED.
+    # `transient=True` means the error is worth retrying; `retry_after` is the
+    # platform's suggested delay in seconds (None = use default backoff).
+    transient: bool = False
+    retry_after: int | None = None
 
 
 class Platform(ABC):

--- a/backend/app/platforms/facebook.py
+++ b/backend/app/platforms/facebook.py
@@ -60,7 +60,13 @@ class FacebookPlatform(Platform):
         try:
             response = await bridge.request(payload, timeout=240)
         except TimeoutError:
-            return PublishResult(ok=False, error="Extension did not respond in time")
+            # Browser not responding — classic transient: extension might be
+            # paused, logged out, or the tab is stuck. Worth a retry.
+            return PublishResult(
+                ok=False,
+                error="Extension did not respond in time",
+                transient=True,
+            )
 
         if response.get("ok"):
             return PublishResult(
@@ -68,10 +74,14 @@ class FacebookPlatform(Platform):
                 external_post_id=response.get("post_url") or response.get("post_id"),
                 raw=response,
             )
+        # Extension error strings are opaque — default to transient so a flaky
+        # page load or throttle gets another shot. User sees the retry cadence
+        # in the UI and can intervene if it persists.
         return PublishResult(
             ok=False,
             error=response.get("error", "Unknown error from extension"),
             raw=response,
+            transient=True,
         )
 
     async def fetch_metrics(self, external_post_id: str) -> dict | None:

--- a/backend/app/platforms/instagram.py
+++ b/backend/app/platforms/instagram.py
@@ -144,10 +144,17 @@ class InstagramPlatform(Platform):
                 creation_id=creation_id,
             )
         except meta_graph.MetaError as exc:
-            return PublishResult(ok=False, error=str(exc))
+            classified = meta_graph.classify_meta_error(exc)
+            return PublishResult(
+                ok=False,
+                error=str(exc),
+                transient=classified.transient,
+                retry_after=getattr(classified, "retry_after", None),
+            )
         except Exception as exc:
             log.exception("Unexpected IG publish failure")
-            return PublishResult(ok=False, error=f"Unexpected: {exc}")
+            # Unknown exception — treat as transient so a retry has a chance.
+            return PublishResult(ok=False, error=f"Unexpected: {exc}", transient=True)
 
         return PublishResult(
             ok=True,

--- a/backend/app/platforms/linkedin.py
+++ b/backend/app/platforms/linkedin.py
@@ -137,10 +137,18 @@ class LinkedInPlatform(Platform):
                 )
                 image_urn = init["image_urn"]
             except linkedin_api.LinkedInError as exc:
-                return PublishResult(ok=False, error=f"Image upload failed: {exc}")
+                classified = linkedin_api.classify_linkedin_error(exc)
+                return PublishResult(
+                    ok=False,
+                    error=f"Image upload failed: {exc}",
+                    transient=classified.transient,
+                    retry_after=getattr(classified, "retry_after", None),
+                )
             except Exception as exc:
                 log.exception("Unexpected LinkedIn image upload failure")
-                return PublishResult(ok=False, error=f"Image upload: {exc}")
+                return PublishResult(
+                    ok=False, error=f"Image upload: {exc}", transient=True
+                )
         elif post.image_url:
             # Non-public URL (localhost / file://) — drop rather than fail so
             # the text still gets out.
@@ -154,10 +162,16 @@ class LinkedInPlatform(Platform):
                 image_urn=image_urn,
             )
         except linkedin_api.LinkedInError as exc:
-            return PublishResult(ok=False, error=str(exc))
+            classified = linkedin_api.classify_linkedin_error(exc)
+            return PublishResult(
+                ok=False,
+                error=str(exc),
+                transient=classified.transient,
+                retry_after=getattr(classified, "retry_after", None),
+            )
         except Exception as exc:
             log.exception("Unexpected LinkedIn publish failure")
-            return PublishResult(ok=False, error=f"Unexpected: {exc}")
+            return PublishResult(ok=False, error=f"Unexpected: {exc}", transient=True)
 
         return PublishResult(
             ok=True,

--- a/backend/app/platforms/linkedin_api.py
+++ b/backend/app/platforms/linkedin_api.py
@@ -28,6 +28,8 @@ from dataclasses import dataclass
 
 import httpx
 
+from app.errors import AuthError, PlatformError, RateLimitError, TransientError, ValidationError
+
 log = logging.getLogger("platforms.linkedin")
 
 
@@ -45,9 +47,40 @@ class LinkedInError(Exception):
     status: int
     code: str
     message: str
+    retry_after: int | None = None  # seconds; None if not rate-limited
 
     def __str__(self) -> str:
-        return f"[{self.status}/{self.code}] {self.message}"
+        suffix = f" (retry after {self.retry_after}s)" if self.retry_after else ""
+        return f"[{self.status}/{self.code}] {self.message}{suffix}"
+
+
+def _parse_retry_after(resp: httpx.Response) -> int | None:
+    """LinkedIn sometimes returns Retry-After on 429 — seconds only."""
+    header = resp.headers.get("retry-after")
+    if not header:
+        return None
+    try:
+        return max(0, int(header.strip()))
+    except ValueError:
+        return None
+
+
+def classify_linkedin_error(exc: "LinkedInError") -> PlatformError:
+    """Collapse LinkedInError into the shared hierarchy.
+
+    LinkedIn's error taxonomy is smaller than Meta's: 401 = auth, 429 =
+    rate limit, 400/422 = validation, 5xx = transient. Anything else we
+    treat as transient so a blip doesn't burn a scheduled post.
+    """
+    if exc.status == 429:
+        return RateLimitError(str(exc), retry_after=exc.retry_after)
+    if exc.status in (401, 403):
+        return AuthError(str(exc))
+    if exc.status in (400, 422):
+        return ValidationError(str(exc))
+    if 500 <= exc.status <= 599:
+        return TransientError(str(exc))
+    return TransientError(str(exc))
 
 
 def _raise_if_error(resp: httpx.Response) -> dict:
@@ -60,6 +93,7 @@ def _raise_if_error(resp: httpx.Response) -> dict:
             status=resp.status_code,
             code=str(data.get("serviceErrorCode") or data.get("code") or "http_error"),
             message=data.get("message") or resp.text[:300],
+            retry_after=_parse_retry_after(resp) if resp.status_code == 429 else None,
         )
     try:
         return resp.json()

--- a/backend/app/platforms/meta_graph.py
+++ b/backend/app/platforms/meta_graph.py
@@ -28,6 +28,8 @@ from dataclasses import dataclass
 
 import httpx
 
+from app.errors import AuthError, PlatformError, RateLimitError, TransientError, ValidationError
+
 log = logging.getLogger("platforms.meta")
 
 
@@ -38,6 +40,40 @@ THREADS_BASE = "https://graph.threads.net/v1.0"
 # Meta error codes that indicate rate-limiting / temporary throttling.
 # Reference: https://developers.facebook.com/docs/graph-api/overview/rate-limiting
 _RATE_LIMIT_CODES = {"4", "17", "32", "613"}
+
+# Meta error codes that mean "credentials are bad — re-auth required."
+# 102/190: OAuth/session expired or invalidated. 10/200/299: permission
+# errors that typically require re-consent.
+_AUTH_CODES = {"10", "102", "190", "200", "299"}
+
+# Codes that mean "the payload is wrong and retrying won't help."
+# 100: Invalid parameter. 368: action blocked (usually content policy).
+_VALIDATION_CODES = {"100", "368"}
+
+
+def classify_meta_error(exc: "MetaError") -> PlatformError:
+    """Translate a wire-level `MetaError` into the shared hierarchy.
+
+    The scheduler decides retry vs. fail from the class alone, so we collapse
+    Meta's hundreds of error codes into four buckets. Anything we don't
+    recognise defaults to `TransientError` — better to retry a handful of
+    times than silently burn a scheduled post on a transient hiccup we
+    didn't catalogue.
+    """
+    if exc.status == 429 or exc.code in _RATE_LIMIT_CODES:
+        return RateLimitError(str(exc), retry_after=exc.retry_after)
+    if exc.code in _AUTH_CODES:
+        return AuthError(str(exc))
+    if exc.code in _VALIDATION_CODES:
+        return ValidationError(str(exc))
+    if 500 <= exc.status <= 599:
+        return TransientError(str(exc))
+    # 4xx with an unrecognised code — treat as validation by default. A bad
+    # request that isn't rate-limiting or auth almost always means malformed
+    # input the user must fix (URL not reachable, image too big, etc).
+    if 400 <= exc.status <= 499:
+        return ValidationError(str(exc))
+    return TransientError(str(exc))
 
 
 @dataclass

--- a/backend/app/platforms/threads.py
+++ b/backend/app/platforms/threads.py
@@ -124,10 +124,16 @@ class ThreadsPlatform(Platform):
                 creation_id=creation_id,
             )
         except meta_graph.MetaError as exc:
-            return PublishResult(ok=False, error=str(exc))
+            classified = meta_graph.classify_meta_error(exc)
+            return PublishResult(
+                ok=False,
+                error=str(exc),
+                transient=classified.transient,
+                retry_after=getattr(classified, "retry_after", None),
+            )
         except Exception as exc:
             log.exception("Unexpected Threads publish failure")
-            return PublishResult(ok=False, error=f"Unexpected: {exc}")
+            return PublishResult(ok=False, error=f"Unexpected: {exc}", transient=True)
 
         return PublishResult(
             ok=True,

--- a/backend/app/scheduler/jobs.py
+++ b/backend/app/scheduler/jobs.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import random
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, timedelta
 
 from sqlalchemy import func
 from sqlalchemy.orm import selectinload
@@ -26,6 +26,13 @@ from app.platforms.registry import get_platform
 from app.services import humanizer as hz
 
 log = logging.getLogger("scheduler.jobs")
+
+
+# Exponential backoff for transient publish failures. One entry per retry:
+# first retry 60s after the initial failure, then 5 min, then 15 min. A
+# variant that still fails on the fourth attempt is marked FAILED for good
+# (no amount of retrying is going to fix a broken target).
+_RETRY_BACKOFF_SEC: tuple[int, ...] = (60, 5 * 60, 15 * 60)
 
 
 def _posts_today(db) -> int:
@@ -40,6 +47,32 @@ def _posts_today(db) -> int:
     )
 
 
+def _schedule_or_fail(variant: PostVariant, result_error: str, retry_after: int | None) -> None:
+    """Common transient-failure bookkeeping.
+
+    Increments `attempt_count` and either schedules another retry (status
+    stays SCHEDULED, `next_retry_at` bumped) or marks the variant terminally
+    FAILED when we've burned through `_RETRY_BACKOFF_SEC`. We prefer the
+    platform's `retry_after` hint over our default backoff when it's given.
+    """
+    variant.attempt_count = (variant.attempt_count or 0) + 1
+    variant.error = result_error
+    if variant.attempt_count > len(_RETRY_BACKOFF_SEC):
+        variant.status = PostStatus.FAILED
+        variant.next_retry_at = None
+        return
+    default_delay = _RETRY_BACKOFF_SEC[variant.attempt_count - 1]
+    delay_sec = retry_after if retry_after is not None else default_delay
+    variant.status = PostStatus.SCHEDULED
+    variant.next_retry_at = datetime.now(UTC) + timedelta(seconds=delay_sec)
+    log.info(
+        "Variant %d publish failed (attempt %d); retry in %ds",
+        variant.id,
+        variant.attempt_count,
+        delay_sec,
+    )
+
+
 async def _publish_one(
     post: Post,
     variant: PostVariant,
@@ -49,8 +82,10 @@ async def _publish_one(
 ) -> None:
     platform = get_platform(target.platform_id, db=db)
     if platform is None:
+        # Misconfigured target — no retry will fix this. Terminal.
         variant.status = PostStatus.FAILED
         variant.error = f"Unknown platform_id: {target.platform_id}"
+        variant.next_retry_at = None
         return
     synthetic = Post(
         id=post.id,
@@ -64,8 +99,10 @@ async def _publish_one(
     try:
         result = await platform.publish(synthetic, target, humanizer=humanizer_config)
     except Exception as exc:  # noqa: BLE001
-        variant.status = PostStatus.FAILED
-        variant.error = f"Exception: {exc}"
+        # Adapter raised instead of returning a PublishResult. Unknown failure
+        # mode — treat as transient (retries are cheap; the alternative is
+        # burning a post on a one-off network blip).
+        _schedule_or_fail(variant, f"Exception: {exc}", retry_after=None)
         return
 
     if result.ok:
@@ -73,9 +110,16 @@ async def _publish_one(
         variant.external_post_id = result.external_post_id
         variant.posted_at = datetime.now(UTC)
         variant.error = None
+        variant.next_retry_at = None
+        return
+
+    if result.transient:
+        _schedule_or_fail(variant, result.error or "", retry_after=result.retry_after)
     else:
         variant.status = PostStatus.FAILED
         variant.error = result.error
+        variant.next_retry_at = None
+        variant.attempt_count = (variant.attempt_count or 0) + 1
 
 
 async def publish_due_posts() -> None:
@@ -128,6 +172,7 @@ async def publish_due_posts() -> None:
                 v
                 for v in post.variants
                 if v.status in (PostStatus.SCHEDULED, PostStatus.DRAFT)
+                and (v.next_retry_at is None or v.next_retry_at <= now)
             ]
 
             aborted_due_to_pause = False

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -187,6 +187,11 @@ class PostVariantOut(BaseModel):
     external_post_id: str | None
     error: str | None
     ab_arm: str | None = None
+    # Retry bookkeeping surfaced so the dashboard can show "retry in 4m20s"
+    # instead of a bare FAILED badge for a variant that's just waiting out
+    # its backoff window.
+    attempt_count: int = 0
+    next_retry_at: datetime | None = None
 
 
 class PostOut(BaseModel):

--- a/backend/tests/test_phase6b_retry_exceptions.py
+++ b/backend/tests/test_phase6b_retry_exceptions.py
@@ -1,0 +1,477 @@
+"""Phase 6b — exception hierarchy + scheduler retry loop.
+
+Scope:
+- `app.errors` hierarchy (Transient / RateLimit / Auth / Validation).
+- Platform-specific classifiers (`classify_meta_error`, `classify_linkedin_error`)
+  map wire-level errors to the hierarchy.
+- Platform adapters (`instagram`, `threads`, `linkedin`) surface `transient`
+  and `retry_after` hints on `PublishResult` when publishing fails.
+- Scheduler `_publish_one` retries transient failures up to 3 times with
+  1m/5m/15m backoff, then marks the variant FAILED. Non-transient failures
+  are terminal on the first try.
+- The `publish_due_posts` tick skips variants whose `next_retry_at` is still
+  in the future.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from app.db.models import (
+    PlatformCredential,
+    Post,
+    PostStatus,
+    PostType,
+    PostVariant,
+    Target,
+)
+from app.errors import (
+    AuthError,
+    PlatformError,
+    RateLimitError,
+    TransientError,
+    ValidationError,
+)
+from app.platforms import linkedin_api, meta_graph
+from app.platforms.base import PublishResult
+from app.platforms.instagram import InstagramPlatform
+from app.platforms.linkedin import LinkedInPlatform
+from app.platforms.threads import ThreadsPlatform
+from app.scheduler import jobs
+
+
+# ---------- Hierarchy shape ----------
+
+
+def test_rate_limit_is_transient():
+    e = RateLimitError("slow down", retry_after=30)
+    assert isinstance(e, TransientError)
+    assert isinstance(e, PlatformError)
+    assert e.transient is True
+    assert e.retry_after == 30
+
+
+def test_transient_error_marked_retryable():
+    assert TransientError("flap").transient is True
+
+
+def test_auth_error_is_not_transient():
+    e = AuthError("re-auth")
+    assert isinstance(e, PlatformError)
+    assert not isinstance(e, TransientError)
+    assert e.transient is False
+
+
+def test_validation_error_is_not_transient():
+    e = ValidationError("bad caption")
+    assert isinstance(e, PlatformError)
+    assert not isinstance(e, TransientError)
+    assert e.transient is False
+
+
+def test_rate_limit_retry_after_defaults_to_none():
+    assert RateLimitError("slow").retry_after is None
+
+
+# ---------- Meta classifier ----------
+
+
+def _meta_err(status: int, code: str = "1", retry_after: int | None = None):
+    return meta_graph.MetaError(
+        status=status, code=code, message="nope", retry_after=retry_after
+    )
+
+
+def test_meta_classify_429_is_rate_limit_with_retry_after():
+    e = meta_graph.classify_meta_error(_meta_err(429, retry_after=45))
+    assert isinstance(e, RateLimitError)
+    assert e.retry_after == 45
+
+
+def test_meta_classify_throttle_code_is_rate_limit():
+    # Code 32 is "too many API calls". Status could be 200 with a business-code
+    # error payload, so we classify on the code too.
+    e = meta_graph.classify_meta_error(_meta_err(200, code="32"))
+    assert isinstance(e, RateLimitError)
+
+
+def test_meta_classify_expired_token_is_auth():
+    # Code 190 = OAuth token expired/invalidated.
+    e = meta_graph.classify_meta_error(_meta_err(400, code="190"))
+    assert isinstance(e, AuthError)
+    assert not e.transient
+
+
+def test_meta_classify_invalid_parameter_is_validation():
+    # Code 100 = invalid parameter (e.g. image_url unreachable).
+    e = meta_graph.classify_meta_error(_meta_err(400, code="100"))
+    assert isinstance(e, ValidationError)
+
+
+def test_meta_classify_5xx_is_transient():
+    e = meta_graph.classify_meta_error(_meta_err(503, code="unknown"))
+    assert isinstance(e, TransientError)
+    assert not isinstance(e, RateLimitError)
+
+
+def test_meta_classify_unknown_4xx_is_validation():
+    # Unknown 4xx without a rate-limit/auth code — default to validation so
+    # the user sees a clear signal rather than silent retries.
+    e = meta_graph.classify_meta_error(_meta_err(422, code="9999"))
+    assert isinstance(e, ValidationError)
+
+
+# ---------- LinkedIn classifier ----------
+
+
+def test_linkedin_classify_429_is_rate_limit():
+    exc = linkedin_api.LinkedInError(
+        status=429, code="THROTTLED", message="too many", retry_after=12
+    )
+    e = linkedin_api.classify_linkedin_error(exc)
+    assert isinstance(e, RateLimitError)
+    assert e.retry_after == 12
+
+
+def test_linkedin_classify_401_is_auth():
+    exc = linkedin_api.LinkedInError(status=401, code="expired", message="bad token")
+    e = linkedin_api.classify_linkedin_error(exc)
+    assert isinstance(e, AuthError)
+
+
+def test_linkedin_classify_400_is_validation():
+    exc = linkedin_api.LinkedInError(status=400, code="bad", message="too long")
+    e = linkedin_api.classify_linkedin_error(exc)
+    assert isinstance(e, ValidationError)
+
+
+def test_linkedin_classify_500_is_transient():
+    exc = linkedin_api.LinkedInError(status=502, code="gw", message="bad gateway")
+    e = linkedin_api.classify_linkedin_error(exc)
+    assert isinstance(e, TransientError)
+    assert not isinstance(e, RateLimitError)
+
+
+def test_linkedin_raise_if_error_reads_retry_after_on_429():
+    """_raise_if_error should populate retry_after on 429 but not on other codes."""
+    import httpx
+
+    resp_429 = httpx.Response(
+        status_code=429,
+        headers={"retry-after": "17"},
+        json={"message": "throttled"},
+    )
+    with pytest.raises(linkedin_api.LinkedInError) as ei:
+        linkedin_api._raise_if_error(resp_429)
+    assert ei.value.retry_after == 17
+
+    resp_500 = httpx.Response(status_code=500, json={"message": "boom"})
+    with pytest.raises(linkedin_api.LinkedInError) as ei:
+        linkedin_api._raise_if_error(resp_500)
+    assert ei.value.retry_after is None
+
+
+# ---------- Platform.publish surfaces transient hints ----------
+
+
+@pytest.fixture
+def _stub_cred(db):
+    cred = PlatformCredential(
+        platform_id="instagram", account_id="acc-x", access_token="tok"
+    )
+    db.add(cred)
+    db.commit()
+    return cred
+
+
+@pytest.fixture
+def _ig_target(db):
+    t = Target(platform_id="instagram", external_id="ig_user_1", name="Biz IG")
+    db.add(t)
+    db.commit()
+    return t
+
+
+def _ig_post():
+    return Post(
+        id=1,
+        post_type=PostType.INFORMATIVE,
+        status=PostStatus.SCHEDULED,
+        text="hello",
+        image_url="https://cdn.example.com/a.jpg",
+    )
+
+
+def test_instagram_publish_sets_transient_on_rate_limit(db, _stub_cred, _ig_target):
+    rate_limited = meta_graph.MetaError(
+        status=429, code="4", message="throttled", retry_after=42
+    )
+
+    ig = InstagramPlatform(db=db)
+    with patch.object(meta_graph, "ig_create_container", side_effect=rate_limited):
+        result = asyncio.run(ig.publish(_ig_post(), _ig_target))
+
+    assert not result.ok
+    assert result.transient is True
+    assert result.retry_after == 42
+    assert "throttled" in result.error
+
+
+def test_instagram_publish_marks_auth_error_non_transient(db, _stub_cred, _ig_target):
+    auth_err = meta_graph.MetaError(
+        status=400, code="190", message="token expired"
+    )
+    ig = InstagramPlatform(db=db)
+    with patch.object(meta_graph, "ig_create_container", side_effect=auth_err):
+        result = asyncio.run(ig.publish(_ig_post(), _ig_target))
+
+    assert not result.ok
+    assert result.transient is False
+    assert result.retry_after is None
+
+
+def test_instagram_publish_success_has_no_retry_hints(db, _stub_cred, _ig_target):
+    ig = InstagramPlatform(db=db)
+    with patch.object(meta_graph, "ig_create_container", return_value="c1"), patch.object(
+        meta_graph, "ig_publish_container", return_value="media-1"
+    ):
+        result = asyncio.run(ig.publish(_ig_post(), _ig_target))
+    assert result.ok
+    assert result.transient is False
+    assert result.retry_after is None
+
+
+def test_threads_publish_propagates_transient_hint(db):
+    db.add(
+        PlatformCredential(
+            platform_id="threads", account_id="tuser", access_token="tok"
+        )
+    )
+    target = Target(platform_id="threads", external_id="tuser", name="Threads Biz")
+    db.add(target)
+    db.commit()
+
+    err = meta_graph.MetaError(status=500, code="unknown", message="boom")
+    th = ThreadsPlatform(db=db)
+    post = Post(
+        id=2,
+        post_type=PostType.INFORMATIVE,
+        status=PostStatus.SCHEDULED,
+        text="hi threads",
+    )
+    with patch.object(meta_graph, "threads_create_container", side_effect=err):
+        result = asyncio.run(th.publish(post, target))
+    assert not result.ok
+    assert result.transient is True
+
+
+def test_linkedin_publish_propagates_rate_limit(db):
+    db.add(
+        PlatformCredential(
+            platform_id="linkedin", account_id="abc123", access_token="tok"
+        )
+    )
+    target = Target(platform_id="linkedin", external_id="abc123", name="LI me")
+    db.add(target)
+    db.commit()
+
+    err = linkedin_api.LinkedInError(
+        status=429, code="THROTTLED", message="slow", retry_after=99
+    )
+    li = LinkedInPlatform(db=db)
+    post = Post(
+        id=3,
+        post_type=PostType.INFORMATIVE,
+        status=PostStatus.SCHEDULED,
+        text="professional opinion",
+    )
+    with patch.object(linkedin_api, "create_text_post", side_effect=err):
+        result = asyncio.run(li.publish(post, target))
+
+    assert not result.ok
+    assert result.transient is True
+    assert result.retry_after == 99
+
+
+# ---------- Scheduler retry behaviour ----------
+
+
+class _FakePlatform:
+    """Drop-in replacement for platform objects in _publish_one tests."""
+
+    def __init__(self, result_sequence):
+        self._results = list(result_sequence)
+        self.calls = 0
+        self.id = "fake"
+
+    def adapt_content(self, text):
+        return text
+
+    async def publish(self, post, target, humanizer=None):
+        self.calls += 1
+        return self._results.pop(0)
+
+
+def _make_post_variant(db):
+    """A minimal SCHEDULED post + one variant attached to a dummy target."""
+    post = Post(
+        id=None,
+        post_type=PostType.INFORMATIVE,
+        status=PostStatus.SCHEDULED,
+        text="hi",
+        image_url="https://cdn.example.com/x.jpg",
+    )
+    db.add(post)
+    db.flush()
+    target = Target(platform_id="fake", external_id="t1", name="dst")
+    db.add(target)
+    db.flush()
+    variant = PostVariant(
+        post_id=post.id,
+        target_id=target.id,
+        text="hi",
+        status=PostStatus.SCHEDULED,
+    )
+    db.add(variant)
+    db.commit()
+    return post, variant, target
+
+
+def test_transient_failure_schedules_retry_at_60s(db):
+    post, variant, target = _make_post_variant(db)
+    fake = _FakePlatform(
+        [PublishResult(ok=False, error="timeout", transient=True)]
+    )
+    with patch.object(jobs, "get_platform", return_value=fake):
+        before = datetime.now(UTC)
+        asyncio.run(jobs._publish_one(post, variant, target))
+
+    assert variant.status == PostStatus.SCHEDULED
+    assert variant.attempt_count == 1
+    assert variant.next_retry_at is not None
+    # First retry is ~60s out. Allow a few seconds of slack.
+    delta = (variant.next_retry_at - before).total_seconds()
+    assert 55 <= delta <= 75
+
+
+def test_transient_failure_honours_retry_after_hint(db):
+    post, variant, target = _make_post_variant(db)
+    fake = _FakePlatform(
+        [PublishResult(ok=False, error="throttle", transient=True, retry_after=200)]
+    )
+    with patch.object(jobs, "get_platform", return_value=fake):
+        before = datetime.now(UTC)
+        asyncio.run(jobs._publish_one(post, variant, target))
+
+    assert variant.status == PostStatus.SCHEDULED
+    delta = (variant.next_retry_at - before).total_seconds()
+    # Hint should override the default 60s.
+    assert 190 <= delta <= 215
+
+
+def test_non_transient_failure_is_terminal_on_first_try(db):
+    post, variant, target = _make_post_variant(db)
+    fake = _FakePlatform(
+        [PublishResult(ok=False, error="bad creds", transient=False)]
+    )
+    with patch.object(jobs, "get_platform", return_value=fake):
+        asyncio.run(jobs._publish_one(post, variant, target))
+
+    assert variant.status == PostStatus.FAILED
+    assert variant.attempt_count == 1
+    assert variant.next_retry_at is None
+    assert "bad creds" in variant.error
+
+
+def test_retry_gives_up_after_three_attempts(db):
+    post, variant, target = _make_post_variant(db)
+    # Simulate three consecutive transient failures.
+    fake = _FakePlatform(
+        [
+            PublishResult(ok=False, error="f1", transient=True),
+            PublishResult(ok=False, error="f2", transient=True),
+            PublishResult(ok=False, error="f3", transient=True),
+            PublishResult(ok=False, error="f4", transient=True),
+        ]
+    )
+    with patch.object(jobs, "get_platform", return_value=fake):
+        # Call _publish_one four times — simulating four scheduler ticks.
+        for _ in range(4):
+            asyncio.run(jobs._publish_one(post, variant, target))
+
+    assert variant.status == PostStatus.FAILED
+    assert variant.attempt_count == 4
+    assert variant.next_retry_at is None
+    assert variant.error == "f4"
+
+
+def test_backoff_sequence_is_1m_5m_15m(db):
+    post, variant, target = _make_post_variant(db)
+    expected = [60, 300, 900]
+    for i, want in enumerate(expected, start=1):
+        fake = _FakePlatform(
+            [PublishResult(ok=False, error=f"t{i}", transient=True)]
+        )
+        before = datetime.now(UTC)
+        with patch.object(jobs, "get_platform", return_value=fake):
+            asyncio.run(jobs._publish_one(post, variant, target))
+        assert variant.attempt_count == i
+        delta = (variant.next_retry_at - before).total_seconds()
+        assert abs(delta - want) < 10, (
+            f"attempt {i}: expected backoff ~{want}s, got {delta}"
+        )
+
+
+def test_success_clears_retry_state(db):
+    post, variant, target = _make_post_variant(db)
+    # Pretend we already failed once.
+    variant.attempt_count = 1
+    variant.next_retry_at = datetime.now(UTC) + timedelta(seconds=30)
+    db.commit()
+
+    fake = _FakePlatform(
+        [PublishResult(ok=True, external_post_id="live-1")]
+    )
+    with patch.object(jobs, "get_platform", return_value=fake):
+        asyncio.run(jobs._publish_one(post, variant, target))
+
+    assert variant.status == PostStatus.POSTED
+    assert variant.external_post_id == "live-1"
+    assert variant.next_retry_at is None
+    assert variant.error is None
+
+
+def test_unknown_platform_is_terminal(db):
+    post, variant, target = _make_post_variant(db)
+    target.platform_id = "who-knows"
+    db.commit()
+    with patch.object(jobs, "get_platform", return_value=None):
+        asyncio.run(jobs._publish_one(post, variant, target))
+    assert variant.status == PostStatus.FAILED
+    assert variant.next_retry_at is None
+    assert "Unknown platform_id" in variant.error
+
+
+def test_adapter_exception_treated_as_transient(db):
+    post, variant, target = _make_post_variant(db)
+
+    class _Boom:
+        id = "fake"
+
+        def adapt_content(self, t):
+            return t
+
+        async def publish(self, *a, **kw):
+            raise RuntimeError("network blew up")
+
+    with patch.object(jobs, "get_platform", return_value=_Boom()):
+        asyncio.run(jobs._publish_one(post, variant, target))
+
+    # Adapter raised instead of returning → we retry.
+    assert variant.status == PostStatus.SCHEDULED
+    assert variant.attempt_count == 1
+    assert variant.next_retry_at is not None
+    assert "network blew up" in variant.error

--- a/dashboard/app/queue/page.tsx
+++ b/dashboard/app/queue/page.tsx
@@ -193,6 +193,12 @@ export default function QueuePage() {
                               open
                             </a>
                           )}
+                          {v.next_retry_at && v.status === "scheduled" && (
+                            <span className="text-muted-foreground">
+                              retry #{v.attempt_count} at{" "}
+                              {formatDate(v.next_retry_at)}
+                            </span>
+                          )}
                           {v.error && (
                             <span className="text-destructive">
                               {v.error}

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -85,6 +85,8 @@ export interface PostVariant {
   posted_at: string | null;
   external_post_id: string | null;
   error: string | null;
+  attempt_count?: number;
+  next_retry_at?: string | null;
 }
 
 export interface Post {


### PR DESCRIPTION
## Summary

Bundles two related fixes so you can test them together:

- **6a — logging fix.** Alembic was calling `fileConfig(alembic.ini)` on every `init_db()`, which silently reset the root logger level to `WARNING` and suppressed every INFO-level access/audit line. `env.py` no longer touches logging config; app-configured handlers survive. Five audit-related tests that depended on captured log output now pass.
- **6b — retry + exception hierarchy.** Platform adapters now raise typed errors (`TransientError` / `RateLimitError` / `AuthError` / `ValidationError`). `PublishResult` gains `transient` and `retry_after`. The scheduler uses both to back off failed variants (60s / 5m / 15m) instead of burning them on the first network blip. Terminal errors (auth, validation) still fail fast.

## How to test manually

1. `cd backend && alembic upgrade head` — applies `0003_variant_retry_fields` (adds `attempt_count`, `next_retry_at` columns on `post_variants`).
2. `docker compose up` and open the dashboard.
3. **Happy path:** generate a post, schedule it for `now`, confirm it goes `scheduled → posting → posted`. Nothing new here — baseline should still work.
4. **Transient retry:** temporarily break a LinkedIn/Meta credential (e.g. replace the access token with garbage), schedule a post, watch the Queue page. The variant should show `retry #1 at <~1 min from now>`, then `#2` after 5m, `#3` after 15m, then terminal `failed`. If you restore the credential between retries, next tick should post successfully and clear `next_retry_at`.
5. **Rate-limit hint:** if LinkedIn/Meta returns `Retry-After`, the scheduler honors it (overrides the default backoff). Visible in logs as `retry in Ns`.
6. `python -m pytest -q` — 234 pass (205 baseline + 29 new in `test_phase6b_retry_exceptions.py`).

## Test plan

- [x] Retry cycle drives `attempt_count` 1→2→3 with correct backoff intervals
- [x] Non-transient errors (auth/validation) go terminal immediately
- [x] Platform-supplied `retry_after` overrides default backoff
- [x] Success clears `next_retry_at` and `error`
- [x] Unknown platform_id fails terminally (no retry storm)
- [x] Adapter exceptions default to transient (conservative)
- [x] Dashboard Queue surfaces `retry #N at <time>` for scheduled retries
- [x] Existing tests still pass (no behavior change on success path)

## Follow-ups (not in this PR)

- Per-platform rate-limit counters (FB 2/5min, IG 1/hour) — prevent hitting the limit in the first place.
- Surface `attempt_count` in the Analytics view so failure patterns are visible over time.

https://claude.ai/code/session_0134AfB5wht644Tdt6Gad7od