### PR TITLE
Meta production-readiness + guided home dashboard

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -7,6 +7,7 @@ from app.api import (
     auth,
     business_profile,
     calendar_ics,
+    dashboard,
     feedback,
     followers,
     health,
@@ -23,6 +24,7 @@ from app.api import (
 api_router = APIRouter()
 api_router.include_router(auth.router)
 api_router.include_router(health.router)
+api_router.include_router(dashboard.router)
 api_router.include_router(business_profile.router)
 api_router.include_router(targets.router)
 api_router.include_router(posts.router)

--- a/backend/app/api/dashboard.py
+++ b/backend/app/api/dashboard.py
@@ -1,0 +1,365 @@
+"""Dashboard overview — one aggregator endpoint so the guided home page
+doesn't need to fan out into 6 separate requests.
+
+The shape is deliberately flat and UI-oriented: we compute *next_step* on
+the backend where all state lives, and the frontend just renders it. This
+keeps the home page "what do I do next?" logic testable in one place.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Literal
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.db import get_session
+from app.db.models import (
+    BusinessProfile,
+    ContentPlan,
+    PlanStatus,
+    PlatformCredential,
+    Post,
+    PostStatus,
+    PostVariant,
+    Target,
+)
+from app.ws.extension_bridge import bridge
+
+router = APIRouter(prefix="/api/dashboard", tags=["dashboard"])
+
+
+NextStepId = Literal[
+    "connect_extension",
+    "create_profile",
+    "connect_platform",
+    "add_targets",
+    "generate_plan",
+    "review_drafts",
+    "resolve_failures",
+    "refresh_tokens",
+    "all_set",
+]
+
+
+class NextStep(BaseModel):
+    id: NextStepId
+    title: str
+    description: str
+    cta_label: str
+    cta_href: str
+
+
+class SetupBlock(BaseModel):
+    backend_ok: bool
+    extension_connected: bool
+    scheduler_running: bool
+    has_business_profile: bool
+    platforms_connected: int
+    # Subset of platforms_connected: Meta-backed creds whose token expires
+    # within the next 7 days.
+    platforms_expiring_soon: int
+    targets_active: int
+    plans_active: int
+
+
+class PublishingNow(BaseModel):
+    variant_id: int
+    post_id: int
+    target_name: str
+    platform_id: str
+    started_at: datetime | None
+
+
+class NextScheduled(BaseModel):
+    variant_id: int
+    post_id: int
+    target_name: str
+    platform_id: str
+    scheduled_for: datetime
+
+
+class RecentFailure(BaseModel):
+    variant_id: int
+    post_id: int
+    target_name: str
+    platform_id: str
+    error: str
+    updated_at: datetime
+    # User-actionable problems (not-a-group-member, checkpoint) surface
+    # differently in the UI so transient / permanent classifications don't
+    # get blurred together.
+    kind: Literal["permanent", "transient"]
+
+
+class ActivityBlock(BaseModel):
+    publishing_now: PublishingNow | None
+    next_scheduled: NextScheduled | None
+    pending_review: int
+    failed_last_24h: int
+    scheduled_total: int
+    posted_today: int
+    drafts: int
+    recent_failures: list[RecentFailure]
+
+
+class DashboardOverview(BaseModel):
+    next_step: NextStep
+    setup: SetupBlock
+    activity: ActivityBlock
+
+
+_PERMANENT_MARKERS = ("not_a_group_member", "checkpoint_detected")
+
+
+def _classify_error(err: str | None) -> Literal["permanent", "transient"]:
+    if not err:
+        return "transient"
+    return "permanent" if any(m in err for m in _PERMANENT_MARKERS) else "transient"
+
+
+def _compute_next_step(
+    *,
+    extension_connected: bool,
+    has_profile: bool,
+    platforms_connected: int,
+    targets_active: int,
+    expiring_soon: int,
+    pending_review: int,
+    plans_active: int,
+    scheduled_total: int,
+    permanent_failures: int,
+) -> NextStep:
+    """Decide the one thing the user should do now.
+
+    Priority order: blockers that stop anything from working (extension,
+    profile, platform, target) → user-actionable failures → routine work
+    (review drafts, generate plan) → housekeeping (refresh tokens) → idle.
+    """
+    if permanent_failures > 0:
+        return NextStep(
+            id="resolve_failures",
+            title=f"{permanent_failures} post{'s' if permanent_failures != 1 else ''} need your attention",
+            description="Some posts failed with user-actionable errors (not a member of a group, FB checkpoint, etc). Fix them, then re-queue.",
+            cta_label="Open queue",
+            cta_href="/queue",
+        )
+    if not extension_connected and platforms_connected == 0:
+        # Only push the extension when we clearly need it (no Meta creds yet
+        # — the extension is the FB path). IG/Threads users without FB can
+        # live without it.
+        return NextStep(
+            id="connect_extension",
+            title="Install the Chrome extension",
+            description="Facebook publishing routes through the extension. Load extension/dist as an unpacked extension in chrome://extensions.",
+            cta_label="Open Platforms",
+            cta_href="/platforms",
+        )
+    if not has_profile:
+        return NextStep(
+            id="create_profile",
+            title="Describe your business",
+            description="The generator uses your business profile as context. It takes about a minute.",
+            cta_label="Fill in profile",
+            cta_href="/profile",
+        )
+    if platforms_connected == 0:
+        return NextStep(
+            id="connect_platform",
+            title="Connect a platform",
+            description="Connect Instagram / Threads via Meta OAuth, or install the extension for Facebook Groups.",
+            cta_label="Connect now",
+            cta_href="/platforms",
+        )
+    if targets_active == 0:
+        return NextStep(
+            id="add_targets",
+            title="Add targets to post to",
+            description="Pick FB groups, IG accounts, or threads to publish to. The scheduler won't do anything without at least one active target.",
+            cta_label="Manage targets",
+            cta_href="/targets",
+        )
+    if pending_review > 0:
+        return NextStep(
+            id="review_drafts",
+            title=f"Review {pending_review} draft{'s' if pending_review != 1 else ''}",
+            description="Drafts you approve go to the queue; the rest stay here.",
+            cta_label="Open review",
+            cta_href="/review",
+        )
+    if plans_active == 0 and scheduled_total == 0:
+        return NextStep(
+            id="generate_plan",
+            title="Generate a content plan",
+            description="Generate a week of posts from your profile + targets, then review and approve.",
+            cta_label="Plan content",
+            cta_href="/plans",
+        )
+    if expiring_soon > 0:
+        return NextStep(
+            id="refresh_tokens",
+            title=f"{expiring_soon} Meta token{'s' if expiring_soon != 1 else ''} expiring soon",
+            description="The scheduler auto-refreshes nightly, but you can refresh now if you want to be safe.",
+            cta_label="Open Platforms",
+            cta_href="/platforms",
+        )
+    return NextStep(
+        id="all_set",
+        title="All set",
+        description="Posting is scheduled and on track. You don't need to do anything right now.",
+        cta_label="Open queue",
+        cta_href="/queue",
+    )
+
+
+@router.get("/overview", response_model=DashboardOverview)
+def overview(db: Session = Depends(get_session)) -> DashboardOverview:
+    from app.scheduler import scheduler as app_scheduler
+
+    now = datetime.now(UTC)
+    # SQLite stores naive UTC — normalise the comparison baseline.
+    now_naive = now.replace(tzinfo=None)
+    day_ago = now_naive - timedelta(days=1)
+    start_of_day = now_naive.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    # --- Setup block ---
+    has_profile = db.query(BusinessProfile).first() is not None
+    platforms_connected = db.query(PlatformCredential).count()
+    targets_active = (
+        db.query(Target)
+        .filter(Target.active.is_(True))
+        .filter(Target.review_status != "rejected")
+        .count()
+    )
+    plans_active = (
+        db.query(ContentPlan)
+        .filter(ContentPlan.status == PlanStatus.ACTIVE)
+        .count()
+    )
+    expiring_soon = (
+        db.query(PlatformCredential)
+        .filter(PlatformCredential.token_expires_at.isnot(None))
+        .filter(
+            PlatformCredential.token_expires_at <= now_naive + timedelta(days=7)
+        )
+        .count()
+    )
+
+    # --- Activity block ---
+    pending_review = (
+        db.query(Post).filter(Post.status == PostStatus.PENDING_REVIEW).count()
+    )
+    drafts = db.query(Post).filter(Post.status == PostStatus.DRAFT).count()
+    scheduled_total = (
+        db.query(PostVariant)
+        .filter(PostVariant.status == PostStatus.SCHEDULED)
+        .count()
+    )
+    posted_today = (
+        db.query(PostVariant)
+        .filter(PostVariant.status == PostStatus.POSTED)
+        .filter(PostVariant.posted_at >= start_of_day)
+        .count()
+    )
+    failed_last_24h = (
+        db.query(PostVariant)
+        .filter(PostVariant.status == PostStatus.FAILED)
+        .count()
+    )
+
+    publishing_row = (
+        db.query(PostVariant)
+        .filter(PostVariant.status == PostStatus.POSTING)
+        .order_by(PostVariant.id.desc())
+        .first()
+    )
+    publishing_now: PublishingNow | None = None
+    if publishing_row is not None:
+        target = db.get(Target, publishing_row.target_id)
+        publishing_now = PublishingNow(
+            variant_id=publishing_row.id,
+            post_id=publishing_row.post_id,
+            target_name=target.name if target else "unknown",
+            platform_id=target.platform_id if target else "unknown",
+            started_at=publishing_row.scheduled_for,
+        )
+
+    next_sched_row = (
+        db.query(PostVariant)
+        .filter(PostVariant.status == PostStatus.SCHEDULED)
+        .filter(PostVariant.scheduled_for.isnot(None))
+        .order_by(PostVariant.scheduled_for.asc())
+        .first()
+    )
+    next_scheduled: NextScheduled | None = None
+    if next_sched_row is not None and next_sched_row.scheduled_for is not None:
+        target = db.get(Target, next_sched_row.target_id)
+        next_scheduled = NextScheduled(
+            variant_id=next_sched_row.id,
+            post_id=next_sched_row.post_id,
+            target_name=target.name if target else "unknown",
+            platform_id=target.platform_id if target else "unknown",
+            scheduled_for=next_sched_row.scheduled_for,
+        )
+
+    # Recent failures — last 5, any time. These fuel both the "resolve
+    # failures" next-step decision and the activity panel.
+    recent_rows = (
+        db.query(PostVariant)
+        .filter(PostVariant.status == PostStatus.FAILED)
+        .order_by(PostVariant.id.desc())
+        .limit(5)
+        .all()
+    )
+    recent_failures: list[RecentFailure] = []
+    for r in recent_rows:
+        target = db.get(Target, r.target_id)
+        recent_failures.append(
+            RecentFailure(
+                variant_id=r.id,
+                post_id=r.post_id,
+                target_name=target.name if target else "unknown",
+                platform_id=target.platform_id if target else "unknown",
+                error=r.error or "unknown",
+                updated_at=r.posted_at or r.scheduled_for or now_naive,
+                kind=_classify_error(r.error),
+            )
+        )
+    permanent_failures = sum(1 for f in recent_failures if f.kind == "permanent")
+
+    next_step = _compute_next_step(
+        extension_connected=bridge.connected,
+        has_profile=has_profile,
+        platforms_connected=platforms_connected,
+        targets_active=targets_active,
+        expiring_soon=expiring_soon,
+        pending_review=pending_review,
+        plans_active=plans_active,
+        scheduled_total=scheduled_total,
+        permanent_failures=permanent_failures,
+    )
+
+    return DashboardOverview(
+        next_step=next_step,
+        setup=SetupBlock(
+            backend_ok=True,
+            extension_connected=bridge.connected,
+            scheduler_running=app_scheduler.is_running(),
+            has_business_profile=has_profile,
+            platforms_connected=platforms_connected,
+            platforms_expiring_soon=expiring_soon,
+            targets_active=targets_active,
+            plans_active=plans_active,
+        ),
+        activity=ActivityBlock(
+            publishing_now=publishing_now,
+            next_scheduled=next_scheduled,
+            pending_review=pending_review,
+            failed_last_24h=failed_last_24h,
+            scheduled_total=scheduled_total,
+            posted_today=posted_today,
+            drafts=drafts,
+            recent_failures=recent_failures,
+        ),
+    )

--- a/backend/app/platforms/facebook.py
+++ b/backend/app/platforms/facebook.py
@@ -74,14 +74,17 @@ class FacebookPlatform(Platform):
                 external_post_id=response.get("post_url") or response.get("post_id"),
                 raw=response,
             )
-        # Extension error strings are opaque — default to transient so a flaky
-        # page load or throttle gets another shot. User sees the retry cadence
-        # in the UI and can intervene if it persists.
+        err = response.get("error", "Unknown error from extension")
+        # Some errors are user-actionable — retrying is pointless until the
+        # user intervenes (e.g. join the group, pass FB's checkpoint). Mark
+        # those as non-transient so the queue stops re-queuing them.
+        permanent_markers = ("not_a_group_member", "checkpoint_detected")
+        is_permanent = any(marker in err for marker in permanent_markers)
         return PublishResult(
             ok=False,
-            error=response.get("error", "Unknown error from extension"),
+            error=err,
             raw=response,
-            transient=True,
+            transient=not is_permanent,
         )
 
     async def fetch_metrics(self, external_post_id: str) -> dict | None:

--- a/backend/tests/test_dashboard_overview.py
+++ b/backend/tests/test_dashboard_overview.py
@@ -1,0 +1,282 @@
+"""Guided home dashboard — /api/dashboard/overview.
+
+Covers:
+- next_step decision tree (priority order, not every permutation)
+- setup counters (platforms connected, expiring soon, active targets,
+  active plans)
+- activity counters + publishing_now / next_scheduled lookups
+- recent_failures classification (permanent vs transient based on FB's
+  'not_a_group_member' / 'checkpoint_detected' markers)
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.api.dashboard import _classify_error, _compute_next_step
+from app.db.models import (
+    BusinessProfile,
+    ContentPlan,
+    PlanStatus,
+    PlatformCredential,
+    Post,
+    PostStatus,
+    PostType,
+    PostVariant,
+    Target,
+)
+
+
+# ---------- _classify_error ----------
+
+
+def test_classify_error_permanent_for_not_a_member():
+    assert _classify_error("not_a_group_member: join it") == "permanent"
+
+
+def test_classify_error_permanent_for_checkpoint():
+    assert _classify_error("checkpoint_detected: ...") == "permanent"
+
+
+def test_classify_error_transient_for_generic():
+    assert _classify_error("network timeout") == "transient"
+
+
+def test_classify_error_transient_for_none():
+    assert _classify_error(None) == "transient"
+
+
+# ---------- _compute_next_step decision tree ----------
+
+
+_COMMON = dict(
+    extension_connected=True,
+    has_profile=True,
+    platforms_connected=1,
+    targets_active=1,
+    expiring_soon=0,
+    pending_review=0,
+    plans_active=1,
+    scheduled_total=5,
+    permanent_failures=0,
+)
+
+
+def test_next_step_permanent_failures_wins_over_everything():
+    s = _compute_next_step(**{**_COMMON, "permanent_failures": 2})
+    assert s.id == "resolve_failures"
+    assert "attention" in s.title
+
+
+def test_next_step_missing_profile_blocks_before_platform_check():
+    s = _compute_next_step(**{**_COMMON, "has_profile": False, "platforms_connected": 0})
+    # We push profile when platforms also missing — profile is cheaper to fill.
+    assert s.id in {"connect_extension", "create_profile"}
+    # Specifically: extension_connected is True here so the extension nudge
+    # shouldn't fire; we want profile.
+    s2 = _compute_next_step(**{**_COMMON, "has_profile": False})
+    assert s2.id == "create_profile"
+
+
+def test_next_step_no_platforms_pushes_platforms_card():
+    s = _compute_next_step(**{**_COMMON, "platforms_connected": 0})
+    # Extension is connected, so we don't harass for it first.
+    assert s.id == "connect_platform"
+
+
+def test_next_step_no_extension_and_no_platforms_pushes_extension_first():
+    s = _compute_next_step(
+        **{
+            **_COMMON,
+            "extension_connected": False,
+            "platforms_connected": 0,
+            "has_profile": False,
+        }
+    )
+    assert s.id == "connect_extension"
+
+
+def test_next_step_no_targets():
+    s = _compute_next_step(**{**_COMMON, "targets_active": 0})
+    assert s.id == "add_targets"
+
+
+def test_next_step_pending_review_nudges_review():
+    s = _compute_next_step(**{**_COMMON, "pending_review": 3})
+    assert s.id == "review_drafts"
+    assert "3" in s.title
+
+
+def test_next_step_no_plans_no_scheduled_pushes_plan():
+    s = _compute_next_step(**{**_COMMON, "plans_active": 0, "scheduled_total": 0})
+    assert s.id == "generate_plan"
+
+
+def test_next_step_expiring_tokens_surfaces_only_when_everything_else_ok():
+    s = _compute_next_step(**{**_COMMON, "expiring_soon": 1})
+    assert s.id == "refresh_tokens"
+
+
+def test_next_step_all_set():
+    s = _compute_next_step(**_COMMON)
+    assert s.id == "all_set"
+
+
+# ---------- Endpoint — setup + activity snapshots ----------
+
+
+def _make_target(db, name="Test group", **kwargs):
+    t = Target(
+        platform_id=kwargs.get("platform_id", "facebook"),
+        external_id=kwargs.get("external_id", f"https://facebook.com/groups/{name}"),
+        name=name,
+        active=kwargs.get("active", True),
+    )
+    db.add(t)
+    db.commit()
+    return t
+
+
+def _make_post(db, status=PostStatus.DRAFT, text="Hello"):
+    p = Post(post_type=PostType.INFORMATIVE, status=status, text=text)
+    db.add(p)
+    db.commit()
+    return p
+
+
+def _make_variant(db, post, target, *, status, error=None, scheduled_for=None):
+    v = PostVariant(
+        post_id=post.id,
+        target_id=target.id,
+        text=post.text,
+        status=status,
+        scheduled_for=scheduled_for,
+        error=error,
+    )
+    db.add(v)
+    db.commit()
+    return v
+
+
+def test_overview_empty_state_pushes_profile(client, db):
+    r = client.get("/api/dashboard/overview")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["setup"]["has_business_profile"] is False
+    assert data["setup"]["platforms_connected"] == 0
+    assert data["setup"]["targets_active"] == 0
+    assert data["next_step"]["id"] in {"connect_extension", "create_profile"}
+
+
+def test_overview_counts_setup_correctly(client, db):
+    db.add(BusinessProfile(name="ACME", description="We sell things"))
+    db.add(
+        PlatformCredential(
+            platform_id="instagram",
+            account_id="IG1",
+            username="acme",
+            access_token="tkn",
+            extra={},
+            token_expires_at=datetime.now(UTC).replace(tzinfo=None)
+            + timedelta(days=3),  # expiring soon (within 7d)
+        )
+    )
+    db.add(
+        PlatformCredential(
+            platform_id="instagram",
+            account_id="IG2",
+            username="other",
+            access_token="tkn",
+            extra={},
+            token_expires_at=datetime.now(UTC).replace(tzinfo=None)
+            + timedelta(days=30),
+        )
+    )
+    _make_target(db, name="group A")
+    _make_target(db, name="group B", active=False)
+    db.add(
+        ContentPlan(
+            name="April",
+            status=PlanStatus.ACTIVE,
+            start_date=datetime.now(UTC).date(),
+            end_date=(datetime.now(UTC) + timedelta(days=7)).date(),
+        )
+    )
+    db.commit()
+
+    data = client.get("/api/dashboard/overview").json()
+    setup = data["setup"]
+    assert setup["has_business_profile"] is True
+    assert setup["platforms_connected"] == 2
+    assert setup["platforms_expiring_soon"] == 1
+    assert setup["targets_active"] == 1
+    assert setup["plans_active"] == 1
+
+
+def test_overview_activity_lists_publishing_and_next_scheduled(client, db):
+    db.add(BusinessProfile(name="ACME", description="x"))
+    db.add(
+        PlatformCredential(
+            platform_id="facebook",
+            account_id="FB",
+            access_token="t",
+            extra={},
+        )
+    )
+    target = _make_target(db, name="ACME group")
+    p1 = _make_post(db)
+    p2 = _make_post(db)
+    # One currently posting.
+    _make_variant(db, p1, target, status=PostStatus.POSTING)
+    # Two scheduled; earlier one wins.
+    soon = datetime.now(UTC).replace(tzinfo=None) + timedelta(minutes=30)
+    later = datetime.now(UTC).replace(tzinfo=None) + timedelta(hours=4)
+    _make_variant(db, p2, target, status=PostStatus.SCHEDULED, scheduled_for=later)
+    _make_variant(db, p1, target, status=PostStatus.SCHEDULED, scheduled_for=soon)
+
+    data = client.get("/api/dashboard/overview").json()
+    assert data["activity"]["publishing_now"] is not None
+    assert data["activity"]["publishing_now"]["target_name"] == "ACME group"
+    assert data["activity"]["next_scheduled"] is not None
+    # Earlier scheduled_for wins.
+    assert data["activity"]["next_scheduled"]["scheduled_for"].startswith(
+        soon.isoformat()[:16]
+    )
+    assert data["activity"]["scheduled_total"] == 2
+
+
+def test_overview_surfaces_not_a_member_failure_as_permanent(client, db):
+    db.add(BusinessProfile(name="ACME", description="x"))
+    db.add(
+        PlatformCredential(
+            platform_id="facebook",
+            account_id="FB",
+            access_token="t",
+            extra={},
+        )
+    )
+    target = _make_target(db, name="Private club")
+    post = _make_post(db)
+    _make_variant(
+        db,
+        post,
+        target,
+        status=PostStatus.FAILED,
+        error="not_a_group_member: join it first",
+    )
+    _make_variant(
+        db,
+        post,
+        target,
+        status=PostStatus.FAILED,
+        error="ETIMEDOUT",
+    )
+
+    data = client.get("/api/dashboard/overview").json()
+    failures = data["activity"]["recent_failures"]
+    assert len(failures) == 2
+    kinds = {f["kind"] for f in failures}
+    assert kinds == {"permanent", "transient"}
+    # Permanent failure must drive next_step.
+    assert data["next_step"]["id"] == "resolve_failures"

--- a/backend/tests/test_fb_not_a_member.py
+++ b/backend/tests/test_fb_not_a_member.py
@@ -1,0 +1,80 @@
+"""FB 'not a member' error is flagged non-transient so the retry loop
+doesn't pointlessly re-queue a variant that'll keep hitting the same wall.
+
+Contrast with a generic content-script error ("composer_editor_did_not_open")
+which IS transient — the page may have been slow to render and a retry is
+reasonable.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.db.models import (
+    Post,
+    PostStatus,
+    PostType,
+    Target,
+)
+from app.platforms.facebook import FacebookPlatform
+
+
+def _make_post_and_target(db=None):
+    t = Target(
+        platform_id="facebook",
+        external_id="https://facebook.com/groups/123",
+        name="Private club",
+    )
+    db.add(t)
+    db.commit()
+    p = Post(post_type=PostType.INFORMATIVE, status=PostStatus.SCHEDULED, text="hi")
+    db.add(p)
+    db.commit()
+    return p, t
+
+
+@pytest.mark.asyncio
+async def test_fb_not_a_member_is_permanent(db):
+    post, target = _make_post_and_target(db)
+    with patch("app.platforms.facebook.bridge") as mock_bridge:
+        mock_bridge.request = AsyncMock(
+            return_value={
+                "ok": False,
+                "error": "not_a_group_member: join it first",
+            }
+        )
+        result = await FacebookPlatform().publish(post, target)
+    assert result.ok is False
+    assert result.transient is False
+    assert "not_a_group_member" in result.error
+
+
+@pytest.mark.asyncio
+async def test_fb_checkpoint_is_permanent(db):
+    post, target = _make_post_and_target(db)
+    with patch("app.platforms.facebook.bridge") as mock_bridge:
+        mock_bridge.request = AsyncMock(
+            return_value={
+                "ok": False,
+                "error": 'checkpoint_detected: "please re-enter your password"',
+            }
+        )
+        result = await FacebookPlatform().publish(post, target)
+    assert result.ok is False
+    assert result.transient is False
+
+
+@pytest.mark.asyncio
+async def test_fb_generic_content_script_error_is_transient(db):
+    post, target = _make_post_and_target(db)
+    with patch("app.platforms.facebook.bridge") as mock_bridge:
+        mock_bridge.request = AsyncMock(
+            return_value={
+                "ok": False,
+                "error": "composer_editor_did_not_open",
+            }
+        )
+        result = await FacebookPlatform().publish(post, target)
+    assert result.ok is False
+    assert result.transient is True

--- a/dashboard/app/page.tsx
+++ b/dashboard/app/page.tsx
@@ -1,5 +1,406 @@
-import { redirect } from "next/navigation";
+"use client";
 
-export default function Home() {
-  redirect("/profile");
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  getDashboardOverview,
+  type DashboardOverview,
+  type NextStep,
+  type SetupBlock,
+  type ActivityBlock,
+  type RecentFailure,
+} from "@/lib/api";
+import { formatDate } from "@/lib/utils";
+import {
+  AlertTriangle,
+  ArrowRight,
+  Briefcase,
+  CheckCircle2,
+  CircleDashed,
+  Clock,
+  FileEdit,
+  Link2,
+  ListChecks,
+  RefreshCw,
+  Send,
+  Users,
+  XCircle,
+} from "lucide-react";
+
+export default function HomePage() {
+  const [data, setData] = useState<DashboardOverview | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const d = await getDashboardOverview();
+        if (!cancelled) {
+          setData(d);
+          setError(null);
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : String(e));
+        }
+      }
+    };
+    tick();
+    const id = setInterval(tick, 15_000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
+
+  if (error) {
+    return (
+      <div className="p-6">
+        <Card className="border-destructive">
+          <CardContent className="pt-6 text-sm text-destructive">
+            {error}
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="p-6 text-sm text-muted-foreground">
+        Loading dashboard…
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 p-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Home</h1>
+        <p className="text-muted-foreground">
+          Live overview — what's happening and what the system needs from you.
+        </p>
+      </div>
+
+      <NextStepCard step={data.next_step} />
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <SetupCard setup={data.setup} />
+        <ActivityCard activity={data.activity} />
+      </div>
+
+      {data.activity.recent_failures.length > 0 && (
+        <FailuresCard failures={data.activity.recent_failures} />
+      )}
+    </div>
+  );
+}
+
+function NextStepCard({ step }: { step: NextStep }) {
+  const allSet = step.id === "all_set";
+  const needsAttention = step.id === "resolve_failures";
+  return (
+    <Card
+      className={
+        needsAttention
+          ? "border-destructive/60"
+          : allSet
+          ? "border-green-600/40"
+          : "border-primary/40"
+      }
+    >
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          {needsAttention ? (
+            <AlertTriangle className="h-5 w-5 text-destructive" />
+          ) : allSet ? (
+            <CheckCircle2 className="h-5 w-5 text-green-600" />
+          ) : (
+            <CircleDashed className="h-5 w-5 text-primary" />
+          )}
+          <CardTitle>
+            {allSet ? "Everything running" : "Next step"}
+          </CardTitle>
+        </div>
+        <CardDescription className="text-base">
+          <span className="font-medium text-foreground">{step.title}</span>
+          <span className="block pt-1">{step.description}</span>
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Link href={step.cta_href}>
+          <Button variant={needsAttention ? "destructive" : "default"}>
+            {step.cta_label}
+            <ArrowRight className="ml-2 h-4 w-4" />
+          </Button>
+        </Link>
+      </CardContent>
+    </Card>
+  );
+}
+
+function SetupCard({ setup }: { setup: SetupBlock }) {
+  const items: Array<{
+    label: string;
+    ok: boolean;
+    note?: string;
+    href: string;
+    icon: React.ComponentType<{ className?: string }>;
+  }> = [
+    {
+      label: "Chrome extension",
+      ok: setup.extension_connected,
+      note: setup.extension_connected ? "connected" : "not connected",
+      href: "/platforms",
+      icon: Link2,
+    },
+    {
+      label: "Business profile",
+      ok: setup.has_business_profile,
+      note: setup.has_business_profile ? "ready" : "not set up",
+      href: "/profile",
+      icon: Briefcase,
+    },
+    {
+      label: "Platforms connected",
+      ok: setup.platforms_connected > 0,
+      note:
+        setup.platforms_expiring_soon > 0
+          ? `${setup.platforms_connected} connected · ${setup.platforms_expiring_soon} expiring soon`
+          : `${setup.platforms_connected} connected`,
+      href: "/platforms",
+      icon: Link2,
+    },
+    {
+      label: "Active targets",
+      ok: setup.targets_active > 0,
+      note: `${setup.targets_active} active`,
+      href: "/targets",
+      icon: Users,
+    },
+    {
+      label: "Content plans",
+      ok: setup.plans_active > 0,
+      note: `${setup.plans_active} active`,
+      href: "/plans",
+      icon: ListChecks,
+    },
+  ];
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Setup</CardTitle>
+        <CardDescription>
+          The pieces needed for the pipeline to work end-to-end.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-2 text-sm">
+          {items.map((it) => {
+            const Icon = it.icon;
+            return (
+              <li key={it.label}>
+                <Link
+                  href={it.href}
+                  className="flex items-center justify-between rounded-md px-2 py-1.5 hover:bg-accent/60"
+                >
+                  <div className="flex items-center gap-2">
+                    {it.ok ? (
+                      <CheckCircle2 className="h-4 w-4 text-green-600" />
+                    ) : (
+                      <XCircle className="h-4 w-4 text-muted-foreground" />
+                    )}
+                    <Icon className="h-4 w-4 text-muted-foreground" />
+                    <span>{it.label}</span>
+                  </div>
+                  <span className="text-xs text-muted-foreground">
+                    {it.note}
+                  </span>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ActivityCard({ activity }: { activity: ActivityBlock }) {
+  const hasPublishing = activity.publishing_now !== null;
+  const hasNext = activity.next_scheduled !== null;
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Activity</CardTitle>
+        <CardDescription>What's happening right now.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm">
+        {hasPublishing && activity.publishing_now && (
+          <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/5 p-2">
+            <Send className="mt-0.5 h-4 w-4 text-amber-600" />
+            <div className="flex-1">
+              <div className="font-medium">Publishing now</div>
+              <div className="text-xs text-muted-foreground">
+                {activity.publishing_now.platform_id} ·{" "}
+                {activity.publishing_now.target_name}
+              </div>
+            </div>
+          </div>
+        )}
+        {hasNext && activity.next_scheduled && (
+          <div className="flex items-start gap-2 rounded-md border p-2">
+            <Clock className="mt-0.5 h-4 w-4 text-muted-foreground" />
+            <div className="flex-1">
+              <div className="font-medium">
+                Next at {formatDate(activity.next_scheduled.scheduled_for)}
+              </div>
+              <div className="text-xs text-muted-foreground">
+                {activity.next_scheduled.platform_id} ·{" "}
+                {activity.next_scheduled.target_name}
+              </div>
+            </div>
+          </div>
+        )}
+        {!hasPublishing && !hasNext && (
+          <div className="rounded-md border border-dashed p-3 text-center text-xs text-muted-foreground">
+            Nothing running, nothing scheduled.
+          </div>
+        )}
+        <div className="grid grid-cols-2 gap-2 pt-2 text-xs">
+          <StatLink
+            href="/review"
+            icon={FileEdit}
+            count={activity.pending_review}
+            label="awaiting review"
+          />
+          <StatLink
+            href="/queue"
+            icon={ListChecks}
+            count={activity.scheduled_total}
+            label="scheduled"
+          />
+          <StatLink
+            href="/queue?status=posted"
+            icon={Send}
+            count={activity.posted_today}
+            label="posted today"
+          />
+          <StatLink
+            href="/queue?status=failed"
+            icon={AlertTriangle}
+            count={activity.failed_last_24h}
+            label="failed"
+            tone={activity.failed_last_24h > 0 ? "warn" : undefined}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function StatLink({
+  href,
+  icon: Icon,
+  count,
+  label,
+  tone,
+}: {
+  href: string;
+  icon: React.ComponentType<{ className?: string }>;
+  count: number;
+  label: string;
+  tone?: "warn";
+}) {
+  return (
+    <Link
+      href={href}
+      className="flex items-center gap-2 rounded-md border px-2 py-1.5 hover:bg-accent/60"
+    >
+      <Icon
+        className={`h-4 w-4 ${
+          tone === "warn" ? "text-amber-600" : "text-muted-foreground"
+        }`}
+      />
+      <span className="font-mono tabular-nums">{count}</span>
+      <span className="text-muted-foreground">{label}</span>
+    </Link>
+  );
+}
+
+function FailuresCard({ failures }: { failures: RecentFailure[] }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Recent failures</CardTitle>
+        <CardDescription>
+          <Badge variant="destructive" className="mr-1">
+            needs you
+          </Badge>{" "}
+          means retrying won't help until you fix something (join a group,
+          pass a checkpoint, re-connect a platform).
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-2 text-sm">
+          {failures.map((f) => (
+            <li
+              key={f.variant_id}
+              className="flex items-start justify-between rounded-md border p-2"
+            >
+              <div className="flex-1 pr-3">
+                <div className="flex items-center gap-2">
+                  {f.kind === "permanent" ? (
+                    <Badge variant="destructive">needs you</Badge>
+                  ) : (
+                    <Badge variant="warning">transient</Badge>
+                  )}
+                  <span className="font-medium">
+                    {f.platform_id} · {f.target_name}
+                  </span>
+                </div>
+                <p className="mt-1 font-mono text-xs text-muted-foreground break-words">
+                  {f.error}
+                </p>
+                {f.kind === "permanent" &&
+                  f.error.includes("not_a_group_member") && (
+                    <p className="mt-1 text-xs">
+                      This account isn't a member of the group. Open it in
+                      Facebook, click{" "}
+                      <span className="font-medium">Join group</span>, wait
+                      for approval if required, then re-queue from the queue
+                      page.
+                    </p>
+                  )}
+              </div>
+              <Link
+                href={`/queue?variant=${f.variant_id}`}
+                className="text-xs text-primary hover:underline"
+              >
+                Open
+              </Link>
+            </li>
+          ))}
+        </ul>
+        <div className="mt-3 flex justify-end">
+          <Link href="/queue?status=failed">
+            <Button variant="outline" size="sm">
+              <RefreshCw className="mr-2 h-4 w-4" />
+              Open queue
+            </Button>
+          </Link>
+        </div>
+      </CardContent>
+    </Card>
+  );
 }

--- a/dashboard/app/platforms/page.tsx
+++ b/dashboard/app/platforms/page.tsx
@@ -381,6 +381,15 @@ function SmokeReportView({ report }: { report: ExtensionSmokeReport }) {
       value: !report.checkpoint_detected,
       critical: true,
     },
+  ];
+  if (report.is_group_page && report.is_group_member !== null) {
+    checks.push({
+      label: "Member of this group",
+      value: report.is_group_member,
+      critical: true,
+    });
+  }
+  checks.push(
     { label: "Composer trigger found", value: report.composer_trigger, critical: true },
     { label: "Composer editor when open", value: report.composer_editor_when_open },
     { label: "Post button when open", value: report.post_button_when_open },
@@ -390,7 +399,7 @@ function SmokeReportView({ report }: { report: ExtensionSmokeReport }) {
     },
     { label: "Comment button on article", value: report.comment_button_on_article },
     { label: "Comment editor on article", value: report.comment_editor_on_article },
-  ];
+  );
   return (
     <div className="space-y-2 rounded-lg border p-3 text-sm">
       <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">

--- a/dashboard/components/layout/sidebar.tsx
+++ b/dashboard/components/layout/sidebar.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import {
   BarChart3,
+  Briefcase,
   Calendar,
   CalendarDays,
   CheckSquare,
@@ -18,7 +19,8 @@ import {
 } from "lucide-react";
 
 const NAV = [
-  { href: "/profile", label: "Business Profile", icon: Home },
+  { href: "/", label: "Home", icon: Home },
+  { href: "/profile", label: "Business Profile", icon: Briefcase },
   { href: "/targets", label: "Targets", icon: Users },
   { href: "/plans", label: "Content Plans", icon: CalendarDays },
   { href: "/library", label: "Media Library", icon: ImageIcon },

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -844,6 +844,8 @@ export interface ExtensionSmokeReport {
   is_group_page: boolean;
   is_logged_in: boolean;
   checkpoint_detected: boolean;
+  // null = not on a group page (or couldn't tell)
+  is_group_member: boolean | null;
   composer_trigger: boolean;
   composer_editor_when_open: boolean;
   post_button_when_open: boolean;
@@ -859,6 +861,84 @@ export const runExtensionSmoke = () =>
   request<{ ok: true; report: ExtensionSmokeReport }>("/api/extension/smoke", {
     method: "POST",
   });
+
+// ---------- Dashboard overview (guided home) ----------
+
+export type NextStepId =
+  | "connect_extension"
+  | "create_profile"
+  | "connect_platform"
+  | "add_targets"
+  | "generate_plan"
+  | "review_drafts"
+  | "resolve_failures"
+  | "refresh_tokens"
+  | "all_set";
+
+export interface NextStep {
+  id: NextStepId;
+  title: string;
+  description: string;
+  cta_label: string;
+  cta_href: string;
+}
+
+export interface SetupBlock {
+  backend_ok: boolean;
+  extension_connected: boolean;
+  scheduler_running: boolean;
+  has_business_profile: boolean;
+  platforms_connected: number;
+  platforms_expiring_soon: number;
+  targets_active: number;
+  plans_active: number;
+}
+
+export interface PublishingNow {
+  variant_id: number;
+  post_id: number;
+  target_name: string;
+  platform_id: string;
+  started_at: string | null;
+}
+
+export interface NextScheduled {
+  variant_id: number;
+  post_id: number;
+  target_name: string;
+  platform_id: string;
+  scheduled_for: string;
+}
+
+export interface RecentFailure {
+  variant_id: number;
+  post_id: number;
+  target_name: string;
+  platform_id: string;
+  error: string;
+  updated_at: string;
+  kind: "permanent" | "transient";
+}
+
+export interface ActivityBlock {
+  publishing_now: PublishingNow | null;
+  next_scheduled: NextScheduled | null;
+  pending_review: number;
+  failed_last_24h: number;
+  scheduled_total: number;
+  posted_today: number;
+  drafts: number;
+  recent_failures: RecentFailure[];
+}
+
+export interface DashboardOverview {
+  next_step: NextStep;
+  setup: SetupBlock;
+  activity: ActivityBlock;
+}
+
+export const getDashboardOverview = () =>
+  request<DashboardOverview>("/api/dashboard/overview");
 
 // ---------- M8: Auth ----------
 

--- a/extension/src/content/facebook.ts
+++ b/extension/src/content/facebook.ts
@@ -149,6 +149,21 @@ const LABELS = {
     "подтверждение безопасности",
     "confirm your identity",
   ],
+  // FB renders a prominent CTA when the current user is NOT a member of the
+  // group they're viewing. The composer is hidden in that case, so matching
+  // this label gives us a clearer error than "composer_trigger_not_found".
+  joinGroup: [
+    "join group",
+    "join this group",
+    "ask to join",
+    "request to join",
+    "вступить в группу",
+    "запросить вступление",
+    "unirse al grupo",
+    "solicitar unirse",
+    "gruppe beitreten",
+    "beitritt anfragen",
+  ],
 } as const;
 
 function detectLocale(): string {
@@ -179,6 +194,14 @@ async function publishPost(
   // 1. Find the composer trigger ("Write something...").
   const trigger = await waitFor(() => findComposerTrigger(), 15000);
   if (!trigger) {
+    // Most common cause: user isn't a member of the group. FB hides the
+    // composer entirely and shows a "Join group" CTA instead. Surface that
+    // as a specific, actionable error so the dashboard can explain.
+    if (isGroupPage() && findJoinGroupButton()) {
+      throw new Error(
+        "not_a_group_member: this account isn't a member of the group — join it first (or accept the pending request)",
+      );
+    }
     throw new Error(
       `composer_trigger_not_found: locale=${detectLocale()} url=${location.pathname}`,
     );
@@ -309,6 +332,24 @@ function findPhotoVideoButton(): HTMLElement | null {
   for (const b of buttons) {
     const label = (b.getAttribute("aria-label") ?? b.textContent ?? "").trim();
     if (matchesLabel(label, LABELS.photoVideoButton)) return b;
+  }
+  return null;
+}
+
+function isGroupPage(): boolean {
+  return /^\/groups\/[^/]+/.test(location.pathname);
+}
+
+function findJoinGroupButton(): HTMLElement | null {
+  // Search only visible role=button elements — FB sometimes keeps stale DOM
+  // nodes from previous navigations; restricting to the main scope avoids
+  // false positives from a cached page preview.
+  const scope =
+    document.querySelector<HTMLElement>('[role="main"]') ?? document.body;
+  const buttons = scope.querySelectorAll<HTMLElement>('[role="button"]');
+  for (const b of buttons) {
+    const label = (b.getAttribute("aria-label") ?? b.textContent ?? "").trim();
+    if (matchesLabel(label, LABELS.joinGroup)) return b;
   }
   return null;
 }
@@ -709,6 +750,7 @@ type SmokeReport = {
   is_group_page: boolean;
   is_logged_in: boolean;
   checkpoint_detected: boolean;
+  is_group_member: boolean | null;
   composer_trigger: boolean;
   composer_editor_when_open: boolean;
   post_button_when_open: boolean;
@@ -745,12 +787,23 @@ async function runSmoke(): Promise<SmokeReport> {
     );
   }
 
+  // Membership: only meaningful if we're actually on a group page. Composer
+  // presence is the positive signal; Join button presence is the negative.
+  let isMember: boolean | null = null;
+  if (isGroupPage) {
+    const hasComposer = !!findComposerTrigger();
+    const hasJoin = !!findJoinGroupButton();
+    if (hasComposer) isMember = true;
+    else if (hasJoin) isMember = false;
+  }
+
   const report: SmokeReport = {
     locale: detectLocale(),
     url,
     is_group_page: isGroupPage,
     is_logged_in: isLoggedIn,
     checkpoint_detected: checkpoint,
+    is_group_member: isMember,
     composer_trigger: !!findComposerTrigger(),
     composer_editor_when_open: false,
     post_button_when_open: false,
@@ -762,7 +815,11 @@ async function runSmoke(): Promise<SmokeReport> {
     warnings,
   };
 
-  if (!report.composer_trigger && isGroupPage && !checkpoint) {
+  if (isGroupPage && isMember === false) {
+    warnings.push(
+      "not_a_group_member: posting will fail — join the group (or accept pending request) first",
+    );
+  } else if (!report.composer_trigger && isGroupPage && !checkpoint) {
     warnings.push("composer_trigger_missing: selectors may be stale");
   }
 


### PR DESCRIPTION
## Summary

Closes the remaining gaps that kept Meta (FB / IG / Threads) from being
day-one usable, and replaces the placeholder `/` redirect with a guided
home dashboard that tells the user what to do next instead of leaving
them to figure it out from the sidebar.

### Meta gaps closed

- **Long-lived token refresh** — service + daily cron at 04:00 UTC + on-
  demand `POST /api/platform-credentials/{id}/refresh`. OAuth callback
  persists `token_expires_at`; `PlatformCredentialOut` exposes
  `days_until_expiry` so the dashboard can badge green / amber / red.
- **FB first_comment** — content script now opens the comment composer
  on the fresh permalink, types humanly, submits with Enter. Failures
  surface as `comment_warning` without failing the publish (the post
  itself is already committed).
- **Fail-loud smoke** — `runSmoke()` probes composer, post button,
  photo/video, comment editor, checkpoint, logged-in, group-member.
  `POST /api/extension/smoke` proxies it through the WS bridge so the
  dashboard can render a checklist without DevTools.
- **Non-member detection** — when the composer is missing but a
  "Join group" CTA is present, throw `not_a_group_member` instead of
  the generic selector-miss. Treated as permanent (`transient=False`)
  so the retry loop stops re-queuing pointlessly.

### Guided home dashboard

- New `GET /api/dashboard/overview` aggregator returns setup state,
  activity counters, recent failures (classified permanent vs
  transient), and a single `next_step` the UI just renders.
- `/` now renders **Next step → Setup → Activity → Recent failures**.
  Priority order: permanent-failure fixes > onboarding blockers >
  routine work > token refresh > idle.
- Failures card explains the `not_a_group_member` remediation in plain
  language ("open the group in FB, click Join, then re-queue").

### Also

- Fixed pre-existing Alembic collision (two migrations both named
  `0002`); `0002_follower_snapshots` → `0002b` so `test_client`
  fixture can start.
- Sidebar: Home at the top.

## Test plan

- [x] `cd backend && python -m pytest -q` — **294 passed** (+20 new):
  `test_token_refresh.py`, `test_dashboard_overview.py`,
  `test_fb_not_a_member.py`.
- [x] Backend imports clean (`python -c "from app.main import app"`).
- [x] Dashboard `tsc --noEmit` — no new errors (2 pre-existing
  `plans/[id]/page.tsx` `media_asset_id` errors unrelated).
- [ ] Manual smoke: Platforms page → Run smoke test on a group where
      you are a member → expect all greens. Re-run on a group where you
      are NOT a member → expect `Member of this group` red + warning.
- [ ] Manual smoke: Disconnect → / page should show "Install the Chrome
      extension" as Next step.
- [ ] Manual smoke: Schedule a post to a group you're not a member of →
      expect FAILED variant with `not_a_group_member` error, Home shows
      "N posts need your attention" and explains Join.

https://claude.ai/code/session_0134AfB5wht644Tdt6Gad7od